### PR TITLE
Handle ruby string substitution in tool executable

### DIFF
--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -125,6 +125,11 @@ class Configurator
       # populate name if not given      
       tool[:name] = name.to_s if (tool[:name].nil?)
 
+      # handle inline ruby string substitution in executable
+      if (tool[:executable] =~ RUBY_STRING_REPLACEMENT_PATTERN)
+        tool[:executable].replace(@system_wrapper.module_eval(tool[:executable]))
+      end
+
       # populate stderr redirect option
       tool[:stderr_redirect] = StdErrRedirect::NONE if (tool[:stderr_redirect].nil?)
 


### PR DESCRIPTION
We don't attempt to substitute ${#} etc, as this data is probably not known
at this point. At any rate, it's the wrong bit of code.

We have to substitute before validation, otherwise that fails. Most of the
other substitution happens after validation.

Reference #7
