### PR TITLE
Fixed gcvor detailed HTML report generation.

### DIFF
--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -57,6 +57,7 @@
         - -p
         - -b
         - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
+        - --html
         - --html-details
         - -r .
         - -o  "$": GCOV_ARTIFACTS_FILE


### PR DESCRIPTION
The GCOV HTML detailed report does not generate an html file.
Added parameter for generating the proper html files.
Tested with gcovr 3.3