### PR TITLE
Add CEEDLING_IGNORE_SANITY_CHECK, which if defined skips test sanity check

### DIFF
--- a/lib/ceedling/generator_test_results_sanity_checker.rb
+++ b/lib/ceedling/generator_test_results_sanity_checker.rb
@@ -45,18 +45,20 @@ class GeneratorTestResultsSanityChecker
 
   private
   
-  def sanity_check_warning(file, message)
-    notice = "\n" + 
-             "ERROR: Internal sanity check for test fixture '#{file.ext(@configurator.extension_executable)}' finds that #{message}\n" +
-             "  Possible causes:\n" +
-             "    1. Your test + source dereferenced a null pointer.\n" +
-             "    2. Your test + source indexed past the end of a buffer.\n" +
-             "    3. Your test + source committed a memory access violation.\n" +
-             "    4. Your test fixture produced an exit code of 0 despite execution ending prematurely.\n" +
-             "  Sanity check failures of test results are usually a symptom of interrupted test execution.\n\n"
-    
-    @streaminator.stderr_puts( notice )
-    raise
+ def sanity_check_warning(file, message)
+    unless defined?(CEEDLING_IGNORE_SANITY_CHECK)
+      notice = "\n" + 
+               "ERROR: Internal sanity check for test fixture '#{file.ext(@configurator.extension_executable)}' finds that #{message}\n" +
+               "  Possible causes:\n" +
+               "    1. Your test + source dereferenced a null pointer.\n" +
+               "    2. Your test + source indexed past the end of a buffer.\n" +
+               "    3. Your test + source committed a memory access violation.\n" +
+               "    4. Your test fixture produced an exit code of 0 despite execution ending prematurely.\n" +
+               "  Sanity check failures of test results are usually a symptom of interrupted test execution.\n\n"
+      
+      @streaminator.stderr_puts( notice )
+      raise
+    end
   end
 
 end


### PR DESCRIPTION
This is required if using ceedling to run Unity's test suite, as in this
case the test counts don't match up (Unity's tests are allows to fail,
and this can be treated as a success, for example).
