### PR TITLE
Made Ceedling more graceful when encountering a missing directory that it generates.

### DIFF
--- a/lib/ceedling/configurator_validator.rb
+++ b/lib/ceedling/configurator_validator.rb
@@ -78,9 +78,18 @@ class ConfiguratorValidator
     return true if (filepath =~ TOOL_EXECUTOR_ARGUMENT_REPLACEMENT_PATTERN)
     
     if (not @file_wrapper.exist?(filepath))
-      # no verbosity checking since this is lowest level anyhow & verbosity checking depends on configurator
-      @stream_wrapper.stderr_puts("ERROR: Config filepath #{format_key_sequence(keys, hash[:depth])}['#{filepath}'] does not exist on disk.") 
-      return false
+
+      # See if we can deal with it internally.
+      if GENERATED_DIR_PATH.include?(filepath)      
+        # we already made this directory before let's make it again.
+        FileUtils.mkdir_p File.join(File.dirname(__FILE__), filepath)
+        @stream_wrapper.stderr_puts("WARNING: Generated filepath #{format_key_sequence(keys, hash[:depth])}['#{filepath}'] does not exist on disk. Recreating") 
+ 
+      else
+        # no verbosity checking since this is lowest level anyhow & verbosity checking depends on configurator
+        @stream_wrapper.stderr_puts("ERROR: Config filepath #{format_key_sequence(keys, hash[:depth])}['#{filepath}'] does not exist on disk.")
+        return false
+      end
     end      
 
     return true

--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -36,6 +36,8 @@ unless defined?(PROJECT_ROOT)
   PROJECT_ROOT = Dir.pwd()
 end
 
+GENERATED_DIR_PATH = [['vendor', 'ceedling'], 'src', "test", ['test', 'support'], 'build'].each{|p| File.join(*p)}
+
 EXTENSION_WIN_EXE    = '.exe'
 EXTENSION_NONWIN_EXE = '.out'
 


### PR DESCRIPTION
This change makes Ceedling a little better at handling errors due to users deleting a directory that Ceedling needs, Let's say you are cleaning a repository and you get rid of the `build` directory. Currently, Ceedling does the following:

```
dom@osboxes:~/dev/test-project$ rm -rf build/
dom@osboxes:~/dev/test-project$ rake test:all
ERROR: Config filepath [:project][:build_root]['build'] does not exist on disk.
rake aborted!
/home/dom/dev/test-project/vendor/ceedling/lib/ceedling/configurator.rb:271:in `validate'
/home/dom/dev/test-project/vendor/ceedling/lib/ceedling/setupinator.rb:31:in `do_setup'
vendor/ceedling/lib/../lib/ceedling/rakefile.rb:46:in `<top (required)>'
vendor/ceedling/lib/ceedling.rb:66:in `load'
vendor/ceedling/lib/ceedling.rb:66:in `load_project'
/home/dom/dev/learn-c/rakefile.rb:4:in `<top (required)>'
/home/dom/.rvm/gems/ruby-2.2.4/bin/ruby_executable_hooks:15:in `eval'
/home/dom/.rvm/gems/ruby-2.2.4/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)

```
Now with this commit it does the following:

```
dom@osboxes:~/dev/test-project$ rm -rf build/
dom@osboxes:~/dev/test-project$ rake test:all
WARNING: Generated filepath [:project][:build_root]['build'] does not exist on disk. Recreating
```

The rake will no longer fail and hopefully this.