### PR TITLE
Restored error code on tests failing and added option to gracefully fail

### DIFF
--- a/lib/ceedling/rakefile.rb
+++ b/lib/ceedling/rakefile.rb
@@ -67,12 +67,12 @@ END {
     @ceedling[:file_wrapper].rm_f( @ceedling[:file_wrapper].directory_listing( File.join(@ceedling[:configurator].project_temp_path, '*') ))
   end
 
-	# only perform these final steps if we got here without runtime exceptions or errors
-	if (@ceedling[:system_wrapper].ruby_success)
+  # only perform these final steps if we got here without runtime exceptions or errors
+  if (@ceedling[:system_wrapper].ruby_success)
 
     # tell all our plugins the build is done and process results
-	  @ceedling[:plugin_manager].post_build
-	  @ceedling[:plugin_manager].print_plugin_failures
-	  #exit(1) if (@ceedling[:plugin_manager].plugins_failed?) #do NOT call this. It will keep caller from reporting failures
-	end
+    @ceedling[:plugin_manager].post_build
+    @ceedling[:plugin_manager].print_plugin_failures
+    exit(1) if (@ceedling[:plugin_manager].plugins_failed? && !@ceedling[:setupinator].config_hash[:graceful_fail]) 
+  end
 }


### PR DESCRIPTION
This restores the exit code returning error on failing tests. There is also an added option that can be put in the project.yml. If setting `:graceful_fail:  true` in project.yml, it will behave the same way it currently does.

 As mentioned in #117, the default behavior is for it to return error on failing tests as all test suits do this for CI and scripting purposes.