### PR TITLE
Implement extra config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ ceedling.sublime-workspace
 ceedling-*.gem
 .DS_Store
 .ruby-version
+.bundle
+.bundles
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ DEPENDENCIES
   bundler (>= 1.3.5)
   constructor
   diy
+  popen4
   rake (>= 0.9.2.2)
   require_all
   rr

--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -58,6 +58,7 @@ CMOCK_H_FILE    = 'cmock.h'
 
 
 DEFAULT_CEEDLING_MAIN_PROJECT_FILE = 'project.yml' unless defined?(DEFAULT_CEEDLING_MAIN_PROJECT_FILE) # main project file
+DEFAULT_CEEDLING_EXTRA_PROJECT_FILE = 'extra.yml' unless defined?(DEFAULT_CEEDLING_EXTRA_PROJECT_FILE) # extra config file
 DEFAULT_CEEDLING_USER_PROJECT_FILE = 'user.yml'    unless defined?(DEFAULT_CEEDLING_USER_PROJECT_FILE) # supplemental user config file
 
 INPUT_CONFIGURATION_CACHE_FILE     = 'input.yml'   unless defined?(INPUT_CONFIGURATION_CACHE_FILE)     # input configuration file dump

--- a/lib/ceedling/loginator.rb
+++ b/lib/ceedling/loginator.rb
@@ -7,6 +7,7 @@ class Loginator
   def setup_log_filepath
     config_files = []
     config_files << @project_file_loader.main_file
+    config_files << @project_file_loader.extra_file
     config_files << @project_file_loader.user_file
     config_files.concat( @project_config_manager.options_files )
     config_files.compact!

--- a/lib/ceedling/project_file_loader.rb
+++ b/lib/ceedling/project_file_loader.rb
@@ -1,5 +1,5 @@
 require 'ceedling/constants'
-require 'json'
+
 
 class ProjectFileLoader
 
@@ -81,8 +81,6 @@ class ProjectFileLoader
 
     config_hash = project_hash.merge(extra_hash).merge(user_hash)
 
-#    puts JSON.pretty_generate(config_hash)
-    
     return config_hash
   end
       

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ ! -d .bundles ]; then
+	echo "Creating directory for bundles..."
+	mkdir .bundles
+fi
+
+export BUNDLE_PATH=`realpath .bundles`
+echo "BUNDLE_PATH is now set to $BUNDLE_PATH"
+


### PR DESCRIPTION
This pull request adds support for extra project file in addition to user project file. It is helpful when dealing with multiple configurations for a build.

If a extra.yml is present, then the contents in project.yml are merged/exchanged with/by the values in extra.yml. If user.yml is present, these values take preceedence as before.

Furthermore, if the environment variable CEEDLING_EXTRA_PROJECT_FILE is set, the file pointed to by that variable will be used (as with CEEDLING_USER_PROJECT_FILE).
