### PR TITLE
sudo pip install for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - "2.3.0"
 
 before_install:
-  - pip install gcovr
+  - sudo pip install gcovr
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.1 && rvm use 2.1 && ruby -vi; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update -qq && sudo apt-get install --assume-yes --quiet gcc-multilib && sudo apt-get install -qq gcc-avr binutils-avr avr-libc; fi
 


### PR DESCRIPTION
After looking at the last few pull requests, it seems the linux builds now need sudo to install gcovr via pip. I'm not sure what changed on Travis's side, but this change should fix that and we should try to retrigger the pull requests that failed due to this issue.