### PR TITLE
added with-ignore option to Ceedling new

### DIFF
--- a/assets/default_gitignore
+++ b/assets/default_gitignore
@@ -1,0 +1,5 @@
+build/artifacts
+build/gcov
+builld/logs 
+build/temp
+build/test

--- a/bin/ceedling
+++ b/bin/ceedling
@@ -29,6 +29,9 @@ unless (project_found)
     method_option :no_docs, :type => :boolean, :default => false, :desc => "No docs in vendor directory"
     method_option :nodocs, :type => :boolean, :default => false
     method_option :as_gem, :type => :boolean, :default => false, :desc => "Create the scaffold using Ceedling as a gem instead of filling in the vendor directory. Implies --no-docs."
+    method_option :asgem, :type => :boolean, :default => false
+    method_option :with_ignore, :type => :boolean, :default => false, :desc => "Create a gitignore file for ignoring ceedling generated files."
+    method_option :withignore, :type => :boolean, :default => false
     method_option :no_configs, :type => :boolean, :default => false, :desc => "Don't install starter configuration files."
     method_option :noconfigs, :type => :boolean, :default => false
     def new(name, silent = false)
@@ -47,9 +50,10 @@ unless (project_found)
     no_commands do
       def copy_assets_and_create_structure(name, silent=false, force=false, options = {})
 
-        no_docs    = options[:no_docs]    || options[:nodocs]    || false
-        no_configs = options[:no_configs] || options[:noconfigs] || false
-        as_gem     = options[:as_gem]     || options[:asgem]     || false
+        no_docs     = options[:no_docs]     || options[:nodocs]     || false
+        no_configs  = options[:no_configs]  || options[:noconfigs]  || false
+        as_gem      = options[:as_gem]      || options[:asgem]      || false
+        with_ignore = options[:with_ignore] || options[:withignore] || false
 
         ceedling_path     = File.join(name, 'vendor', 'ceedling')
         source_path       = File.join(name, 'src')
@@ -119,6 +123,10 @@ unless (project_found)
           else
             copy_file(File.join('assets', 'project_with_guts.yml'), File.join(name, 'project.yml'), :force => force)
           end
+        end
+
+        if (with_ignore)
+          copy_file(File.join('assets', 'default_gitignore'), File.join(name, '.gitignore'), :force => force)
         end
 
         unless silent

--- a/spec/gcov/gcov_deployment_spec.rb
+++ b/spec/gcov/gcov_deployment_spec.rb
@@ -44,7 +44,7 @@ describe "Ceedling" do
         it "should be testable" do
           @c.with_context do
             Dir.chdir "temp_sensor" do
-              @output = `bundle exec ruby -S ceedling gcov:all`
+              @output = `bundle exec ruby -S ceedling gcov:all 2>&1`
               expect(@output).to match(/TESTED:\s+47/)
               expect(@output).to match(/PASSED:\s+47/)
 

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -131,6 +131,14 @@ module CeedlingTestCases
     end
   end
 
+  def has_an_ignore
+    @c.with_context do
+      Dir.chdir @proj_name do
+        expect(File.exists?(".gitignore")).to eq true
+      end
+    end
+  end
+
   def can_upgrade_projects
     @c.with_context do
       output = `bundle exec ruby -S ceedling upgrade #{@proj_name} 2>&1`
@@ -187,7 +195,7 @@ module CeedlingTestCases
         FileUtils.cp test_asset_path("example_file.c"), 'src/'
         FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
 
-        output = `bundle exec ruby -S ceedling test:all`
+        output = `bundle exec ruby -S ceedling test:all 2>&1`
         expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
         expect(output).to match(/TESTED:\s+\d/)
         expect(output).to match(/PASSED:\s+\d/)
@@ -204,7 +212,7 @@ module CeedlingTestCases
         FileUtils.cp test_asset_path("example_file.c"), 'src/'
         FileUtils.cp test_asset_path("test_example_file.c"), 'test/'
 
-        output = `bundle exec ruby -S ceedling test:all`
+        output = `bundle exec ruby -S ceedling test:all 2>&1`
         expect($?.exitstatus).to match(1) # Since a test fails, we return error here
         expect(output).to match(/TESTED:\s+\d/)
         expect(output).to match(/PASSED:\s+\d/)
@@ -221,7 +229,7 @@ module CeedlingTestCases
         FileUtils.cp test_asset_path("example_file.c"), 'src/'
         FileUtils.cp test_asset_path("test_example_file_boom.c"), 'test/'
 
-        output = `bundle exec ruby -S ceedling test:all`
+        output = `bundle exec ruby -S ceedling test:all 2>&1`
         expect($?.exitstatus).to match(1) # Since a test explodes, we return error here
         expect(output).to match(/ERROR: Ceedling Failed/)
       end
@@ -283,7 +291,7 @@ module CeedlingTestCases
         expect($?.exitstatus).to match(0)
         expect(output).to match(/Generate Complete/i)
 
-        output = `bundle exec ruby -S ceedling module:create[unicorns]`
+        output = `bundle exec ruby -S ceedling module:create[unicorns] 2>&1`
         expect($?.exitstatus).to match(1)
         expect(output).to match(/ERROR: Ceedling Failed/)
       end

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -35,6 +35,23 @@ describe "Ceedling" do
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
   end
 
+  describe "deployed in a project's `vendor` directory." do
+    before do
+      @c.with_context do
+        `bundle exec ruby -S ceedling new --with-ignore #{@proj_name} 2>&1`
+      end
+    end
+
+    it { can_create_projects }
+    it { has_an_ignore }
+    it { contains_a_vendor_directory }
+    it { contains_documentation }
+    it { can_test_projects_with_success }
+    it { can_use_the_module_plugin }
+  end
+
+
+
   describe "deployed in a project's `vendor` directory without docs." do
     before do
       @c.with_context do


### PR DESCRIPTION
This PR adds an option to Ceedling to generate a .gitignore file as sought out by #45. This PR also contains a little bit of spec clean up so the output of the rspec system tests isn't as sloppy as before.

 