### PR TITLE
Fix inability to remove paths, clobbered by #144

### DIFF
--- a/lib/ceedling/file_path_utils.rb
+++ b/lib/ceedling/file_path_utils.rb
@@ -19,11 +19,10 @@ class FilePathUtils
 
   ######### class methods ##########
 
-  # standardize path to use '/' path separator & begin with './' & have no trailing path separator
+  # standardize path to use '/' path separator & have no trailing path separator
   def self.standardize(path)
     path.strip!
     path.gsub!(/\\/, '/')
-    path.gsub!(/^((\+|-):)?/, '')
     path.chomp!('/')
     return path
   end


### PR DESCRIPTION
PR #144 caused the `-:` and `+:` prefixes to be removed by `FilePathUtils.standardize` even if not followed by a `./`. This clobbered the ability to remove paths from the list in e.g. an options file.

I'm not sure what the original intent of this line was:

```
    path.gsub!(/^((\+|-):)?\.\//, '')
```

as it removed both a leading `./` and any `-:` that preceded it. I think the right thing to do is to remove it altogether.