### PR TITLE
Add support for regexes in per-file flags

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -1338,7 +1338,7 @@ Notes:
 * File specifiers are case sensitive (must match original file
   name)
 
-* File specifiers do support regular expressions
+* File specifiers do support regular expressions if encased in quotes
 
 * '*' is a special (optional) file specifier to provide flags
   to all files not otherwise specified

--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -1338,6 +1338,8 @@ Notes:
 * File specifiers are case sensitive (must match original file
   name)
 
+* File specifiers do support regular expressions
+
 * '*' is a special (optional) file specifier to provide flags
   to all files not otherwise specified
 
@@ -1352,6 +1354,8 @@ Example [:flags] YAML blurb
         - -Wall
       :fan:        # add '--O2' to compilation of fan.c
         - --O2
+      :'test_.+':   # add '-pedantic' to all test-files
+        - -pedantic
       :*:          # add '-foo' to compilation of all files not main.c or fan.c
         - -foo
   :test:

--- a/lib/ceedling/flaginator.rb
+++ b/lib/ceedling/flaginator.rb
@@ -32,9 +32,9 @@ class Flaginator
    
     # 1. try literals
     literals, magic = partition(hash) { |k, v| k.to_s =~ /^\w+$/ }  
-    return literals[file_key] if (literals.include?(file_key)
+    return literals[file_key] if literals.include?(file_key)
     
-    any, regex = partition(magic) { |k, v| (k == :*) || (k == :.*)  } # glob or regex wild card
+    any, regex = partition(magic) { |k, v| (k == :'*') || (k == :'.*')  } # glob or regex wild card
     
     # 2. try regexes
     find_res = regex.find { |k, v| file_name =~ /#{k.to_s}/ }

--- a/lib/ceedling/flaginator.rb
+++ b/lib/ceedling/flaginator.rb
@@ -41,7 +41,7 @@ class Flaginator
     return find_res[1] if find_res
     
     # 3. try anything
-    find_res = any.find { |k, v| file_name =~ /#{k.to_s}/ }
+    find_res = any.find { |k, v| file_name =~ /.*/ }
     return find_res[1] if find_res
       
     # 4. well, we've tried

--- a/lib/ceedling/flaginator.rb
+++ b/lib/ceedling/flaginator.rb
@@ -7,6 +7,8 @@ require 'ceedling/constants'
 # :flags:
 #   :release:
 #     :compile:
+#       :'test_.*'
+#         - -pedantic   # add '-pedantic' to every test file
 #       :*:          # add '-foo' to compilation of all files not main.c
 #         - -foo
 #       :main:       # add '-Wall' to compilation of main.c
@@ -17,16 +19,41 @@ require 'ceedling/constants'
 #         - --bar
 #         - --baz
 
+def partition(hash, &predicate)
+  hash.partition(&predicate).map(&:to_h)
+end
 
 class Flaginator
 
   constructor :configurator
 
+  def get_flag(hash, file_name)
+    file_key = file_name.to_sym
+   
+    # 1. try literals
+    literals, magic = partition(hash) { |k, v| k.to_s =~ /^\w+$/ }  
+    return literals[file_key] if (literals.include?(file_key)
+    
+    any, regex = partition(magic) { |k, v| (k == :*) || (k == :.*)  } # glob or regex wild card
+    
+    # 2. try regexes
+    find_res = regex.find { |k, v| file_name =~ /#{k.to_s}/ }
+    return find_res[1] if find_res
+    
+    # 3. try anything
+    find_res = any.find { |k, v| file_name =~ /#{k.to_s}/ }
+    return find_res[1] if find_res
+      
+    # 4. well, we've tried
+    return []
+  end
+  
   def flag_down( operation, context, file )
     # create configurator accessor method
     accessor = ('flags_' + context.to_s).to_sym
 
     # create simple filename key from whatever filename provided
+    file_name = File.basename( file ).ext('')
     file_key = File.basename( file ).ext('').to_sym
 
     # if no entry in configuration for flags for this context, bail out
@@ -41,14 +68,7 @@ class Flaginator
     # redefine flags to sub hash associated with the operation
     flags = flags[operation]
 
-    # if our file is in the flags hash, extract the array of flags
-    if (flags.include?( file_key )) then return flags[file_key]
-    # if our file isn't in the flags hash, but there is default for all other files, extract array of flags
-    elsif (flags.include?( :* )) then return flags[:*]
-    end
-
-    # fall through: flags were specified but none applying to present file
-    return []
+    return get_flag(flags, file_name)
   end
 
 end

--- a/lib/ceedling/flaginator.rb
+++ b/lib/ceedling/flaginator.rb
@@ -7,7 +7,7 @@ require 'ceedling/constants'
 # :flags:
 #   :release:
 #     :compile:
-#       :'test_.*'
+#       :'test_.+'
 #         - -pedantic   # add '-pedantic' to every test file
 #       :*:          # add '-foo' to compilation of all files not main.c
 #         - -foo
@@ -37,7 +37,7 @@ class Flaginator
     any, regex = partition(magic) { |k, v| (k == :'*') || (k == :'.*')  } # glob or regex wild card
     
     # 2. try regexes
-    find_res = regex.find { |k, v| file_name =~ /#{k.to_s}/ }
+    find_res = regex.find { |k, v| file_name =~ /^#{k.to_s}$/ }
     return find_res[1] if find_res
     
     # 3. try anything


### PR DESCRIPTION
## Change
This PR adds support for regular expressions for 'per-file' flags instead of simple literals and 'anything else'.

## Motivation
The current system has two issues:
1. The configuration file can become long if many flags are added to specific files
2. On adding a new file it is easy to forget to add appropriate flags.

With regular expressions it is easy to add flags to different groups of files (tests, runners, mocks, modules, etc).

## Priority of flag resolution
1. Literals
2. Regex matches
3. `.*` respectively `*`

## Example
```
:'(mock|test)_\w+?(?<!_runner)':  # match only mocks and test files
  - -x c++
:'test_\w+?_runner':  # match only runners
  - -Og
:'Sut_.+':
 - -ansi
:'.*':   # match anything else, equivalent to :*:
 - -O3
```