### PR TITLE
Added option to personalize the gcovr report filter.

### DIFF
--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -36,7 +36,7 @@
     :arguments:
         - -p
         - -b
-        - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
+        - -e "${1}"
         - --html
         - -r .
         - -o GcovCoverageResults.html
@@ -46,7 +46,7 @@
     :arguments:
         - -p
         - -b
-        - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
+        - -e "${1}"
         - --html
         - -r .
         - -o  "$": GCOV_ARTIFACTS_FILE
@@ -56,7 +56,7 @@
     :arguments:
         - -p
         - -b
-        - -e "'^vendor.*|^build.*|^test.*|^lib.*'"
+        - -e "${1}"
         - --html
         - --html-details
         - -r .

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -160,17 +160,17 @@ namespace UTILS_SYM do
 
     if @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'basic'
       puts "Creating a basic html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
-      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [])
+      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [], @ceedling[:configurator].project_config_hash[:gcov_html_report_filter] )
       @ceedling[:tool_executor].exec(command[:line], command[:options])
     elsif @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'detailed'
       puts "Creating a detailed html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
-      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_ADVANCED, [])
+      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_ADVANCED, [], @ceedling[:configurator].project_config_hash[:gcov_html_report_filter] )
       @ceedling[:tool_executor].exec(command[:line], command[:options])
     else
       puts "In your project.yml, define: \n\n:gcov:\n  :html_report_type:\n\n to basic or detailed to refine this feature."
       puts "For now, just creating basic."
       puts "Creating a basic html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
-      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [])
+      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [], @ceedling[:configurator].project_config_hash[:gcov_html_report_filter] )
       @ceedling[:tool_executor].exec(command[:line], command[:options])
     end
     puts "Done."

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -13,7 +13,8 @@ class Gcov < Plugin
       project_test_results_path: GCOV_RESULTS_PATH,
       project_test_dependencies_path: GCOV_DEPENDENCIES_PATH,
       defines_test: DEFINES_TEST + ['CODE_COVERAGE'],
-      collection_defines_test_and_vendor: COLLECTION_DEFINES_TEST_AND_VENDOR + ['CODE_COVERAGE']
+      collection_defines_test_and_vendor: COLLECTION_DEFINES_TEST_AND_VENDOR + ['CODE_COVERAGE'],
+      gcov_html_report_filter: GCOV_FILTER_EXPR
     }
 
     @plugin_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))

--- a/plugins/gcov/lib/gcov_constants.rb
+++ b/plugins/gcov/lib/gcov_constants.rb
@@ -13,4 +13,6 @@ GCOV_ARTIFACTS_FILE    = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverageResults.htm
 
 GCOV_IGNORE_SOURCES    = %w(unity cmock cexception).freeze
 
+GCOV_FILTER_EXPR       = '^vendor.*|^build.*|^test.*|^lib.*'
+
 


### PR DESCRIPTION
The gcov report is fixed, but with complex project there is need to
customize the report filtering.

The user could use now a gcov option like this:

:gcov:
  :html_report_filter: "*.vendor.*|^build.*|^test.*|^lib.*|.*/new_filter*"

Fixes #260