### PR TITLE
Add support for whitespace between # and include

### DIFF
--- a/lib/preprocessinator_includes_handler.rb
+++ b/lib/preprocessinator_includes_handler.rb
@@ -1,5 +1,3 @@
-
-
 class PreprocessinatorIncludesHandler
   
   constructor :configurator, :tool_executor, :task_invoker, :file_path_utils, :yaml_wrapper, :file_wrapper
@@ -7,7 +5,7 @@ class PreprocessinatorIncludesHandler
   # shallow includes: only those headers a source file explicitly includes
 
   def invoke_shallow_includes_list(filepath)
-    @task_invoker.invoke_test_shallow_include_lists( [@file_path_utils.form_preprocessed_includes_list_filepath(filepath)] )
+    @task_invoker.invoke_test_shallow_include_lists([@file_path_utils.form_preprocessed_includes_list_filepath(filepath)])
   end
 
   # ask the preprocessor for a make-style dependency rule of only the headers the source file immediately includes
@@ -19,7 +17,7 @@ class PreprocessinatorIncludesHandler
     # (decorating the names creates file names that don't exist, thus preventing the preprocessor 
     #  from snaking out and discovering the entire include path that winds through the code)
     contents = @file_wrapper.read(filepath)
-    contents.gsub!( /#include\s+\"\s*(\S+)\s*\"/, "#include \"\\1\"\n#include \"@@@@\\1\"" )
+    contents.gsub!(/#\s*include\s+\"\s*(\S+)\s*\"/, "#include \"\\1\"\n#include \"@@@@\\1\"")
     @file_wrapper.write( temp_filepath, contents )
     
     # extract the make-style dependency rule telling the preprocessor to 

--- a/lib/test_includes_extractor.rb
+++ b/lib/test_includes_extractor.rb
@@ -53,7 +53,7 @@ class TestIncludesExtractor
     
     contents.split("\n").each do |line|
       # look for include statement
-      scan_results = line.scan(/#include\s+\"\s*(.+#{'\\'+header_extension})\s*\"/)
+      scan_results = line.scan(/#\s*include\s+\"\s*(.+#{'\\'+header_extension})\s*\"/)
       
       includes << scan_results[0][0] if (scan_results.size > 0)
     end

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'rspec/mocks/standalone'
+
+describe PreprocessinatorIncludesHandler do
+  describe "#form_shallow_dependencies_rule" do
+    it "should allow #includes with whitespace after the # symbol" do
+      objects = {
+          :configurator => Object.new, :tool_executor => BasicObject.new,
+          :task_invoker => mock(), :file_path_utils => Object.new,
+          :yaml_wrapper => nil, :file_wrapper => Object.new
+      }
+
+      input = <<-EOS.strip_indentation
+        #include "nospace.h"
+        # include "single-space.h"
+        #\tinclude "tab.h"
+        #        include "multiple-spaces.h"
+      EOS
+
+      expected_output = <<-EOS.strip_indentation
+        #include "nospace.h"
+        #include "@@@@nospace.h"
+        #include "single-space.h"
+        #include "@@@@single-space.h"
+        #include "tab.h"
+        #include "@@@@tab.h"
+        #include "multiple-spaces.h"
+        #include "@@@@multiple-spaces.h"
+      EOS
+
+      objects[:file_path_utils].stub(:form_temp_path)
+      objects[:file_wrapper].stub(:read).and_return(input)
+      objects[:configurator].stub(:tools_test_includes_preprocessor)
+      objects[:tool_executor].stub(:build_command_line).and_return(:line => nil, :options => nil)
+      objects[:tool_executor].stub(:exec).and_return(:output => 'done')
+
+      objects[:file_wrapper].should_receive(:write).with(nil, expected_output)
+      PreprocessinatorIncludesHandler.new(objects).form_shallow_dependencies_rule(nil)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ support_dir = File.join(File.dirname(__FILE__), 'support')
 # # ceedling_files = File.join(File.dirname(__FILE__), '../lib/**/*.rb')
 # # require_all Dir.glob(ceedling_files)
 
+require 'preprocessinator_includes_handler'
 require 'preprocessinator_extractor'
 require 'configurator_builder'
 require 'configurator'
@@ -42,5 +43,9 @@ class String
         indent + rel
       end
     end.compact.join
+  end
+
+  def strip_indentation
+    self.left_margin.rstrip
   end
 end


### PR DESCRIPTION
The C standard allows whitespace between the pound symbol (#) and the include keyword. This patch fixes Ceedling so it will find such #include statements. This allows developers to indent #include lines in a conditional compilation. For example:

``` C
#if CONDITION
#        include "file1.h"
#else
#        include "file2.h"
#endif
```
