### PR TITLE
Fixed problem in gcovr where unity.c and cmock.c are reported as part…

### DIFF
--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -36,7 +36,7 @@
     :arguments:
         - -p
         - -b
-        - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
+        - -e "^vendor.*|^build.*|^test.*|^lib.*"
         - --html
         - -r .
         - -o GcovCoverageResults.html
@@ -46,7 +46,7 @@
     :arguments:
         - -p
         - -b
-        - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
+        - -e "^vendor.*|^build.*|^test.*|^lib.*"
         - --html
         - -r .
         - -o  "$": GCOV_ARTIFACTS_FILE
@@ -56,7 +56,7 @@
     :arguments:
         - -p
         - -b
-        - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
+        - -e "^vendor.*|^build.*|^test.*|^lib.*"
         - --html
         - --html-details
         - -r .


### PR DESCRIPTION
… of the coverage metrics
Currently using:
```
$ ceedling utils:gcov
```
is including unity.c and cmock.c as part of the coverage statistics. The ```-e``` is ill-formed as it is using
```
-e "'^vendor.*|^build.*|^test.*|^lib.*'"
```
but needs to be
```
-e "^vendor.*|^build.*|^test.*|^lib.*"
```
for the directory exclude to work correctly.
Tested on OSX and Linux.