### PR TITLE
Swallow extra blank line in Unity output

### DIFF
--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -87,7 +87,7 @@ OPERATION_LINK_SYM     = :link     unless defined?(OPERATION_LINK_SYM)
 RUBY_STRING_REPLACEMENT_PATTERN = /#\{.+\}/
 RUBY_EVAL_REPLACEMENT_PATTERN   = /^\{(.+)\}$/
 TOOL_EXECUTOR_ARGUMENT_REPLACEMENT_PATTERN = /(\$\{(\d+)\})/
-TEST_STDOUT_STATISTICS_PATTERN  = /-+\s*(\d+)\s+Tests\s+(\d+)\s+Failures\s+(\d+)\s+Ignored\s+(OK|FAIL)\s*/i
+TEST_STDOUT_STATISTICS_PATTERN  = /\n-+\s*(\d+)\s+Tests\s+(\d+)\s+Failures\s+(\d+)\s+Ignored\s+(OK|FAIL)\s*/i
 
 NULL_FILE_PATH = '/dev/null'
 


### PR DESCRIPTION
Suppresses empty TEST OUTPUT sections, e.g.
```
-----------
TEST OUTPUT
-----------
[test_foo.c]
  - ""
```