### PR TITLE
Only load release rules if there is a release build

### DIFF
--- a/lib/ceedling/tasks_base.rake
+++ b/lib/ceedling/tasks_base.rake
@@ -92,7 +92,9 @@ namespace :options do
       # @ceedling[:setupinator].reset_defaults( @ceedling[:setupinator].config_hash )
       hash = @ceedling[:project_config_manager].merge_options( @ceedling[:setupinator].config_hash, option_path )
       @ceedling[:setupinator].do_setup( hash )
-      load(File.join(CEEDLING_LIB, 'ceedling', 'rules_release.rake'))
+      if @ceedling[:configurator].project_release_build
+        load(File.join(CEEDLING_LIB, 'ceedling', 'rules_release.rake'))
+      end
     end
   end
 


### PR DESCRIPTION
Slight oversight in my earlier patch - can't load `rules_release.rake` if there's no release build.