### PR TITLE
Fixed double module create rake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ Gemfile.lock
 tags
 *.taghl
 
+examples/blinky/build/
+examples/blinky/vendor/
+examples/temp_sensor/vendor/
+examples/temp_sensor/build/
+
 ceedling.sublime-project
 ceedling.sublime-workspace
 ceedling-*.gem

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .*.swp
 .swp
 Gemfile.lock
+
 tags
+*.taghl
+
 ceedling.sublime-project
 ceedling.sublime-workspace
 ceedling-*.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: required
 language: ruby c
 
-os: 
+os:
   - osx
   - linux
-  
+
 rvm:
   - "2.0.0"
   - "2.3.0"
@@ -12,12 +12,12 @@ rvm:
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.1 && rvm use 2.1 && ruby -v; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update -qq && sudo apt-get install --assume-yes --quiet gcc-multilib && sudo apt-get install -qq gcc-avr binutils-avr avr-libc; fi
-  
+
 install:
   - gem update bundler
   - bundle install
 
 script:
   - bundle exec rake ci
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then mkdir examples/blinky/vendor && cd examples/blinky/vendor && ln -s ../../.. ./ceedling && cd .. && rake test:all && cd ../..; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then mkdir examples/temp_sensor/vendor && cd examples/temp_sensor/vendor && ln -s ../../.. ./ceedling && cd .. && rake test:all && cd ../..; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then mkdir examples/blinky/vendor && cd examples/blinky/vendor && ln -s ../../.. ./ceedling && cd .. && rake module:create[someNewModule] module:destroy[someNewModule] test:all && cd ../..; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then mkdir examples/temp_sensor/vendor && cd examples/temp_sensor/vendor && ln -s ../../.. ./ceedling && cd .. && rake module:create[someNewModule] module:destroy[someNewModule] test:all && cd ../..; fi

--- a/examples/blinky/project.yml
+++ b/examples/blinky/project.yml
@@ -14,7 +14,7 @@
 #You'll have to specify these
 :environment:
   - :mcu: atmega328p
-  - :f_cpu: 16000000UL 
+  - :f_cpu: 16000000UL
   - :serial_port: COM8  #change this to the serial port you are using!!!
   - :objcopy: avr-objcopy
   # Uncomment these lines if you are using windows and don't have these tools in your path

--- a/examples/temp_sensor/project.yml
+++ b/examples/temp_sensor/project.yml
@@ -66,5 +66,5 @@
     - vendor/ceedling/plugins
   :enabled:
     - stdout_pretty_tests_report
-    #- stdout_ide_tests_report
+    - module_generator
 ...

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -328,6 +328,7 @@ class Configurator
 
   def insert_rake_plugins(plugins)
     plugins.each do |plugin|
+      # TODO needs a duplicate guard
       @project_config_hash[:project_rakefile_component_files] << plugin
     end
   end

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -344,7 +344,7 @@ DEFAULT_CEEDLING_CONFIG = {
     :release_dependencies_generator => { :arguments => [] },
 
     :plugins => {
-      :load_paths => CEEDLING_PLUGINS,
+      :load_paths => [], #XXX this is injected twice as of now so removed til better handling is found CEEDLING_PLUGINS,
       :enabled => [],
     }
   }.freeze


### PR DESCRIPTION
Fixed issue seen in #166 and updated travis to create and destroy a module to confirm this behaviour is fixed. 

I will admit this is not the best solution. We need to be able to detect duplicate rake files in the configurator and not double load those rake files.