### PR TITLE
Fix error when not using subprojects plugin

### DIFF
--- a/lib/ceedling/release_invoker.rb
+++ b/lib/ceedling/release_invoker.rb
@@ -64,7 +64,7 @@ class ReleaseInvoker
   end
 
   def sort_objects_and_libraries(both)
-    extension = "\\" + (EXTENSION_SUBPROJECTS || ".LIBRARY")
+    extension = "\\" + ((defined? EXTENSION_SUBPROJECTS) ? EXTENSION_SUBPROJECTS : ".LIBRARY")
     sorted_objects = both.group_by {|v| v.match(/.+#{extension}$/) ? :libraries : :objects }
     libraries = sorted_objects[:libraries] || []
     objects   = sorted_objects[:objects]   || []


### PR DESCRIPTION
`EXTENSION_SUBPROJECTS` may not be defined, especially if not using the new subprojects plugin.