### PR TITLE
Note MS Windows file name restrictions

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -202,6 +202,11 @@ General notes:
    and Rakefiles, consult the [Rake tutorial, examples, and
    user guide](http://rubyrake.org/).
 
+4. When using Ceedling in Windows environments, a test file name may 
+   not include the sequences “patch” or “setup”. The Windows Installer 
+   Detection Technology (part of UAC), requires administrator 
+   privileges to execute file names with these strings.
+
 
 
 Now What? How Do I Make It GO?


### PR DESCRIPTION
Addition per #229, #146 and #116, as I couldn't see this in the documentation.

Unfortunately I have only Pandoc and MS Word available for editing ODT and PDF. Both Word and Pandoc introduce unrequired changes into the documents. If someone else is able to either convert the markdown to these two formats or otherwise edit the file to add the change that would be great!
  