### PR TITLE
Travis fixes for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ os:
   - linux
 
 rvm:
-  - "2.0.0"
-  - "2.3.0"
+  - "2.1"
+  - "2.4"
 
 before_install:
-  - sudo pip install gcovr
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.1 && rvm use 2.1 && ruby -vi; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo pip install gcovr; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then pip2 install gcovr; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update -qq && sudo apt-get install --assume-yes --quiet gcc-multilib && sudo apt-get install -qq gcc-avr binutils-avr avr-libc; fi
 
 install:


### PR DESCRIPTION
While updating the docs for the gcov plugin, I noticed the OSX builds were not working in their current state. The issues were as followed:

- `pip` is not available out of the box any more on OSX, but you can use `pip2` or `pip3`(see https://github.com/travis-ci/travis-ci/issues/8829)
- The last two OSX Versions (10.11 and 10.12 see http://rubies.travis-ci.org/) do not have ruby 2.0.0 out of the box so I upped the minimum version to 2.1 and also the max to 2.4 (since that was released a while ago)