### PR TITLE
Allow arrays as include values

### DIFF
--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -234,9 +234,9 @@ class Configurator
     paths.flatten.each { |path| FilePathUtils::standardize( path ) }
 
     config[:paths].each_pair do |collection, paths|
-      paths.each{|path| FilePathUtils::standardize( path )}
-      # ensure that list is an array (i.e. handle case of list being a single string)
-      config[:paths][collection] = [paths].flatten
+      # ensure that list is an array (i.e. handle case of list being a single string,
+      # or a multidimensional array)
+      config[:paths][collection] = [paths].flatten.map{|path| FilePathUtils::standardize( path )}
     end
 
     config[:files].each_pair { |collection, files| files.each{ |path| FilePathUtils::standardize( path ) } }


### PR DESCRIPTION
This commit is the missing half of #17, "feature/dynamic_include_paths".

Allowing arrays as include path values allows include paths to be
generated at runtime, as the result of some ruby operation.

For example:

```
:paths:
  :include:
    - <%= ['some_value', 'some_other_value'] %>
    - <%= `build_system_tool_returning_array_of_paths`.split("\n") %>
```

This allows include paths to be generated by the build tool, without
upsetting ceedling too much.
