### PR TITLE
Bug in the module_generator.

### DIFF
--- a/plugins/module_generator/lib/module_generator.rb
+++ b/plugins/module_generator/lib/module_generator.rb
@@ -117,7 +117,7 @@ class ModuleGenerator < Plugin
     }
 
     location = File.dirname(path.gsub('\\', '/'))
-	location.sub!(/^\/?#{Regexp.escape(@context[:paths][:base])}\/?/i, '')
+    location.sub!(/^\/?#{Regexp.escape(@context[:paths][:base])}\/?/i, '')
     location.sub!(/^\/?#{Regexp.escape(@context[:paths][:src])}\/?/i, '')
     location.sub!(/^\/?#{Regexp.escape(@context[:paths][:test])}\/?/i, '')
     

--- a/plugins/module_generator/lib/module_generator.rb
+++ b/plugins/module_generator/lib/module_generator.rb
@@ -117,9 +117,9 @@ class ModuleGenerator < Plugin
     }
 
     location = File.dirname(path.gsub('\\', '/'))
-    location.sub!(/^\/?#{@context[:paths][:base]}\/?/i, '')
-    location.sub!(/^\/?#{@context[:paths][:src]}\/?/i, '')
-    location.sub!(/^\/?#{@context[:paths][:test]}\/?/i, '')
+	location.sub!(/^\/?#{Regexp.escape(@context[:paths][:base])}\/?/i, '')
+    location.sub!(/^\/?#{Regexp.escape(@context[:paths][:src])}\/?/i, '')
+    location.sub!(/^\/?#{Regexp.escape(@context[:paths][:test])}\/?/i, '')
     
     @context[:location] = location
 


### PR DESCRIPTION
Cause: The usage of regex's special characters in MODULE_GENERATOR_SOURCE_ROOT, MODULE_GENERATOR_PROJECT_ROOT or MODULE_GENERATOR_TEST_ROOT.
Example: For example when MODULE_GENERATOR_SOURCE_ROOT equals "../" and try to create a module with folders in the path (like "folderName/source.c") then the first two letters of the path will be missing in the generated file (like "lderName/test_source.c").
Solution: The solution is to escape those strings (with Regexp.escape()) before using them to compose the final regex passed as argument for the method String.sub().