### PR TITLE
allow generating module_generator path for any path

### DIFF
--- a/plugins/module_generator/config/module_generator.yml
+++ b/plugins/module_generator/config/module_generator.yml
@@ -1,4 +1,1 @@
 :module_generator:
-  :project_root: ./
-  :source_root: src/
-  :test_root: test/


### PR DESCRIPTION
https://github.com/ThrowTheSwitch/Ceedling/issues/208

inc_root is already working. But not source_root and any path which are already defined in module_generator.yml