### PR TITLE
rake task pattern only looks for mock prefix in file basename

### DIFF
--- a/lib/ceedling/rules_cmock.rake
+++ b/lib/ceedling/rules_cmock.rake
@@ -1,6 +1,6 @@
 
 
-rule(/#{CMOCK_MOCK_PREFIX}.+#{'\\'+EXTENSION_SOURCE}$/ => [
+rule(/#{CMOCK_MOCK_PREFIX}[^\/\\]+#{'\\'+EXTENSION_SOURCE}$/ => [
     proc do |task_name|
       @ceedling[:file_finder].find_header_input_for_mock_file(task_name)
     end  


### PR DESCRIPTION
Fixes #77 

Not perfect yet. The pattern should probably use a system-dependent file separator, rather than just forward- and back-slash

Also, I'm not positive where the correct place to add a test for this functionality is.