### PR TITLE
Expand module:create/destroy to 'run' in subfolder (Enhancement of #201)

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -323,6 +323,7 @@ Ceedling (more on this later).
   ceedling release:assemble:foo.s
 
 * `ceedling module:create[Filename]`:
+* `ceedling module:create[<Path:>Filename]`:
 
   It's often helpful to create a file automatically. What's better than
   that? Creating a source file, a header file, and a corresponding test
@@ -330,6 +331,10 @@ Ceedling (more on this later).
 
   There are also patterns which can be specified to automatically generate
   a bunch of files. Try `ceedling module:create[Poodles,mch]` for example!
+
+  The module generator has several options you can configure.
+  F.e. Generating the source/header/test file in a subdirectory (by adding <Path> when calling module:create).
+  For more info, refer to the [Module Generator](https://github.com/ThrowTheSwitch/Ceedling/blob/master/docs/CeedlingPacket.md#module-generator) section.
 
 * `ceedling logging <tasks...>`:
 
@@ -1911,6 +1916,77 @@ Example [:plugins] YAML blurb
   root>/artifacts` directory (e.g. test/ for test tasks, `release/` for a
   release build, or even `bullseye/` for bullseye runs).
 
+Module Generator
+========================
+Ceedling includes a plugin called module_generator that will create a source, header and test file for you.
+There are several possibilities to configure this plugin through your project.yml to suit your project's needs.
+
+Directory Structure
+-------------------------------------------
+
+The default configuration for directory/project structure is:
+```yaml
+:module_generator:
+  :project_root: ./
+  :source_root: src/
+  :test_root: test/
+```
+You can change these variables in your project.yml file to comply with your project's directory structure.
+
+If you call `ceedling module:create`, it will create three files:
+1. A source file in the source_root
+2. A header file in the source_root
+3. A test file in the test_root
+
+If you want your header file to be in another location,
+you can specify the ':inc_root:" in your project.yml file:
+```yaml
+:module_generator:
+  :inc_root: inc/
+```
+The module_generator will then create the header file in your defined ':inc_root:'.
+By default, ':inc_root:' is not defined so the module_generator will use the source_root.
+
+Sometimes, your project can't be divided into a single src, inc, and test folder. You have several directories
+with sources/..., something like this for example:
+<project_root>
+ - myDriver
+   - src
+   - inc
+   - test
+ - myOtherDriver
+   - src
+   - inc
+   - test
+ - ...
+
+Don't worry, you don't have to manually create the source/header/test files.
+The module_generator can accept a path to create a source_root/inc_root/test_root folder with your files:
+`ceedling module:create[<module_root_path>:<module_name>]`
+
+F.e., applied to the above project structure:
+`ceedling module:create[myOtherDriver:driver]`
+This will make the module_generator run in the subdirectory 'myOtherDriver' and generate the module files
+for you in that directory. So, this command will generate the following files:
+1. A source file 'driver.c' in <project_root>/myOtherDriver/<source_root>
+2. A header file 'driver.h' in <project_root>/myOtherDriver/<source_root> (or <inc_root> if specified)
+3. A test file 'test_driver.c' in <project_root>/myOtherDriver/<test_root>
+
+Naming
+-------------------------------------------
+By default, the module_generator will generate your files in lowercase.
+`ceedling module:create[mydriver]` and `ceedling module:create[myDriver]`(note the uppercase) will generate the same files:
+1. mydriver.c
+2. mydriver.h
+3. test_mydriver.c
+
+You can configure the module_generator to use a differect naming mechanism through the project.yml:
+```yaml
+:module_generator:
+  :naming: "camel"
+```
+There are other possibilities as well (bumpy, camel, snake, caps).
+Refer to the unity module generator for more info (the unity module generator is used under the hood by module_generator).
 
 Advanced Topics (Coming)
 ========================
@@ -1945,4 +2021,3 @@ Creating Custom Plugins
 -----------------------
 
 Oh boy. This is going to take some explaining.
-

--- a/plugins/module_generator/lib/module_generator.rb
+++ b/plugins/module_generator/lib/module_generator.rb
@@ -23,7 +23,11 @@ class ModuleGenerator < Plugin
   def divine_options(optz={})
     {
       :path_src     => ((defined? MODULE_GENERATOR_SOURCE_ROOT ) ? MODULE_GENERATOR_SOURCE_ROOT.gsub('\\', '/').sub(/^\//, '').sub(/\/$/, '') : "src" ),
-      :path_inc     => ((defined? MODULE_GENERATOR_SOURCE_ROOT ) ? MODULE_GENERATOR_SOURCE_ROOT.gsub('\\', '/').sub(/^\//, '').sub(/\/$/, '') : "src" ),
+      :path_inc     => ((defined? MODULE_GENERATOR_INC_ROOT ) ?
+                                 MODULE_GENERATOR_INC_ROOT.gsub('\\', '/').sub(/^\//, '').sub(/\/$/, '')
+                                 : (defined? MODULE_GENERATOR_SOURCE_ROOT ) ?
+                                 MODULE_GENERATOR_SOURCE_ROOT.gsub('\\', '/').sub(/^\//, '').sub(/\/$/, '')
+                                 : "src" ),
       :path_tst     => ((defined? MODULE_GENERATOR_TEST_ROOT   ) ? MODULE_GENERATOR_TEST_ROOT.gsub(  '\\', '/').sub(/^\//, '').sub(/\/$/, '') : "test" ),
       :pattern      => optz[:pattern],
       :test_prefix  => ((defined? PROJECT_TEST_FILE_PREFIX     ) ? PROJECT_TEST_FILE_PREFIX : "Test" ),

--- a/plugins/module_generator/lib/module_generator.rb
+++ b/plugins/module_generator/lib/module_generator.rb
@@ -21,6 +21,7 @@ class ModuleGenerator < Plugin
   private
 
   def divine_options(optz={})
+    unity_generator_options =
     {
       :path_src     => ((defined? MODULE_GENERATOR_SOURCE_ROOT ) ? MODULE_GENERATOR_SOURCE_ROOT.gsub('\\', '/').sub(/^\//, '').sub(/\/$/, '') : "src" ),
       :path_inc     => ((defined? MODULE_GENERATOR_INC_ROOT ) ?
@@ -37,6 +38,14 @@ class ModuleGenerator < Plugin
       :naming       => ((defined? MODULE_GENERATOR_NAMING      ) ? MODULE_GENERATOR_NAMING : nil ),
       :update_svn   => ((defined? MODULE_GENERATOR_UPDATE_SVN  ) ? MODULE_GENERATOR_UPDATE_SVN : false ),
     }
+
+    unless optz[:module_root_path].to_s.empty?
+      unity_generator_options[:path_src]  = File.join(optz[:module_root_path], unity_generator_options[:path_src])
+      unity_generator_options[:path_inc]  = File.join(optz[:module_root_path], unity_generator_options[:path_inc])
+      unity_generator_options[:path_tst]  = File.join(optz[:module_root_path], unity_generator_options[:path_tst])
+    end
+
+    return unity_generator_options
   end
 
 end

--- a/plugins/module_generator/module_generator.rake
+++ b/plugins/module_generator/module_generator.rake
@@ -1,26 +1,43 @@
 
 namespace :module do
+  module_root_separator = ":"
 
   desc "Generate module (source, header and test files)"
   task :create, :module_path do |t, args|
     files = [args[:module_path]] + (args.extras || [])
-    optz = {}
+    optz = { :module_root_path => "" }
     ["dh", "dih", "mch", "mvp", "src", "test"].each do |pat|
       p = files.delete(pat)
       optz[:pattern] = p unless p.nil?
     end
-    files.each {|v| @ceedling[:module_generator].create(v, optz) }
+    files.each {
+      |v|
+      module_root_path, module_name = v.split(module_root_separator, 2)
+      if module_name
+        optz[:module_root_path] = module_root_path
+        v = module_name
+      end
+      @ceedling[:module_generator].create(v, optz)
+    }
   end
 
   desc "Destroy module (source, header and test files)"
   task :destroy, :module_path do |t, args|
     files = [args[:module_path]] + (args.extras || [])
-    optz = { :destroy => true }
+    optz = { :destroy => true, :module_root_path => "" }
     ["dh", "dih", "mch", "mvp", "src", "test"].each do |pat|
       p = files.delete(pat)
       optz[:pattern] = p unless p.nil?
     end
-    files.each {|v| @ceedling[:module_generator].create(v, optz) }
+    files.each {
+      |v|
+      module_root_path, module_name = v.split(module_root_separator, 2)
+      if module_name
+        optz[:module_root_path] = module_root_path
+        v = module_name
+      end
+      @ceedling[:module_generator].create(v, optz)
+    }
   end
 
 end


### PR DESCRIPTION
(see #201 for original but all info is copied here for convenience)

By default ceedling expects the following project structure:
  - project_root
    - src
    - test
However, we are using ceedling in the following directory/project structure:
  - project_root
    - driver1
      - src
      - inc
      - test
    - driver2
      - src
      - inc
      - test

Instead of having separate Ceedling projects for every driver, we wanted Ceedling to manage all the tests for all drivers. That way it was also easier to generate a complete code coverage report (since Ceedling had everything built-in to do so).
This worked out-of-the-box but the slightly annoying thing was that module:create/destroy did not work properly with this project structure.
So I added a way to create a module in a subdirectory of the project_root.
By specifying <module_root>:<module_name>, the necessary files are created using <module_root> as root instead of project_root.
Applied to the project structure described above:

$> ceedling module:create[driver1:driver_code]
--> this will create the following files:
1. <project_root>/driver1/src/driver_code.c
2. <project_root>/driver1/src/driver_code.h
3. <project_root>/driver1/test/test_driver_code.c

The other thing was that we put our headers in a separate inc folder. So I added the MODULE_GENERATOR_INC_ROOT. If it is not specified in the .yml file (:inc_root:), Ceedling falls back to using the SRC_ROOT.

Tell me what you think and also if I missed something in the docs explaining how to do either of these two things.

As you might notice, I'm not a ruby programmer. So if this is a valuable addition to ceedling but there are better, more rubyish ways to do stuff, please let me know (and I can refactor if necessary).