### PR TITLE
Timing for junit

### DIFF
--- a/lib/ceedling/generator_test_results.rb
+++ b/lib/ceedling/generator_test_results.rb
@@ -1,19 +1,20 @@
 require 'rubygems'
 require 'rake' # for .ext()
 require 'ceedling/constants'
- 
+
 class GeneratorTestResults
 
   constructor :configurator, :generator_test_results_sanity_checker, :yaml_wrapper
- 
+
   def process_and_write_results(unity_shell_result, results_file, test_file)
     output_file   = results_file
-    
+
     results = get_results_structure
-    
+
     results[:source][:path] = File.dirname(test_file)
     results[:source][:file] = File.basename(test_file)
-    
+    results[:time] = unity_shell_result[:time] unless unity_shell_result[:time].nil?
+
     # process test statistics
     if (unity_shell_result[:output] =~ TEST_STDOUT_STATISTICS_PATTERN)
       results[:counts][:total]   = $1.to_i
@@ -24,7 +25,7 @@ class GeneratorTestResults
 
     # remove test statistics lines
     output_string = unity_shell_result[:output].sub(TEST_STDOUT_STATISTICS_PATTERN, '')
-    
+
     output_string.lines do |line|
       # process unity output
       case line
@@ -44,13 +45,13 @@ class GeneratorTestResults
         results[:stdout] << line.chomp
       end
     end
-    
+
     @generator_test_results_sanity_checker.verify(results, unity_shell_result[:exit_code])
-    
+
     output_file = results_file.ext(@configurator.extension_testfail) if (results[:counts][:failed] > 0)
-    
+
     @yaml_wrapper.dump(output_file, results)
-    
+
     return { :result_file => output_file, :result => results }
   end
 
@@ -64,19 +65,20 @@ class GeneratorTestResults
       :ignores   => [],
       :counts    => {:total => 0, :passed => 0, :failed => 0, :ignored  => 0},
       :stdout    => [],
+      :time      => 0.0
       }
   end
-  
+
   def extract_line_elements(line, filename)
     # handle anything preceding filename in line as extra output to be collected
     stdout = nil
     stdout_regex = /(.+)#{Regexp.escape(filename)}.+/i
-    
+
     if (line =~ stdout_regex)
       stdout = $1.clone
       line.sub!(/#{Regexp.escape(stdout)}/, '')
     end
-    
+
     # collect up test results minus and extra output
     elements = (line.strip.split(':'))[1..-1]
 

--- a/lib/ceedling/plugin_manager.rb
+++ b/lib/ceedling/plugin_manager.rb
@@ -1,4 +1,3 @@
-require 'set'
 require 'ceedling/constants'
 
 class PluginManager

--- a/lib/ceedling/plugin_reportinator.rb
+++ b/lib/ceedling/plugin_reportinator.rb
@@ -68,7 +68,8 @@ class PluginReportinator
       :failures  => [],
       :ignores   => [],
       :stdout    => [],
-      :counts    => {:total => 0, :passed => 0, :failed => 0, :ignored  => 0, :stdout => 0}
+      :counts    => {:total => 0, :passed => 0, :failed => 0, :ignored  => 0, :stdout => 0},
+      :time      => 0.0
       }
   end
  

--- a/lib/ceedling/plugin_reportinator_helper.rb
+++ b/lib/ceedling/plugin_reportinator_helper.rb
@@ -3,7 +3,6 @@ require 'rubygems'
 require 'rake' # for ext()
 require 'ceedling/constants'
 
-
 class PluginReportinatorHelper
   
   attr_writer :ceedling
@@ -31,7 +30,6 @@ class PluginReportinatorHelper
 
   def process_results(aggregate_results, results)
     return if (results.empty?)
-  
     aggregate_results[:successes]        << { :source => results[:source].clone, :collection => results[:successes].clone } if (results[:successes].size > 0)
     aggregate_results[:failures]         << { :source => results[:source].clone, :collection => results[:failures].clone  } if (results[:failures].size > 0)
     aggregate_results[:ignores]          << { :source => results[:source].clone, :collection => results[:ignores].clone   } if (results[:ignores].size > 0)
@@ -41,6 +39,7 @@ class PluginReportinatorHelper
     aggregate_results[:counts][:failed]  += results[:counts][:failed]
     aggregate_results[:counts][:ignored] += results[:counts][:ignored]
     aggregate_results[:counts][:stdout]  += results[:stdout].size
+    aggregate_results[:time] += results[:time]
   end
 
 

--- a/lib/ceedling/tool_executor.rb
+++ b/lib/ceedling/tool_executor.rb
@@ -1,4 +1,5 @@
 require 'ceedling/constants'
+require 'benchmark'
 
 class ShellExecutionException < RuntimeError
   attr_reader :shell_result
@@ -62,11 +63,14 @@ class ToolExecutor
     shell_result = {}
 
     # depending on background exec option, we shell out differently
-    if (options[:background_exec] != BackgroundExec::NONE)
-      shell_result = @system_wrapper.shell_system( command_line, options[:boom] )
-    else
-      shell_result = @system_wrapper.shell_backticks( command_line, options[:boom] )
+    time = Benchmark.realtime do
+      if (options[:background_exec] != BackgroundExec::NONE)
+        shell_result = @system_wrapper.shell_system( command_line, options[:boom] )
+      else
+        shell_result = @system_wrapper.shell_backticks( command_line, options[:boom] )
+      end
     end
+    shell_result[:time] = time
 
     #scrub the string for illegal output
     shell_result[:output].scrub! unless (!("".respond_to? :scrub!) || (shell_result[:output].nil?))

--- a/spec/generator_test_results_spec.rb
+++ b/spec/generator_test_results_spec.rb
@@ -82,6 +82,11 @@ describe GeneratorTestResults do
       expect(IO.read(TEST_OUT_FILE)).to eq(IO.read('spec/support/test_example.pass'))
     end
 
+    it 'handles a normal test output with time' do
+      @generate_test_results.process_and_write_results({:output => NORMAL_OUTPUT, :time => 0.01234}, TEST_OUT_FILE, 'some/place/test_example.c')
+      expect(IO.read(TEST_OUT_FILE)).to eq(IO.read('spec/support/test_example_with_time.pass'))
+    end
+
     it 'handles a normal test output with ignores' do
       @generate_test_results.process_and_write_results({:output => IGNORE_OUTPUT}, TEST_OUT_FILE, 'some/place/test_example.c')
       expect(IO.read(TEST_OUT_FILE)).to eq(IO.read('spec/support/test_example_ignore.pass'))

--- a/spec/support/test_example.fail
+++ b/spec/support/test_example.fail
@@ -19,3 +19,4 @@
 :stdout:
 - Verbose output one
 - Verbous output two
+:time: 0.0

--- a/spec/support/test_example_empty.pass
+++ b/spec/support/test_example_empty.pass
@@ -11,3 +11,4 @@
   :failed: 0
   :ignored: 0
 :stdout: []
+:time: 0.0

--- a/spec/support/test_example_ignore.pass
+++ b/spec/support/test_example_ignore.pass
@@ -19,3 +19,4 @@
 :stdout:
 - Verbose output one
 - Verbous output two
+:time: 0.0

--- a/spec/support/test_example_mangled.pass
+++ b/spec/support/test_example_mangled.pass
@@ -17,3 +17,4 @@
 :stdout:
 - Verbose output one
 - test_example.c:269:test_tVerbous output two
+:time: 0.0

--- a/spec/support/test_example_with_time.pass
+++ b/spec/support/test_example_with_time.pass
@@ -19,4 +19,4 @@
 :stdout:
 - Verbose output one
 - Verbous output two
-:time: 0.0
+:time: 0.01234


### PR DESCRIPTION
This PR adds a simple timing mechanism to Ceedling via benchmark and updates the junit plugin to take advantage of this improvement. 

I'm aware of the commit in unity to time individual tests (https://github.com/ThrowTheSwitch/Unity/pull/278), which can eventually replace the benchmark inside Ceedling.