### PR TITLE
Fixed XML inside <FailedTests>

### DIFF
--- a/plugins/xml_tests_report/xml_tests_report.rb
+++ b/plugins/xml_tests_report/xml_tests_report.rb
@@ -57,7 +57,7 @@ class XmlTestsReport < Plugin
         result[:collection].each do |item|
           filename = File.join( result[:source][:path], result[:source][:file] )
         
-          stream.puts "\t\t<FailedTest id=\"#{@test_counter}\"/>"
+          stream.puts "\t\t<Test id=\"#{@test_counter}\">"
           stream.puts "\t\t\t<Name>#{filename}::#{item[:test]}</Name>"
   				stream.puts "\t\t\t<FailureType>Assertion</FailureType>"
           stream.puts "\t\t\t<Location>"


### PR DESCRIPTION
The last commit that claimed to have fixed the botched XML, in fact didn't. This does, and makes it more consistent with the structure of the rest of the document...