### PR TITLE
curses gem dependence 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 rvm:
   - "1.9.3"
   - "2.0.0"
+  - "2.1.8"
+  - "2.2.4"
+  - "2.3.0"
 install:
   - gem update bundler
   - bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "constructor"
 gem "diy"
 gem "rr"
 gem "thor"
+gem "curses"
 
 #gem "pty",    :platforms => [ :ruby ] #automatically included on *nix platforms
 gem "popen4", :platforms => [ :mswin ]

--- a/ceedling.gemspec
+++ b/ceedling.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "thor", ">= 0.14.5"
   s.add_dependency "rake", ">= 0.8.7"
+  s.add_dependency "curses", ">= 1.0.0"
 
   # Files needed from submodules
   s.files         = []


### PR DESCRIPTION
In versions of Ruby above 2.1.0, curses is not built in but a gem instead. I've added the dependency and updated the ci to test the newer versions of ruby on builds.