### PR TITLE
Stop including test support files in release build

### DIFF
--- a/lib/ceedling/configurator_builder.rb
+++ b/lib/ceedling/configurator_builder.rb
@@ -316,6 +316,32 @@ class ConfiguratorBuilder
   end
 
 
+  def collect_release_existing_compilation_input(in_hash)
+    release_input = @file_wrapper.instantiate_file_list
+
+    paths =
+      in_hash[:collection_paths_source] +
+      in_hash[:collection_paths_include]
+
+    paths << File.join(in_hash[:cexception_vendor_path], CEXCEPTION_LIB_PATH) if (in_hash[:project_use_exceptions])
+
+    paths.each do |path|
+      release_input.include( File.join(path, "*#{in_hash[:extension_header]}") )
+      if File.exists?(path) and not File.directory?(path)
+        release_input.include( path )
+      else
+        release_input.include( File.join(path, "*#{in_hash[:extension_source]}") )
+      end
+    end
+
+    @file_system_utils.revise_file_list( release_input, in_hash[:files_source] )
+    @file_system_utils.revise_file_list( release_input, in_hash[:files_include] )
+    # finding assembly files handled explicitly through other means
+
+    return {:collection_release_existing_compilation_input => release_input}
+  end
+
+
   def collect_all_existing_compilation_input(in_hash)
     all_input = @file_wrapper.instantiate_file_list
 

--- a/lib/ceedling/configurator_setup.rb
+++ b/lib/ceedling/configurator_setup.rb
@@ -37,6 +37,7 @@ class ConfiguratorSetup
     flattened_config.merge!(@configurator_builder.collect_assembly(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_source(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_headers(flattened_config))
+    flattened_config.merge!(@configurator_builder.collect_release_existing_compilation_input(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_all_existing_compilation_input(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_test_and_vendor_defines(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_release_and_vendor_defines(flattened_config))

--- a/lib/ceedling/file_finder.rb
+++ b/lib/ceedling/file_finder.rb
@@ -83,7 +83,7 @@ class FileFinder
   end
   
   
-  def find_compilation_input_file(file_path, complain=:error)
+  def find_compilation_input_file(file_path, complain=:error, release=false)
     found_file = nil
     
     source_file = File.basename(file_path).ext(@configurator.extension_source)
@@ -105,6 +105,12 @@ class FileFinder
           @file_wrapper.directory_listing( File.join(@configurator.cmock_mock_path, '*') ),
           complain)
 
+    elsif release
+      found_file =
+        @file_finder_helper.find_file_in_collection(
+          source_file,
+          @configurator.collection_release_existing_compilation_input,
+          complain)
     else
       found_file = 
         @file_finder_helper.find_file_in_collection(

--- a/lib/ceedling/rules_release.rake
+++ b/lib/ceedling/rules_release.rake
@@ -21,7 +21,7 @@ end
 
 rule(/#{PROJECT_RELEASE_BUILD_OUTPUT_C_PATH}\/#{'.+\\'+EXTENSION_OBJECT}$/ => [
     proc do |task_name|
-      @ceedling[:file_finder].find_compilation_input_file(task_name)
+      @ceedling[:file_finder].find_compilation_input_file(task_name, :error, true)
     end
   ]) do |object|
   @ceedling[:generator].generate_object_file(

--- a/lib/ceedling/rules_release_deep_dependencies.rake
+++ b/lib/ceedling/rules_release_deep_dependencies.rake
@@ -2,7 +2,7 @@
 
 rule(/#{PROJECT_RELEASE_DEPENDENCIES_PATH}\/#{'.+\\'+EXTENSION_DEPENDENCIES}$/ => [
     proc do |task_name|
-      @ceedling[:file_finder].find_compilation_input_file(task_name)
+      @ceedling[:file_finder].find_compilation_input_file(task_name, :error, true)
     end  
   ]) do |dep|
   @ceedling[:generator].generate_dependencies_file(


### PR DESCRIPTION
Test support files are not meant to be included in the release build. This PR makes Ceedling stop including those files in the release build.