### PR TITLE
Fixed error when not using PTY or Popen4 (like on Windows).

### DIFF
--- a/bin/ceedling
+++ b/bin/ceedling
@@ -184,7 +184,7 @@ else
 
       #if neither of these libraries were available, we can just shell out to the command and collect results
       def spawn_command(cmd, &block)
-        block.call( `#{cmd}` )
+        block.call( StringIO.new(`#{cmd}`) )
       end
     end
 


### PR DESCRIPTION
When not using PTY or Popen4, we just capture the output after everything is done.

However, we need to return the captured `stdout` as a `StringIO` (instead of a `String`) so the block can use `each` to iterate over it.

Fixes #84