### PR TITLE
Update generator_test_results.rb

### DIFF
--- a/lib/ceedling/generator_test_results.rb
+++ b/lib/ceedling/generator_test_results.rb
@@ -27,7 +27,7 @@ class GeneratorTestResults
     output_string = unity_shell_result[:output].sub(TEST_STDOUT_STATISTICS_PATTERN, '')
     
     # bust up the output into individual lines
-    raw_unity_lines = output_string.split(/\n|\r\n/)
+    raw_unity_lines = output_string.split(/\r|\r\n/)
     
     raw_unity_lines.each do |line|
       # process unity output


### PR DESCRIPTION
output_string.split corrected to (/\r|\r\n/) was (/\n|\r\n/). It was not working on linux system (tried in linux Mint). 
