### PR TITLE
Config file includes

### DIFF
--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -194,15 +194,15 @@ class Configurator
   end
 
 
-  def find_and_merge_includes(config)
-    if config[:include]
-      until config[:include].empty?
-        path = config[:include].shift
+  def merge_imports(config)
+    if config[:import]
+      until config[:import].empty?
+        path = config[:import].shift
         path = @system_wrapper.module_eval(path) if (path =~ RUBY_STRING_REPLACEMENT_PATTERN)
         config.deep_merge!(@yaml_wrapper.load(path))
       end
     end
-    config.delete(:include)
+    config.delete(:import)
   end
 
 

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -197,7 +197,9 @@ class Configurator
   def find_and_merge_includes(config)
     if config[:include]
       until config[:include].empty?
-        config.deep_merge!(@yaml_wrapper.load(config[:include].shift))
+        path = config[:include].shift
+        path = @system_wrapper.module_eval(path) if (path =~ RUBY_STRING_REPLACEMENT_PATTERN)
+        config.deep_merge!(@yaml_wrapper.load(path))
       end
     end
     config.delete(:include)

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -180,7 +180,7 @@ class Configurator
     plugin_defaults = @configurator_plugins.find_plugin_defaults(config)
 
     config_plugins.each do |plugin|
-      config.deep_merge( @yaml_wrapper.load(plugin) )
+      config.deep_merge!( @yaml_wrapper.load(plugin) )
     end
 
     plugin_defaults.each do |defaults|

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -194,6 +194,16 @@ class Configurator
   end
 
 
+  def find_and_merge_includes(config)
+    if config[:include]
+      until config[:include].empty?
+        config.deep_merge!(@yaml_wrapper.load(config[:include].shift))
+      end
+    end
+    config.delete(:include)
+  end
+
+
   def eval_environment_variables(config)
     config[:environment].each do |hash|
       key   = hash.keys[0]
@@ -337,3 +347,4 @@ class Configurator
 
 
 end
+

--- a/lib/ceedling/project_config_manager.rb
+++ b/lib/ceedling/project_config_manager.rb
@@ -18,8 +18,7 @@ class ProjectConfigManager
 
   def merge_options(config_hash, option_filepath)
     @options_files << File.basename( option_filepath )
-    config_hash.deep_merge( @yaml_wrapper.load( option_filepath ) )
-    return config_hash
+    config_hash.deep_merge!( @yaml_wrapper.load( option_filepath ) )
   end 
   
 

--- a/lib/ceedling/setupinator.rb
+++ b/lib/ceedling/setupinator.rb
@@ -24,6 +24,7 @@ class Setupinator
     @ceedling[:configurator].populate_unity_defaults( config_hash )
     @ceedling[:configurator].populate_cmock_defaults( config_hash )
     @ceedling[:configurator].find_and_merge_plugins( config_hash )
+    @ceedling[:configurator].find_and_merge_includes( config_hash )
     @ceedling[:configurator].tools_setup( config_hash )
     @ceedling[:configurator].eval_environment_variables( config_hash )
     @ceedling[:configurator].eval_paths( config_hash )

--- a/lib/ceedling/setupinator.rb
+++ b/lib/ceedling/setupinator.rb
@@ -24,7 +24,7 @@ class Setupinator
     @ceedling[:configurator].populate_unity_defaults( config_hash )
     @ceedling[:configurator].populate_cmock_defaults( config_hash )
     @ceedling[:configurator].find_and_merge_plugins( config_hash )
-    @ceedling[:configurator].find_and_merge_includes( config_hash )
+    @ceedling[:configurator].merge_imports( config_hash )
     @ceedling[:configurator].tools_setup( config_hash )
     @ceedling[:configurator].eval_environment_variables( config_hash )
     @ceedling[:configurator].eval_paths( config_hash )


### PR DESCRIPTION
We use a *lot* of options files to configure our products.

In some cases it would be really nice to be able to have config files (project.yml, options files) load other config files, for commonly re-used definitions (target processor, common code modules, etc).

This patch makes that possible, for example:

```
---
:include:
  - path/to/config.yml
  - path/to/another/config.yml
...
```

These can be recursively nested, the included files can include other files in turn, just like in C.