### PR TITLE
Allow ERB usage inside project.yml, and allow arrays as include values

### DIFF
--- a/lib/ceedling/yaml_wrapper.rb
+++ b/lib/ceedling/yaml_wrapper.rb
@@ -1,10 +1,11 @@
 require 'yaml'
+require 'erb'
 
 
 class YamlWrapper
 
   def load(filepath)
-    return YAML.load(File.read(filepath))
+    return YAML.load(ERB.new(File.read(filepath)).result)
   end
 
   def dump(filepath, structure)


### PR DESCRIPTION
ERB is much more flexible than instance_eval'ing ruby interpolated
strings, and allows much more of project.yml to be generated at runtime,
without having to resort to generating project.yml programatically.

Allowing arrays as include path values allows include paths to be
generated at runtime, as the result of some ruby operation.

For example:

:paths:
  :include:
    - <%= ['some_value', 'some_other_value'] %>
    - <%= `build_system_tool_returning_array_of_paths`.split("\n") %>

This allows include paths to be generated by the build tool, without
upsetting ceedling too much.
