### PR TITLE
Use "=~" instead of ".match" for better performance in preprocessinator_extractor.rb

### DIFF
--- a/lib/ceedling/preprocessinator_extractor.rb
+++ b/lib/ceedling/preprocessinator_extractor.rb
@@ -16,13 +16,13 @@ class PreprocessinatorExtractor
 
     lines = []
     File.readlines(filepath).each do |line|
-      if found_file and not line.match(not_pragma)
+      if found_file and not line =~ not_pragma
         lines << line
       else
         found_file = false
       end
 
-      found_file = true if line.match(pattern)
+      found_file = true if line =~ pattern
     end
 
     return lines


### PR DESCRIPTION
While playing around to see what ways Ceedling can be sped up, I found a quick change that can be done to preprocessinator_extractor.rb to help performance. The change replaces ".match" with "=~" for a noticeable performance increase when doing test:all (it was about 4% on my system).

I'm going to play with more things over the next few weeks so see if any thing else can be improved performance wise.