### PR TITLE
Don't remove './' prefix

### DIFF
--- a/lib/ceedling/file_path_utils.rb
+++ b/lib/ceedling/file_path_utils.rb
@@ -23,7 +23,7 @@ class FilePathUtils
   def self.standardize(path)
     path.strip!
     path.gsub!(/\\/, '/')
-    path.gsub!(/^((\+|-):)?\.\//, '')
+    path.gsub!(/^((\+|-):)?/, '')
     path.chomp!('/')
     return path
   end


### PR DESCRIPTION
I have the same problem as described in issue #55.  I want to specify a path as being "./**".  I don't know why but currently a "./" prefix is intentionally removed.  This change no longer removes that prefix.