### PR TITLE
Don't form dependency rules from #includes which are commented out

### DIFF
--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -19,7 +19,7 @@ class PreprocessinatorIncludesHandler
     # (decorating the names creates file names that don't exist, thus preventing the preprocessor 
     #  from snaking out and discovering the entire include path that winds through the code)
     contents = @file_wrapper.read(filepath)
-    contents.gsub!( /#include\s+\"\s*(\S+)\s*\"/, "#include \"\\1\"\n#include \"@@@@\\1\"" )
+    contents.gsub!( /^\s*#include\s+\"\s*(\S+)\s*\"/, "#include \"\\1\"\n#include \"@@@@\\1\"" )
     @file_wrapper.write( temp_filepath, contents )
     
     # extract the make-style dependency rule telling the preprocessor to 


### PR DESCRIPTION
This one cost a few thousand pounds in developer time.

Most places that parse out #includes at least check to see whether there's
something (like a comment) on the same line as the #include. Although this
missed the obvious cases such as /\* ... */ and #if 0 comments, at least
it was something.

One particular call site did not, however. The upshot was that something
like

```
#include "mock_file.h"
// #include "file.h"
```

would compile and link both mock_file.o _and_ file.o, causing a linker
error.
