### PR TITLE
gcov deployment tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ rvm:
   - "2.3.0"
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.1 && rvm use 2.1 && ruby -v; fi
+  - pip install gcovr
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.1 && rvm use 2.1 && ruby -vi; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update -qq && sudo apt-get install --assume-yes --quiet gcc-multilib && sudo apt-get install -qq gcc-avr binutils-avr avr-libc; fi
 
 install:

--- a/assets/project_with_guts_gcov.yml
+++ b/assets/project_with_guts_gcov.yml
@@ -10,14 +10,14 @@
   :use_test_preprocessor: TRUE
   :use_auxiliary_dependencies: TRUE
   :build_root: build
-  # :release_build: TRUE
-  :test_file_prefix: Test
+#  :release_build: TRUE
+  :test_file_prefix: test_
 
 #:release_build:
-#  :output: TempSensor.out
+#  :output: MyApp.out
 #  :use_assembly: FALSE
 
-:environment: []
+:environment:
 
 :extension:
   :executable: .out
@@ -32,7 +32,10 @@
     - test/support
 
 :defines:
-  :common: &common_defines []
+  # in order to add common defines:
+  #  1) remove the trailing [] from the :common: section
+  #  2) add entries to the :common: section (e.g. :test: has TEST defined)
+  :commmon: &common_defines []
   :test:
     - *common_defines
     - TEST
@@ -41,10 +44,12 @@
     - TEST
 
 :cmock:
+  :mock_prefix: mock_
   :when_no_prototypes: :warn
   :enforce_strict_ordering: TRUE
   :plugins:
     - :ignore
+    - :callback
   :treat_as:
     uint8:    HEX8
     uint16:   HEX16
@@ -52,19 +57,26 @@
     int8:     INT8
     bool:     UINT8
 
+:gcov:
+    :html_report_type: basic
+
 #:tools:
 # Ceedling defaults to using gcc for compiling, linking, etc.
 # As [:tools] is blank, gcc will be used (so long as it's in your system path)
 # See documentation to configure a given toolchain for use
 
-:tools_test_linker:
-  :arguments:
-    - -lm
-:tools_gcov_linker:
-  :arguments:
-    - -lm
-#:gcov:
-#  :html_report_type: basic
+# LIBRARIES
+# These libraries are automatically injected into the build process. Those specified as
+# common will be used in all types of builds. Otherwise, libraries can be injected in just
+# tests or releases. These options are MERGED with the options in supplemental yaml files.
+:libraries:
+  :placement: :end
+  :flag: "${1}"  # or "-L ${1}" for example
+  :common: &common_libraries []
+  :test:
+    - *common_libraries
+  :release:
+    - *common_libraries
 
 :plugins:
   :load_paths:

--- a/examples/temp_sensor/rakefile.rb
+++ b/examples/temp_sensor/rakefile.rb
@@ -1,4 +1,6 @@
 PROJECT_CEEDLING_ROOT = "vendor/ceedling"
-load "#{PROJECT_CEEDLING_ROOT}/lib/ceedling/rakefile.rb"
+load "#{PROJECT_CEEDLING_ROOT}/lib/ceedling.rb"
+
+Ceedling.load_project
 
 task :default => %w[ test:all release ]

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -159,15 +159,20 @@ namespace UTILS_SYM do
     end
 
     if @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'basic'
-      puts 'Creating a basic html report of gcov results...'
+      puts "Creating a basic html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
       command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [])
       @ceedling[:tool_executor].exec(command[:line], command[:options])
-    elsif @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'advanced'
-      puts 'Creating an indepth html report of gcov results...'
+    elsif @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'detailed'
+      puts "Creating a detailed html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
       command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_ADVANCED, [])
       @ceedling[:tool_executor].exec(command[:line], command[:options])
     else
-      puts 'define \n:gcov:\n\t:html_report_type:\n to basic or advanced to use this feature.'
+      puts "In your project.yml, define: \n\n:gcov:\n  :html_report_type:\n\n to basic or detailed to refine this feature."
+      puts "For now, just creating basic."
+      puts "Creating a basic html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
+      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [])
+      @ceedling[:tool_executor].exec(command[:line], command[:options])
     end
+    puts "Done."
   end
 end

--- a/spec/gcov/gcov_deployment_spec.rb
+++ b/spec/gcov/gcov_deployment_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_system_helper'
+require 'gcov/gcov_test_cases_spec'
+
+describe "Ceedling" do
+  describe "Gcov" do
+    include CeedlingTestCases
+    include GcovTestCases
+    before :all do
+      @c = SystemContext.new
+      @c.deploy_gem
+    end
+
+    after :all do
+      @c.done!
+    end
+
+    before { @proj_name = "fake_project" }
+    after { @c.with_context { FileUtils.rm_rf @proj_name } }
+
+    describe "basic operations" do
+      before do
+        @c.with_context do
+          `bundle exec ruby -S ceedling new #{@proj_name} 2>&1`
+        end
+      end
+
+      it { can_test_projects_with_gcov_with_success }
+      it { can_test_projects_with_gcov_with_fail }
+      it { can_test_projects_with_gcov_with_compile_error }
+      it { can_fetch_project_help_for_gcov }
+      it { can_create_html_report }
+    end
+
+
+    describe "command: `ceedling example [example]`" do
+      describe "temp_sensor" do
+        before do
+          @c.with_context do
+            output = `bundle exec ruby -S ceedling example temp_sensor 2>&1`
+            expect(output).to match(/created!/)
+          end
+        end
+
+        it "should be testable" do
+          @c.with_context do
+            Dir.chdir "temp_sensor" do
+              @output = `bundle exec ruby -S ceedling gcov:all`
+              expect(@output).to match(/TESTED:\s+47/)
+              expect(@output).to match(/PASSED:\s+47/)
+
+              expect(@output).to match(/AdcConductor\.c Lines executed:/i)
+              expect(@output).to match(/AdcHardware\.c Lines executed:/i)
+              expect(@output).to match(/AdcModel\.c Lines executed:/i)
+              expect(@output).to match(/Executor\.c Lines executed:/i)
+              expect(@output).to match(/Main\.c Lines executed:/i)
+              expect(@output).to match(/Model\.c Lines executed:/i)
+              # there are more, but this is a good place to stop.
+
+              @output = `bundle exec ruby -S ceedling utils:gcov`
+              expect(@output).to match(/For now, just creating basic\./)
+              expect(@output).to match(/Creating a basic html report of gcov results in build\/artifacts\/gcov\/GcovCoverageResults\.html\.\.\./)
+              expect(File.exists?('build/artifacts/gcov/GcovCoverageResults.html')).to eq true
+
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/gcov/gcov_test_cases_spec.rb
+++ b/spec/gcov/gcov_test_cases_spec.rb
@@ -1,0 +1,93 @@
+require 'fileutils'
+require 'tmpdir'
+require 'yaml'
+require 'spec_system_helper'
+require 'pp'
+
+
+module GcovTestCases
+
+  def can_test_projects_with_gcov_with_success
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("project_with_guts_gcov.yml"), "project.yml"
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling gcov:all`
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
+  def can_test_projects_with_gcov_with_fail
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("project_with_guts_gcov.yml"), "project.yml"
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling gcov:all`
+        expect($?.exitstatus).to match(1) # Since a test fails, we return error here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
+  def can_test_projects_with_gcov_with_compile_error
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("project_with_guts_gcov.yml"), "project.yml"
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_boom.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling test:all`
+        expect($?.exitstatus).to match(1) # Since a test explodes, we return error here
+        expect(output).to match(/ERROR: Shell command failed/)
+        expect(output).to match(/> And exited with status:\s+/)
+        expect(output).to match(/rake aborted!/)
+      end
+    end
+  end
+
+  def can_fetch_project_help_for_gcov
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("project_with_guts_gcov.yml"), "project.yml"
+        output = `bundle exec ruby -S ceedling help`
+        expect($?.exitstatus).to match(0)
+        expect(output).to match(/ceedling gcov:\*/i)
+        expect(output).to match(/ceedling gcov:all/i)
+        expect(output).to match(/ceedling gcov:delta/i)
+        expect(output).to match(/ceedling utils:gcov/i)
+      end
+    end
+  end
+
+  def can_create_html_report
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("project_with_guts_gcov.yml"), "project.yml"
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling gcov:all`
+        output = `bundle exec ruby -S ceedling utils:gcov`
+        expect(output).to match(/Creating a basic html report of gcov results in build\/artifacts\/gcov\/GcovCoverageResults\.html\.\.\./)
+        expect(File.exists?('build/artifacts/gcov/GcovCoverageResults.html')).to eq true
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds deployment testing for the gcov plugin and is a start to addressing #96. More fine grain testing is still needed, but this confirms the plugin works at the system level  via travis every commit.