### PR TITLE
add new option "use_test_definition"

### DIFF
--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -276,6 +276,7 @@ DEFAULT_CEEDLING_CONFIG = {
       :test_preprocess => [],
       :release => [],
       :release_preprocess => [],
+      :use_test_definition => false,
     },
 
     :flags => {},


### PR DESCRIPTION
I added new option "use_test_definition".
This can be defined under "defines" section as below.

``` yaml
:defines:
    :use_test_definition: true
```

The default value is false.
If you specify this option, you can append -DTEST_FILE_NAME to the build option. 
This feature is discussed in following threads in detail.
- https://github.com/ThrowTheSwitch/Ceedling/issues/88
- https://github.com/TE-HiroakiYamazoe/Ceedling/pull/2
