### PR TITLE
Add escaping in gcovr parameter

### DIFF
--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -36,7 +36,7 @@
     :arguments:
         - -p
         - -b
-        - -e '^vendor.*|^build.*|^test.*|^lib.*'
+        - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
         - --html
         - -r .
         - -o GcovCoverageResults.html
@@ -46,7 +46,7 @@
     :arguments:
         - -p
         - -b
-        - -e '^vendor.*|^build.*|^test.*|^lib.*'
+        - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
         - --html
         - -r .
         - -o  "$": GCOV_ARTIFACTS_FILE
@@ -56,7 +56,7 @@
     :arguments:
         - -p
         - -b
-        - -e '^vendor.*|^build.*|^test.*|^lib.*'
+        - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
         - --html-details
         - -r .
         - -o  "$": GCOV_ARTIFACTS_FILE


### PR DESCRIPTION
This pull request addresses the following error on Windows 7 with italian localization when trying to generate gcovr html report.

```
C:\TestCeed28>rake utils:gcov
Creating a basic html report of gcov results in build/artifacts/gcov/GcovCoverag
eResults.html...
"build.*" non è riconosciuto come comando interno o esterno,
 un programma eseguibile o un file batch.
ERROR: Shell command failed.
> Shell executed command:
'gcovr -p -b -e '^vendor.*|^build.*|^test.*|^lib.*' --html -r . -o  "build/artif
acts/gcov/GcovCoverageResults.html"'
> And exited with status: [255].

rake aborted!
ShellExecutionException: ShellExecutionException
```
On my system works well, but I'm not sure this is the best string escaping method...