### PR TITLE
separate unity config and cmock config

### DIFF
--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -79,6 +79,11 @@ class Configurator
   end
   
   
+  def populate_unity_defaults(config)
+      unity = config[:unity] || {}
+      @unity_runner_config = unity.merge(config[:test_runner] || {})
+  end
+
   def populate_cmock_defaults(config)
     # cmock has its own internal defaults handling, but we need to set these specific values
     # so they're present for the build environment to access;
@@ -106,13 +111,12 @@ class Configurator
       cmock[:includes].uniq!
     end
 
-    @runner_config = cmock.merge(config[:test_runner] || {})
     @cmock_builder.manufacture(cmock)
   end
   
   
   def get_runner_config
-    @runner_config
+    @unity_runner_config
   end
 
 

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -81,7 +81,7 @@ class Configurator
   
   def populate_unity_defaults(config)
       unity = config[:unity] || {}
-      @unity_runner_config = unity.merge(config[:test_runner] || {})
+      @runner_config = unity.merge(@runner_config || config[:test_runner] || {})
   end
 
   def populate_cmock_defaults(config)
@@ -111,12 +111,14 @@ class Configurator
       cmock[:includes].uniq!
     end
 
+    @runner_config = cmock.merge(@runner_config || config[:test_runner] || {})
+
     @cmock_builder.manufacture(cmock)
   end
   
   
   def get_runner_config
-    @unity_runner_config
+    @runner_config
   end
 
 

--- a/lib/ceedling/setupinator.rb
+++ b/lib/ceedling/setupinator.rb
@@ -21,6 +21,7 @@ class Setupinator
     # note: configurator modifies the cmock section of the hash with a couple defaults to tie 
     #       project together - the modified hash is used to build cmock object
     @ceedling[:configurator].populate_defaults( config_hash )
+    @ceedling[:configurator].populate_unity_defaults( config_hash )
     @ceedling[:configurator].populate_cmock_defaults( config_hash )
     @ceedling[:configurator].find_and_merge_plugins( config_hash )
     @ceedling[:configurator].tools_setup( config_hash )


### PR DESCRIPTION
As I mentioned in #97, Ceedling uses cmock option to initialize UnityTestRunnerGenerator,
Because get_runner_config method is only used by the initialization, it shall have unity option.
That is why, I separated unity config from cmock config and let get_runner_config return unity config.

By merging this request, you can speicfy "use_param_tests" under "unity" instead of cmock as below.

```yaml
:unity:
  :use_param_tests: true
```
