### PR TITLE
Ceedling now returns the correct status and more spec test for verification.

### DIFF
--- a/assets/test_example_file_boom.c
+++ b/assets/test_example_file_boom.c
@@ -1,0 +1,13 @@
+#include "unity.h"
+#include "example_file.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_add_numbers_adds_numbers(void) {
+  TEST_ASSERT_EQUAL(2, add_numbers(1,1) //Removed semicolon & parenthesis to make a compile error.
+}
+
+void test_add_numbers_will_fail(void) {
+  TEST_ASSERT_EQUAL(2, add_numbers(2,2));
+}

--- a/assets/test_example_file_success.c
+++ b/assets/test_example_file_success.c
@@ -1,0 +1,14 @@
+#include "unity.h"
+#include "example_file.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_add_numbers_adds_numbers(void) {
+  TEST_ASSERT_EQUAL(2, add_numbers(1,1));
+}
+
+void test_add_numbers_will_fail_but_is_ignored_for_now(void) {
+  TEST_IGNORE();
+  TEST_ASSERT_EQUAL(2, add_numbers(2,2));
+}

--- a/bin/ceedling
+++ b/bin/ceedling
@@ -198,8 +198,11 @@ else
       begin
         PTY.spawn(cmd) do |stdout, stdin, pid|
           begin
+            yield stdout, stdin, pid
             block.call(stdout)
           rescue Errno::EIO
+          ensure
+            Process.wait pid
           end
         end
       rescue Exception => e
@@ -359,7 +362,12 @@ else
   end
 
   f.close if options[:outfile]
-  true
 
-#===================================================================================================================
+  
+  #===================================================================================================================
 end
+
+# This is a quick way to report the exit status since rake already returns
+# the correct result. If we ever chain commands together this will need to be
+# changed.
+exit($?.exitstatus) unless $?.nil?

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -27,8 +27,12 @@ describe "Ceedling" do
     it { contains_documentation }
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
-    it { can_test_projects }
+    it { can_test_projects_with_success }
+    it { can_test_projects_with_fail }
+    it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { handles_creating_the_same_module_twice_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
   end
 
   describe "deployed in a project's `vendor` directory without docs." do
@@ -43,8 +47,12 @@ describe "Ceedling" do
     it { does_not_contain_documentation }
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
-    it { can_test_projects }
+    it { can_test_projects_with_success }
+    it { can_test_projects_with_fail }
+    it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { handles_creating_the_same_module_twice_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
   end
 
   describe "ugrade a project's `vendor` directory" do
@@ -59,15 +67,23 @@ describe "Ceedling" do
     it { does_not_contain_documentation }
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
-    it { can_test_projects }
+    it { can_test_projects_with_success }
+    it { can_test_projects_with_fail }
+    it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { handles_creating_the_same_module_twice_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
 
     it { can_upgrade_projects }
     it { contains_a_vendor_directory }
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
-    it { can_test_projects }
+    it { can_test_projects_with_success }
+    it { can_test_projects_with_fail }
+    it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { handles_creating_the_same_module_twice_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
   end
 
   describe "deployed as a gem" do
@@ -81,8 +97,12 @@ describe "Ceedling" do
     it { does_not_contain_a_vendor_directory }
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
-    it { can_test_projects }
+    it { can_test_projects_with_success }
+    it { can_test_projects_with_fail }
+    it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { handles_creating_the_same_module_twice_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
   end
 
   describe "command: `ceedling examples`" do


### PR DESCRIPTION
This commit is designed to fix #148, #117, and #174. It also adds more system tests with altered exit statuses to confirm behaviour of failures and when to expect something to return failure. 

@mvandervoord  I see you made a commit to address this issue as well, so  if you have some spare time I'd like to discuss both commits and make sure they are compatible/make sense as a solution to the issue. 