### PR TITLE
Improve Gcov reports

### DIFF
--- a/assets/project_as_gem.yml
+++ b/assets/project_as_gem.yml
@@ -57,6 +57,9 @@
     int8:     INT8
     bool:     UINT8
 
+:gcov:
+    :html_report_type: basic
+
 #:tools:
 # Ceedling defaults to using gcc for compiling, linking, etc.
 # As [:tools] is blank, gcc will be used (so long as it's in your system path)

--- a/assets/project_with_guts.yml
+++ b/assets/project_with_guts.yml
@@ -57,6 +57,9 @@
     int8:     INT8
     bool:     UINT8
 
+:gcov:
+    :html_report_type: basic
+
 #:tools:
 # Ceedling defaults to using gcc for compiling, linking, etc.
 # As [:tools] is blank, gcc will be used (so long as it's in your system path)

--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -49,5 +49,17 @@
         - -e '^vendor.*|^build.*|^test.*|^lib.*'
         - --html
         - -r .
-        - -o  '${GCOV_ARTIFACTS_PATH}/GcovCoverageResults.html'
+        - -o  "$": GCOV_ARTIFACTS_FILE
+  :gcov_post_report_advanced:
+    :executable: gcovr
+    :optional: TRUE
+    :arguments:
+        - -p
+        - -b
+        - -e '^vendor.*|^build.*|^test.*|^lib.*'
+        - --html-details
+        - -r .
+        - -o  "$": GCOV_ARTIFACTS_FILE
+
+
 ...

--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -40,4 +40,14 @@
         - --html
         - -r .
         - -o GcovCoverageResults.html
+  :gcov_post_report_basic:
+    :executable: gcovr
+    :optional: TRUE
+    :arguments:
+        - -p
+        - -b
+        - -e '^vendor.*|^build.*|^test.*|^lib.*'
+        - --html
+        - -r .
+        - -o  '${GCOV_ARTIFACTS_PATH}/GcovCoverageResults.html'
 ...

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -1,4 +1,3 @@
-
 directory(GCOV_BUILD_OUTPUT_PATH)
 directory(GCOV_RESULTS_PATH)
 directory(GCOV_ARTIFACTS_PATH)
@@ -6,159 +5,156 @@ directory(GCOV_DEPENDENCIES_PATH)
 
 CLEAN.include(File.join(GCOV_BUILD_OUTPUT_PATH, '*'))
 CLEAN.include(File.join(GCOV_RESULTS_PATH, '*'))
+CLEAN.include(File.join(GCOV_ARTIFACTS_PATH, '*'))
 CLEAN.include(File.join(GCOV_DEPENDENCIES_PATH, '*'))
 
 CLOBBER.include(File.join(GCOV_BUILD_PATH, '**/*'))
 
+rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\' + EXTENSION_OBJECT}$/ => [
+       proc do |task_name|
+         @ceedling[:file_finder].find_compilation_input_file(task_name)
+       end
+     ]) do |object|
 
-rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\'+EXTENSION_OBJECT}$/ => [
-    proc do |task_name|
-      @ceedling[:file_finder].find_compilation_input_file(task_name)
-    end
-  ]) do |object|
-
-  if (File.basename(object.source) =~ /^(#{PROJECT_TEST_FILE_PREFIX}|#{CMOCK_MOCK_PREFIX}|#{GCOV_IGNORE_SOURCES.join('|')})/i)
+  if File.basename(object.source) =~ /^(#{PROJECT_TEST_FILE_PREFIX}|#{CMOCK_MOCK_PREFIX}|#{GCOV_IGNORE_SOURCES.join('|')})/i
     @ceedling[:generator].generate_object_file(
       TOOLS_GCOV_COMPILER,
       OPERATION_COMPILE_SYM,
       GCOV_SYM,
       object.source,
       object.name,
-      @ceedling[:file_path_utils].form_test_build_list_filepath( object.name ) )
+      @ceedling[:file_path_utils].form_test_build_list_filepath(object.name)
+    )
   else
     @ceedling[GCOV_SYM].generate_coverage_object_file(object.source, object.name)
   end
-
 end
 
-rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\'+EXTENSION_EXECUTABLE}$/) do |bin_file|
+rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\' + EXTENSION_EXECUTABLE}$/) do |bin_file|
   @ceedling[:generator].generate_executable_file(
     TOOLS_GCOV_LINKER,
     GCOV_SYM,
     bin_file.prerequisites,
     bin_file.name,
-    @ceedling[:file_path_utils].form_test_build_map_filepath(bin_file.name))
+    @ceedling[:file_path_utils].form_test_build_map_filepath(bin_file.name)
+  )
 end
 
-rule(/#{GCOV_RESULTS_PATH}\/#{'.+\\'+EXTENSION_TESTPASS}$/ => [
-     proc do |task_name|
-       @ceedling[:file_path_utils].form_test_executable_filepath(task_name)
-     end
-  ]) do |test_result|
+rule(/#{GCOV_RESULTS_PATH}\/#{'.+\\' + EXTENSION_TESTPASS}$/ => [
+       proc do |task_name|
+         @ceedling[:file_path_utils].form_test_executable_filepath(task_name)
+       end
+     ]) do |test_result|
   @ceedling[:generator].generate_test_results(TOOLS_GCOV_FIXTURE, GCOV_SYM, test_result.source, test_result.name)
 end
 
-rule(/#{GCOV_DEPENDENCIES_PATH}\/#{'.+\\'+EXTENSION_DEPENDENCIES}$/ => [
-    proc do |task_name|
-      @ceedling[:file_finder].find_compilation_input_file(task_name)
-    end
-  ]) do |dep|
+rule(/#{GCOV_DEPENDENCIES_PATH}\/#{'.+\\' + EXTENSION_DEPENDENCIES}$/ => [
+       proc do |task_name|
+         @ceedling[:file_finder].find_compilation_input_file(task_name)
+       end
+     ]) do |dep|
   @ceedling[:generator].generate_dependencies_file(
     TOOLS_TEST_DEPENDENCIES_GENERATOR,
     GCOV_SYM,
     dep.source,
-    File.join(GCOV_BUILD_OUTPUT_PATH, File.basename(dep.source).ext(EXTENSION_OBJECT) ),
-    dep.name)
+    File.join(GCOV_BUILD_OUTPUT_PATH, File.basename(dep.source).ext(EXTENSION_OBJECT)),
+    dep.name
+  )
 end
 
-task :directories => [GCOV_BUILD_OUTPUT_PATH, GCOV_RESULTS_PATH, GCOV_DEPENDENCIES_PATH, GCOV_ARTIFACTS_PATH]
+task directories: [GCOV_BUILD_OUTPUT_PATH, GCOV_RESULTS_PATH, GCOV_DEPENDENCIES_PATH, GCOV_ARTIFACTS_PATH]
 
 namespace GCOV_SYM do
+  task source_coverage: COLLECTION_ALL_SOURCE.pathmap("#{GCOV_BUILD_OUTPUT_PATH}/%n#{@ceedling[:configurator].extension_object}")
 
-  task :source_coverage => COLLECTION_ALL_SOURCE.pathmap("#{GCOV_BUILD_OUTPUT_PATH}/%n#{@ceedling[:configurator].extension_object}")
-
-  desc "Run code coverage for all tests"
-  task :all => [:directories] do
+  desc 'Run code coverage for all tests'
+  task all: [:directories] do
     @ceedling[:configurator].replace_flattened_config(@ceedling[GCOV_SYM].config)
     @ceedling[:test_invoker].setup_and_invoke(COLLECTION_ALL_TESTS, GCOV_SYM)
     @ceedling[:configurator].restore_config
   end
 
-  desc "Run single test w/ coverage ([*] real test or source file name, no path)."
+  desc 'Run single test w/ coverage ([*] real test or source file name, no path).'
   task :* do
-    message = "\nOops! '#{GCOV_ROOT_NAME}:*' isn't a real task. " +
-              "Use a real test or source file name (no path) in place of the wildcard.\n" +
+    message = "\nOops! '#{GCOV_ROOT_NAME}:*' isn't a real task. " \
+              "Use a real test or source file name (no path) in place of the wildcard.\n" \
               "Example: rake #{GCOV_ROOT_NAME}:foo.c\n\n"
 
-    @ceedling[:streaminator].stdout_puts( message )
+    @ceedling[:streaminator].stdout_puts(message)
   end
 
-  desc "Run tests by matching regular expression pattern."
-  task :pattern, [:regex] => [:directories] do |t, args|
+  desc 'Run tests by matching regular expression pattern.'
+  task :pattern, [:regex] => [:directories] do |_t, args|
     matches = []
 
     COLLECTION_ALL_TESTS.each do |test|
       matches << test if test =~ /#{args.regex}/
     end
 
-    if (matches.size > 0)
+    if !matches.empty?
       @ceedling[:configurator].replace_flattened_config(@ceedling[GCOV_SYM].config)
-      @ceedling[:test_invoker].setup_and_invoke(matches, GCOV_SYM, {:force_run => false})
+      @ceedling[:test_invoker].setup_and_invoke(matches, GCOV_SYM, force_run: false)
       @ceedling[:configurator].restore_config
     else
       @ceedling[:streaminator].stdout_puts("\nFound no tests matching pattern /#{args.regex}/.")
     end
   end
 
-  desc "Run tests whose test path contains [dir] or [dir] substring."
-  task :path, [:dir] => [:directories] do |t, args|
+  desc 'Run tests whose test path contains [dir] or [dir] substring.'
+  task :path, [:dir] => [:directories] do |_t, args|
     matches = []
 
     COLLECTION_ALL_TESTS.each do |test|
-      matches << test if File.dirname(test).include?(args.dir.gsub(/\\/, '/'))
+      matches << test if File.dirname(test).include?(args.dir.tr('\\', '/'))
     end
 
-    if (matches.size > 0)
+    if !matches.empty?
       @ceedling[:configurator].replace_flattened_config(@ceedling[GCOV_SYM].config)
-      @ceedling[:test_invoker].setup_and_invoke(matches, GCOV_SYM, {:force_run => false})
+      @ceedling[:test_invoker].setup_and_invoke(matches, GCOV_SYM, force_run: false)
       @ceedling[:configurator].restore_config
     else
       @ceedling[:streaminator].stdout_puts("\nFound no tests including the given path or path component.")
     end
   end
 
-  desc "Run code coverage for changed files"
-  task :delta => [:directories] do
+  desc 'Run code coverage for changed files'
+  task delta: [:directories] do
     @ceedling[:configurator].replace_flattened_config(@ceedling[GCOV_SYM].config)
-    @ceedling[:test_invoker].setup_and_invoke(COLLECTION_ALL_TESTS, GCOV_SYM, {:force_run => false})
+    @ceedling[:test_invoker].setup_and_invoke(COLLECTION_ALL_TESTS, GCOV_SYM, force_run: false)
     @ceedling[:configurator].restore_config
   end
 
   # use a rule to increase efficiency for large projects
   # gcov test tasks by regex
   rule(/^#{GCOV_TASK_ROOT}\S+$/ => [
-      proc do |task_name|
-        test = task_name.sub(/#{GCOV_TASK_ROOT}/, '')
-        test = "#{PROJECT_TEST_FILE_PREFIX}#{test}" if not (test.start_with?(PROJECT_TEST_FILE_PREFIX))
-        @ceedling[:file_finder].find_test_from_file_path(test)
-      end
-  ]) do |test|
+         proc do |task_name|
+           test = task_name.sub(/#{GCOV_TASK_ROOT}/, '')
+           test = "#{PROJECT_TEST_FILE_PREFIX}#{test}" unless test.start_with?(PROJECT_TEST_FILE_PREFIX)
+           @ceedling[:file_finder].find_test_from_file_path(test)
+         end
+       ]) do |test|
     @ceedling[:rake_wrapper][:directories].invoke
     @ceedling[:configurator].replace_flattened_config(@ceedling[GCOV_SYM].config)
     @ceedling[:test_invoker].setup_and_invoke([test.source], GCOV_SYM)
     @ceedling[:configurator].restore_config
   end
-
 end
 
 if PROJECT_USE_DEEP_DEPENDENCIES
-namespace REFRESH_SYM do
-  task GCOV_SYM do
-    @ceedling[:configurator].replace_flattened_config(@ceedling[GCOV_SYM].config)
-    @ceedling[:test_invoker].refresh_deep_dependencies
-    @ceedling[:configurator].restore_config
+  namespace REFRESH_SYM do
+    task GCOV_SYM do
+      @ceedling[:configurator].replace_flattened_config(@ceedling[GCOV_SYM].config)
+      @ceedling[:test_invoker].refresh_deep_dependencies
+      @ceedling[:configurator].restore_config
+    end
   end
-end
 end
 
 namespace UTILS_SYM do
-  
-  desc "Create gcov code coverage html report"
+  desc 'Create gcov code coverage html report'
   task GCOV_SYM do
     command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT, [])
     puts 'Creating html report of gcov results...'
     @ceedling[:tool_executor].exec(command[:line], command[:options])
   end
-  
 end
-

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -153,8 +153,21 @@ end
 namespace UTILS_SYM do
   desc 'Create gcov code coverage html report'
   task GCOV_SYM do
-    command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [])
-    puts 'Creating html report of gcov results...'
-    @ceedling[:tool_executor].exec(command[:line], command[:options])
+
+    if !File.directory? GCOV_ARTIFACTS_PATH
+      Dir.mkdir GCOV_ARTIFACTS_PATH
+    end
+
+    if @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'basic'
+      puts 'Creating a basic html report of gcov results...'
+      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [])
+      @ceedling[:tool_executor].exec(command[:line], command[:options])
+    elsif @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'advanced'
+      puts 'Creating an indepth html report of gcov results...'
+      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_ADVANCED, [])
+      @ceedling[:tool_executor].exec(command[:line], command[:options])
+    else
+      puts 'define \n:gcov:\n\t:html_report_type:\n to basic or advanced to use this feature.'
+    end
   end
 end

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -153,7 +153,7 @@ end
 namespace UTILS_SYM do
   desc 'Create gcov code coverage html report'
   task GCOV_SYM do
-    command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT, [])
+    command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [])
     puts 'Creating html report of gcov results...'
     @ceedling[:tool_executor].exec(command[:line], command[:options])
   end

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -1,71 +1,59 @@
 require 'ceedling/plugin'
 require 'ceedling/constants'
-
-GCOV_ROOT_NAME         = 'gcov'
-GCOV_TASK_ROOT         = GCOV_ROOT_NAME + ':'
-GCOV_SYM               = GCOV_ROOT_NAME.to_sym
-
-GCOV_BUILD_PATH        = "#{PROJECT_BUILD_ROOT}/#{GCOV_ROOT_NAME}"
-GCOV_BUILD_OUTPUT_PATH = "#{GCOV_BUILD_PATH}/out"
-GCOV_RESULTS_PATH      = "#{GCOV_BUILD_PATH}/results"
-GCOV_DEPENDENCIES_PATH = "#{GCOV_BUILD_PATH}/dependencies"
-GCOV_ARTIFACTS_PATH    = "#{PROJECT_BUILD_ARTIFACTS_ROOT}/#{GCOV_ROOT_NAME}"
-
-GCOV_IGNORE_SOURCES    = ['unity', 'cmock', 'cexception']
-
+require 'gcov_constants'
 
 class Gcov < Plugin
-
   attr_reader :config
 
   def setup
     @result_list = []
 
     @config = {
-      :project_test_build_output_path     => GCOV_BUILD_OUTPUT_PATH,
-      :project_test_results_path          => GCOV_RESULTS_PATH,
-      :project_test_dependencies_path     => GCOV_DEPENDENCIES_PATH,
-      :defines_test                       => DEFINES_TEST + ['CODE_COVERAGE'],
-      :collection_defines_test_and_vendor => COLLECTION_DEFINES_TEST_AND_VENDOR + ['CODE_COVERAGE']
-      }
+      project_test_build_output_path: GCOV_BUILD_OUTPUT_PATH,
+      project_test_results_path: GCOV_RESULTS_PATH,
+      project_test_dependencies_path: GCOV_DEPENDENCIES_PATH,
+      defines_test: DEFINES_TEST + ['CODE_COVERAGE'],
+      collection_defines_test_and_vendor: COLLECTION_DEFINES_TEST_AND_VENDOR + ['CODE_COVERAGE']
+    }
 
     @plugin_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-    @coverage_template_all = @ceedling[:file_wrapper].read( File.join( @plugin_root, 'assets/template.erb') )
+    @coverage_template_all = @ceedling[:file_wrapper].read(File.join(@plugin_root, 'assets/template.erb'))
   end
 
   def generate_coverage_object_file(source, object)
     compile_command =
       @ceedling[:tool_executor].build_command_line(
         TOOLS_GCOV_COMPILER,
-        @ceedling[:flaginator].flag_down( OPERATION_COMPILE_SYM, GCOV_SYM, source),
+        @ceedling[:flaginator].flag_down(OPERATION_COMPILE_SYM, GCOV_SYM, source),
         source,
         object,
-        @ceedling[:file_path_utils].form_test_build_list_filepath( object ) )
+        @ceedling[:file_path_utils].form_test_build_list_filepath(object)
+      )
     @ceedling[:streaminator].stdout_puts("Compiling #{File.basename(source)} with coverage...")
-    @ceedling[:tool_executor].exec( compile_command[:line], compile_command[:options] )
+    @ceedling[:tool_executor].exec(compile_command[:line], compile_command[:options])
   end
 
   def post_test_fixture_execute(arg_hash)
     result_file = arg_hash[:result_file]
 
-    if ((result_file =~ /#{GCOV_RESULTS_PATH}/) and (not @result_list.include?(result_file)))
+    if (result_file =~ /#{GCOV_RESULTS_PATH}/) && !@result_list.include?(result_file)
       @result_list << arg_hash[:result_file]
     end
   end
 
   def post_build
-    return if (not @ceedling[:task_invoker].invoked?(/^#{GCOV_TASK_ROOT}/))
+    return unless @ceedling[:task_invoker].invoked?(/^#{GCOV_TASK_ROOT}/)
 
     # test results
     results = @ceedling[:plugin_reportinator].assemble_test_results(@result_list)
     hash = {
-      :header => GCOV_ROOT_NAME.upcase,
-      :results => results
+      header: GCOV_ROOT_NAME.upcase,
+      results: results
     }
 
     @ceedling[:plugin_reportinator].run_test_results_report(hash) do
       message = ''
-      message = 'Unit test failures.' if (results[:counts][:failed] > 0)
+      message = 'Unit test failures.' if results[:counts][:failed] > 0
       message
     end
 
@@ -73,13 +61,13 @@ class Gcov < Plugin
   end
 
   def summary
-    result_list = @ceedling[:file_path_utils].form_pass_results_filelist( GCOV_RESULTS_PATH, COLLECTION_ALL_TESTS )
+    result_list = @ceedling[:file_path_utils].form_pass_results_filelist(GCOV_RESULTS_PATH, COLLECTION_ALL_TESTS)
 
     # test results
     # get test results for only those tests in our configuration and of those only tests with results on disk
     hash = {
-      :header => GCOV_ROOT_NAME.upcase,
-      :results => @ceedling[:plugin_reportinator].assemble_test_results(result_list, {:boom => false})
+      header: GCOV_ROOT_NAME.upcase,
+      results: @ceedling[:plugin_reportinator].assemble_test_results(result_list, boom: false)
     }
 
     @ceedling[:plugin_reportinator].run_test_results_report(hash)
@@ -92,8 +80,8 @@ class Gcov < Plugin
     @ceedling[:streaminator].stdout_puts "\n" + banner
 
     coverage_sources = sources.clone
-    coverage_sources.delete_if {|item| item =~ /#{CMOCK_MOCK_PREFIX}.+#{EXTENSION_SOURCE}$/}
-    coverage_sources.delete_if {|item| item =~ /#{GCOV_IGNORE_SOURCES.join('|')}#{EXTENSION_SOURCE}$/}
+    coverage_sources.delete_if { |item| item =~ /#{CMOCK_MOCK_PREFIX}.+#{EXTENSION_SOURCE}$/ }
+    coverage_sources.delete_if { |item| item =~ /#{GCOV_IGNORE_SOURCES.join('|')}#{EXTENSION_SOURCE}$/ }
 
     coverage_sources.each do |source|
       basename         = File.basename(source)
@@ -101,17 +89,16 @@ class Gcov < Plugin
       shell_results    = @ceedling[:tool_executor].exec(command[:line], command[:options])
       coverage_results = shell_results[:output]
 
-      if (coverage_results.strip =~ /(File\s+'#{Regexp.escape(source)}'.+$)/m)
-        report = ((($1.lines.to_a)[1..-1])).map{|line| basename + ' ' + line}.join('')
+      if coverage_results.strip =~ /(File\s+'#{Regexp.escape(source)}'.+$)/m
+        report = Regexp.last_match(1).lines.to_a[1..-1].map { |line| basename + ' ' + line }.join('')
         @ceedling[:streaminator].stdout_puts(report + "\n\n")
       end
     end
   end
-
 end
 
 # end blocks always executed following rake run
 END {
   # cache our input configurations to use in comparison upon next execution
-  @ceedling[:cacheinator].cache_test_config( @ceedling[:setupinator].config_hash ) if (@ceedling[:task_invoker].invoked?(/^#{GCOV_TASK_ROOT}/))
+  @ceedling[:cacheinator].cache_test_config(@ceedling[:setupinator].config_hash) if @ceedling[:task_invoker].invoked?(/^#{GCOV_TASK_ROOT}/)
 }

--- a/plugins/gcov/lib/gcov_constants.rb
+++ b/plugins/gcov/lib/gcov_constants.rb
@@ -1,0 +1,16 @@
+
+
+
+GCOV_ROOT_NAME         = 'gcov'.freeze
+GCOV_TASK_ROOT         = GCOV_ROOT_NAME + ':'
+GCOV_SYM               = GCOV_ROOT_NAME.to_sym
+
+GCOV_BUILD_PATH        = File.join(PROJECT_BUILD_ROOT, GCOV_ROOT_NAME)
+GCOV_BUILD_OUTPUT_PATH = File.join(GCOV_BUILD_PATH, "out")
+GCOV_RESULTS_PATH      = File.join(GCOV_BUILD_PATH, "results")
+GCOV_DEPENDENCIES_PATH = File.join(GCOV_BUILD_PATH, "dependencies")
+GCOV_ARTIFACTS_PATH    = File.join(PROJECT_BUILD_ARTIFACTS_ROOT, GCOV_ROOT_NAME)
+
+GCOV_IGNORE_SOURCES    = %w(unity cmock cexception).freeze
+
+

--- a/plugins/gcov/lib/gcov_constants.rb
+++ b/plugins/gcov/lib/gcov_constants.rb
@@ -1,6 +1,4 @@
 
-
-
 GCOV_ROOT_NAME         = 'gcov'.freeze
 GCOV_TASK_ROOT         = GCOV_ROOT_NAME + ':'
 GCOV_SYM               = GCOV_ROOT_NAME.to_sym
@@ -10,6 +8,8 @@ GCOV_BUILD_OUTPUT_PATH = File.join(GCOV_BUILD_PATH, "out")
 GCOV_RESULTS_PATH      = File.join(GCOV_BUILD_PATH, "results")
 GCOV_DEPENDENCIES_PATH = File.join(GCOV_BUILD_PATH, "dependencies")
 GCOV_ARTIFACTS_PATH    = File.join(PROJECT_BUILD_ARTIFACTS_ROOT, GCOV_ROOT_NAME)
+
+GCOV_ARTIFACTS_FILE    = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverageResults.html")
 
 GCOV_IGNORE_SOURCES    = %w(unity cmock cexception).freeze
 


### PR DESCRIPTION
This commits does some work on the gcov plugin most of which is clean up.
The two new things this commit does:

- Now puts the gcov coverage html report into artifacts  
- Adjust level of detail in the report by defining either 'basic' or 'advanced'

The new setting can be added to the project.yml as such:

```
:gcov:
  :html_report_type: basic
```

or


```
:gcov:
  :html_report_type: advanced
```
