### PR TITLE
Plugin path fixes

### DIFF
--- a/examples/blinky/rakefile.rb
+++ b/examples/blinky/rakefile.rb
@@ -1,5 +1,6 @@
 PROJECT_CEEDLING_ROOT = "vendor/ceedling"
-load "#{PROJECT_CEEDLING_ROOT}/lib/ceedling/rakefile.rb"
+load "#{PROJECT_CEEDLING_ROOT}/lib/ceedling.rb"
+Ceedling.load_project
 
 task :default => %w[ test:all release ]
 

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -173,6 +173,9 @@ class Configurator
       FilePathUtils::standardize(path)
     end
 
+    config[:plugins][:load_paths] << FilePathUtils::standardize(Ceedling.load_path)
+    config[:plugins][:load_paths].uniq!
+
     paths_hash = @configurator_plugins.add_load_paths(config)
 
     @rake_plugins   = @configurator_plugins.find_rake_plugins(config, paths_hash)

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -175,10 +175,10 @@ class Configurator
 
     paths_hash = @configurator_plugins.add_load_paths(config)
 
-    @rake_plugins   = @configurator_plugins.find_rake_plugins(config)
-    @script_plugins = @configurator_plugins.find_script_plugins(config)
-    config_plugins  = @configurator_plugins.find_config_plugins(config)
-    plugin_defaults = @configurator_plugins.find_plugin_defaults(config)
+    @rake_plugins   = @configurator_plugins.find_rake_plugins(config, paths_hash)
+    @script_plugins = @configurator_plugins.find_script_plugins(config, paths_hash)
+    config_plugins  = @configurator_plugins.find_config_plugins(config, paths_hash)
+    plugin_defaults = @configurator_plugins.find_plugin_defaults(config, paths_hash)
 
     config_plugins.each do |plugin|
       config.deep_merge!( @yaml_wrapper.load(plugin) )
@@ -328,7 +328,6 @@ class Configurator
 
   def insert_rake_plugins(plugins)
     plugins.each do |plugin|
-      # TODO needs a duplicate guard
       @project_config_hash[:project_rakefile_component_files] << plugin
     end
   end

--- a/lib/ceedling/configurator_plugins.rb
+++ b/lib/ceedling/configurator_plugins.rb
@@ -14,15 +14,20 @@ class ConfiguratorPlugins
   def add_load_paths(config)
     plugin_paths = {}
 
-    config[:plugins][:load_paths].each do |root|
-      @system_wrapper.add_load_path( root ) if ( not @file_wrapper.directory_listing( File.join( root, '*.rb' ) ).empty? )
+    config[:plugins][:enabled].each do |plugin|
+      config[:plugins][:load_paths].each do |root|
+        path = File.join(root, plugin)
 
-      config[:plugins][:enabled].each do |plugin|
-        path = File.join(root, plugin, "lib")
+        is_script_plugin = ( not @file_wrapper.directory_listing( File.join( path, 'lib', '*.rb' ) ).empty? )
+        is_rake_plugin = ( not @file_wrapper.directory_listing( File.join( path, '*.rake' ) ).empty? )
 
-        if ( not @file_wrapper.directory_listing( File.join( path, '*.rb' ) ).empty? )
+        if is_script_plugin or is_rake_plugin
           plugin_paths[(plugin + '_path').to_sym] = path
-          @system_wrapper.add_load_path( path )
+
+          if is_script_plugin
+            @system_wrapper.add_load_path( File.join( path, 'lib') )
+          end
+          break
         end
       end
     end
@@ -32,12 +37,13 @@ class ConfiguratorPlugins
 
 
   # gather up and return .rake filepaths that exist on-disk
-  def find_rake_plugins(config)
+  def find_rake_plugins(config, plugin_paths)
+    @rake_plugins = []
     plugins_with_path = []
 
-    config[:plugins][:load_paths].each do |root|
-      config[:plugins][:enabled].each do |plugin|
-        rake_plugin_path = File.join(root, plugin, "#{plugin}.rake")
+    config[:plugins][:enabled].each do |plugin|
+      if path = plugin_paths[(plugin + '_path').to_sym]
+        rake_plugin_path = File.join(path, "#{plugin}.rake")
         if (@file_wrapper.exist?(rake_plugin_path))
           plugins_with_path << rake_plugin_path
           @rake_plugins << plugin
@@ -50,16 +56,16 @@ class ConfiguratorPlugins
 
 
   # gather up and return just names of .rb classes that exist on-disk
-  def find_script_plugins(config)
-    config[:plugins][:load_paths].each do |root|
-      config[:plugins][:enabled].each do |plugin|
-        script_plugin_path = File.join(root, plugin, "lib", "#{plugin}.rb")
+  def find_script_plugins(config, plugin_paths)
+    @script_plugins = []
 
+    config[:plugins][:enabled].each do |plugin|
+      if path = plugin_paths[(plugin + '_path').to_sym]
+        script_plugin_path = File.join(path, "lib", "#{plugin}.rb")
 
         if @file_wrapper.exist?(script_plugin_path)
           @script_plugins << plugin
         end
-
       end
     end
 
@@ -68,13 +74,12 @@ class ConfiguratorPlugins
 
 
   # gather up and return configuration .yml filepaths that exist on-disk
-  def find_config_plugins(config)
+  def find_config_plugins(config, plugin_paths)
     plugins_with_path = []
 
-    config[:plugins][:load_paths].each do |root|
-      config[:plugins][:enabled].each do |plugin|
-        config_plugin_path = File.join(root, plugin, "config", "#{plugin}.yml")
-
+    config[:plugins][:enabled].each do |plugin|
+      if path = plugin_paths[(plugin + '_path').to_sym]
+        config_plugin_path = File.join(path, "config", "#{plugin}.yml")
 
         if @file_wrapper.exist?(config_plugin_path)
           plugins_with_path << config_plugin_path
@@ -87,12 +92,12 @@ class ConfiguratorPlugins
 
 
   # gather up and return default .yml filepaths that exist on-disk
-  def find_plugin_defaults(config)
+  def find_plugin_defaults(config, plugin_paths)
     defaults_with_path = []
 
-    config[:plugins][:load_paths].each do |root|
-      config[:plugins][:enabled].each do |plugin|
-        default_path = File.join(root, plugin, 'config', 'defaults.yml')
+    config[:plugins][:enabled].each do |plugin|
+      if path = plugin_paths[(plugin + '_path').to_sym]
+        default_path = File.join(path, 'config', 'defaults.yml')
 
         if @file_wrapper.exist?(default_path)
           defaults_with_path << default_path

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -4,7 +4,7 @@ require 'ceedling/file_path_utils'
 
 #this should be defined already, but not always during system specs
 CEEDLING_VENDOR = File.expand_path(File.dirname(__FILE__) + '/../../vendor') unless defined? CEEDLING_VENDOR
-CEEDLING_PLUGINS = [File.expand_path(File.dirname(__FILE__) + '/../../plugins')] unless defined? CEEDLING_PLUGINS
+CEEDLING_PLUGINS = [] unless defined? CEEDLING_PLUGINS
 
 DEFAULT_TEST_COMPILER_TOOL = {
   :executable => FilePathUtils.os_executable_ext('gcc').freeze,
@@ -347,7 +347,7 @@ DEFAULT_CEEDLING_CONFIG = {
     :release_dependencies_generator => { :arguments => [] },
 
     :plugins => {
-      :load_paths => [], #XXX this is injected twice as of now so removed til better handling is found CEEDLING_PLUGINS,
+      :load_paths => CEEDLING_PLUGINS,
       :enabled => [],
     }
   }.freeze


### PR DESCRIPTION
Fixes #262

Possible impacts:

#### 1
In `ConfiguratorPlugins#add_load_paths` I've removed the lines
```
config[:plugins][:load_paths].each do |root|
  @system_wrapper.add_load_path( root ) if ( not @file_wrapper.directory_listing( File.join( root, '*.rb' ) ).empty? )
```
which means that plugins of the form `path/to/plugin_dir/plugin.rb` will not work, but I think these are obsolete anyway as they would not have been found by `ConfiguratorPlugins#find_script_plugins` and therefore would have been flagged as invalid by `ConfiguratorSetup#validate_plugins`

#### 2
In ConfiguratorPlugins#add_load_paths I've changed the contents of `plugin_paths` (that ultimately gets stored in `config[:plugins][(plugin + '_path').to_sym]` by `Configurator#find_and_merge_plugins` to no longer include the trailing `lib` directory. I couldn't find anywhere that this path is actually used (although it's now used by `ConfiguratorPlugins#find_xxx_plugins`) so I don't think this will affect anything but could impact third-party code that's making use of these values.