### PR TITLE
Allow multiple CMock Unity helpers

### DIFF
--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -107,7 +107,8 @@ class Configurator
     cmock[:unity_helper] = false                     if (cmock[:unity_helper].nil?)
 
     if (cmock[:unity_helper])
-      cmock[:includes] << File.basename(cmock[:unity_helper])
+      cmock[:unity_helper] = [cmock[:unity_helper]] if cmock[:unity_helper].is_a? String
+      cmock[:includes] += cmock[:unity_helper].map{|helper| File.basename(helper) }
       cmock[:includes].uniq!
     end
 

--- a/lib/ceedling/configurator_builder.rb
+++ b/lib/ceedling/configurator_builder.rb
@@ -392,10 +392,12 @@ class ConfiguratorBuilder
 
     # if we're using mocks & a unity helper is defined & that unity helper includes a source file component (not only a header of macros),
     # then link in the unity_helper object file too
-    if ( in_hash[:project_use_mocks] and
-         in_hash[:cmock_unity_helper] and
-         @file_wrapper.exist?(in_hash[:cmock_unity_helper].ext(in_hash[:extension_source])) )
-      objects << File.basename(in_hash[:cmock_unity_helper])
+    if ( in_hash[:project_use_mocks] and in_hash[:cmock_unity_helper] )
+      in_hash[:cmock_unity_helper].each do |helper|
+        if @file_wrapper.exist?(helper.ext(in_hash[:extension_source]))
+          objects << File.basename(helper)
+        end
+      end
     end
 
     # no build paths here so plugins can remap if necessary (i.e. path mapping happens at runtime)

--- a/lib/ceedling/configurator_setup.rb
+++ b/lib/ceedling/configurator_setup.rb
@@ -76,7 +76,11 @@ class ConfiguratorSetup
     validation = []
 
     validation << @configurator_validator.validate_filepath(config, :project, :build_root)
-    validation << @configurator_validator.validate_filepath(config, :cmock, :unity_helper) if config[:cmock][:unity_helper]
+    if config[:cmock][:unity_helper]
+      config[:cmock][:unity_helper].each do |path|
+        validation << @configurator_validator.validate_filepath_simple( path, :cmock, :unity_helper ) 
+      end
+    end
 
     config[:project][:options_paths].each do |path|
       validation << @configurator_validator.validate_filepath_simple( path, :project, :options_paths )

--- a/lib/ceedling/dependinator.rb
+++ b/lib/ceedling/dependinator.rb
@@ -52,7 +52,7 @@ class Dependinator
     # if input configuration or ceedling changes, make sure these guys get rebuilt
     mocks_list.each do |mock_filepath|
       @rake_wrapper[mock_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed)
-      @rake_wrapper[mock_filepath].enhance( [@configurator.cmock_unity_helper] )                  if (@configurator.cmock_unity_helper)
+      @rake_wrapper[mock_filepath].enhance( @configurator.cmock_unity_helper )                    if (@configurator.cmock_unity_helper)
     end
   end
 


### PR DESCRIPTION
CMock allows `unity_helper` to be an array of multiple header files. Allow the same in Ceedling.