### PR TITLE
Added a plug-in to use the Fake Function Framework for mocking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 	path = vendor/cmock
 	url = https://github.com/ThrowTheSwitch/CMock.git     
 	branch = master
+[submodule "plugins/fake_function_framework"]
+	path = plugins/fake_function_framework
+	url = https://github.com/ElectronVector/fake_function_framework.git


### PR DESCRIPTION
When enabled, this plug-in replaces CMock with the [Fake Function Framework](https://github.com/meekrosoft/fff) for auto-mock generation.

fff works a little differently than CMock, and gives you some different (less-strict) mocking options. This plug-in also includes a few additional "Unity-style" TEST_ASSERT_ macros for use in tests. You can see some examples in the the [readme](https://github.com/ElectronVector/fake_function_framework/blob/master/README.md).

The mock generator uses the CMock header parsing stuff, and so can still use some of the CMock config options.

This does include the [fff repository](https://github.com/meekrosoft/fff) as a submodule.

The default `rake` task runs the rspec tests and all the tests for the included example.