### PR TITLE
Add default empty array for cmock_includes

### DIFF
--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -311,7 +311,8 @@ DEFAULT_CEEDLING_CONFIG = {
 
     :cmock => {
       :vendor_path => CEEDLING_VENDOR,
-      :defines => []
+      :defines => [],
+      :includes => []
     },
 
     :cexception => {


### PR DESCRIPTION
`:unity_helper` gets added to `:includes` which fails if `:includes` is not specified (undefined method `+` for `nil`).

Make `:includes` default to `[]`