### PR TITLE
Plugin paths

### DIFF
--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -4,6 +4,7 @@ require 'ceedling/file_path_utils'
 
 #this should be defined already, but not always during system specs
 CEEDLING_VENDOR = File.expand_path(File.dirname(__FILE__) + '/../../vendor') unless defined? CEEDLING_VENDOR
+CEEDLING_PLUGINS = File.expand_path(File.dirname(__FILE__) + '/../../plugins') unless defined? CEEDLING_PLUGINS
 
 DEFAULT_TEST_COMPILER_TOOL = {
   :executable => FilePathUtils.os_executable_ext('gcc').freeze,
@@ -333,7 +334,7 @@ DEFAULT_CEEDLING_CONFIG = {
     :release_dependencies_generator => { :arguments => [] },
 
     :plugins => {
-      :load_paths => [],
+      :load_paths => [CEEDLING_PLUGINS],
       :enabled => [],
     }
   }.freeze

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -4,7 +4,7 @@ require 'ceedling/file_path_utils'
 
 #this should be defined already, but not always during system specs
 CEEDLING_VENDOR = File.expand_path(File.dirname(__FILE__) + '/../../vendor') unless defined? CEEDLING_VENDOR
-CEEDLING_PLUGINS = File.expand_path(File.dirname(__FILE__) + '/../../plugins') unless defined? CEEDLING_PLUGINS
+CEEDLING_PLUGINS = [File.expand_path(File.dirname(__FILE__) + '/../../plugins')] unless defined? CEEDLING_PLUGINS
 
 DEFAULT_TEST_COMPILER_TOOL = {
   :executable => FilePathUtils.os_executable_ext('gcc').freeze,
@@ -334,7 +334,7 @@ DEFAULT_CEEDLING_CONFIG = {
     :release_dependencies_generator => { :arguments => [] },
 
     :plugins => {
-      :load_paths => [CEEDLING_PLUGINS],
+      :load_paths => CEEDLING_PLUGINS,
       :enabled => [],
     }
   }.freeze


### PR DESCRIPTION
Add a CEEDLING_PLUGINS array which defaults to containing Ceedling's own plugin path but can be added to by project.yml. This means that the plugins/load_paths section can be omitted if only the Ceedling-provided plugins are being used.

We don't copy Ceedling into our project repositories, so this saves the project configuration file from having to know where Ceedling is installed, or doing something ugly like
```
:plugins:
  :load_paths:
    - "#{PROJECT_CEEDLING_ROOT}/plugins"
```