### PR TITLE
Allow the separate dependency generation step to be skipped

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -802,6 +802,17 @@ project: global project settings
 
   **Default**: FALSE
 
+* `generate_deep_dependencies`:
+
+  When `use_deep_dependencies` is set to TRUE, Ceedling will run a separate
+  build step to generate the deep dependencies. If you are using gcc as your
+  primary compiler, or another compiler that can generate makefile rules as
+  a side effect of compilation, then you can set this to FALSE to avoid the
+  extra build step but still use the deep dependencies data when deciding
+  which source files to rebuild.
+
+  **Default**: TRUE
+
 * `test_file_prefix`:
 
   Ceedling collects test files by convention from within the test file
@@ -1539,14 +1550,14 @@ tools.
 * `test_compiler`:
 
   Compiler for test & source-under-test code
-  ${1}: input source ${2}: output object ${3}: optional output list ${4}: optional per-file flags
+  ${1}: input source ${2}: output object ${3}: optional output list ${4}: optional output dependencies file
 
   **Default**: gcc
 
 * `test_linker`:
 
   Linker to generate test fixture executables
-  ${1}: input objects ${2}: output binary ${3}: optional output map ${4}: optional per-binary flags
+  ${1}: input objects ${2}: output binary ${3}: optional output map ${4}: optional library list
 
   **Default**: gcc
 
@@ -1581,7 +1592,7 @@ tools.
 * `release_compiler`:
 
   Compiler for release source code
-  ${1}: input source ${2}: output object ${3}: optional output list ${4}: optional per-file flags
+  ${1}: input source ${2}: output object ${3}: optional output list ${4}: optional output dependencies file
 
   **Default**: gcc
 
@@ -1595,7 +1606,7 @@ tools.
 * `release_linker`:
 
   Linker for release source code
-  ${1}: input objects ${2}: output binary ${3}: optional output map ${4}: optional per-binary flags
+  ${1}: input objects ${2}: output binary ${3}: optional output map ${4}: optional library list
 
   **Default**: gcc
 

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -21,6 +21,8 @@ DEFAULT_TEST_COMPILER_TOOL = {
     "-c \"${1}\"".freeze,
     "-o \"${2}\"".freeze,
     # gcc's list file output options are complex; no use of ${3} parameter in default config
+    "-MMD".freeze,
+    "-MF \"${4}\"".freeze,
     ].freeze
   }
 
@@ -158,6 +160,8 @@ DEFAULT_RELEASE_COMPILER_TOOL = {
     "-c \"${1}\"".freeze,
     "-o \"${2}\"".freeze,
     # gcc's list file output options are complex; no use of ${3} parameter in default config
+    "-MMD".freeze,
+    "-MF \"${4}\"".freeze,
     ].freeze
   }
 
@@ -242,6 +246,7 @@ DEFAULT_CEEDLING_CONFIG = {
       :test_threads => 1,
       :use_test_preprocessor => false,
       :use_deep_dependencies => false,
+      :generate_deep_dependencies => true, # only applicable if use_deep_dependencies is true
       :test_file_prefix => 'test_',
       :options_paths => [],
       :release_build => false,

--- a/lib/ceedling/dependinator.rb
+++ b/lib/ceedling/dependinator.rb
@@ -11,7 +11,11 @@ class Dependinator
 
 
   def load_release_object_deep_dependencies(dependencies_list)
-    dependencies_list.each { |dependencies_file| @rake_wrapper.load_dependencies( dependencies_file ) }
+    dependencies_list.each do |dependencies_file|
+      if File.exists?(dependencies_file)
+        @rake_wrapper.load_dependencies( dependencies_file )
+      end
+    end
   end
 
 
@@ -25,7 +29,11 @@ class Dependinator
 
   def load_test_object_deep_dependencies(files_list)
     dependencies_list = @file_path_utils.form_test_dependencies_filelist(files_list)
-    dependencies_list.each { |dependencies_file| @rake_wrapper.load_dependencies(dependencies_file) }
+    dependencies_list.each do |dependencies_file|
+      if File.exists?(dependencies_file)
+        @rake_wrapper.load_dependencies(dependencies_file)
+      end
+    end
   end
 
 

--- a/lib/ceedling/file_path_utils.rb
+++ b/lib/ceedling/file_path_utils.rb
@@ -116,6 +116,10 @@ class FilePathUtils
     return File.join( @configurator.project_test_build_cache_path, File.basename(filepath) )
   end
 
+  def form_test_dependencies_filepath(filepath)
+    return File.join( @configurator.project_test_dependencies_path, File.basename(filepath).ext(@configurator.extension_dependencies) )
+  end
+
   def form_pass_results_filepath(filepath)
     return File.join( @configurator.project_test_results_path, File.basename(filepath).ext(@configurator.extension_testpass) )
   end

--- a/lib/ceedling/generator.rb
+++ b/lib/ceedling/generator.rb
@@ -78,9 +78,9 @@ class Generator
     end
   end
 
-  def generate_object_file(tool, operation, context, source, object, list='')
+  def generate_object_file(tool, operation, context, source, object, list='', dependencies='')
     shell_result = {}
-    arg_hash = {:tool => tool, :operation => operation, :context => context, :source => source, :object => object, :list => list}
+    arg_hash = {:tool => tool, :operation => operation, :context => context, :source => source, :object => object, :list => list, :dependencies => dependencies}
     @plugin_manager.pre_compile_execute(arg_hash)
 
     @streaminator.stdout_puts("Compiling #{File.basename(arg_hash[:source])}...", Verbosity::NORMAL)
@@ -89,7 +89,8 @@ class Generator
                                          @flaginator.flag_down( operation, context, source ),
                                          arg_hash[:source],
                                          arg_hash[:object],
-                                         arg_hash[:list])
+                                         arg_hash[:list],
+                                         arg_hash[:dependencies])
 
     begin
       shell_result = @tool_executor.exec( command[:line], command[:options] )

--- a/lib/ceedling/release_invoker_helper.rb
+++ b/lib/ceedling/release_invoker_helper.rb
@@ -8,8 +8,11 @@ class ReleaseInvokerHelper
   def process_deep_dependencies(dependencies_list)
     return if (not @configurator.project_use_deep_dependencies)
 
-    @dependinator.enhance_release_file_dependencies( dependencies_list )
-    @task_invoker.invoke_release_dependencies_files( dependencies_list )
+    if @configurator.project_generate_deep_dependencies
+      @dependinator.enhance_release_file_dependencies( dependencies_list )
+      @task_invoker.invoke_release_dependencies_files( dependencies_list )
+    end
+
     @dependinator.load_release_object_deep_dependencies( dependencies_list )
   end
 

--- a/lib/ceedling/rules_release.rake
+++ b/lib/ceedling/rules_release.rake
@@ -30,7 +30,8 @@ rule(/#{PROJECT_RELEASE_BUILD_OUTPUT_C_PATH}\/#{'.+\\'+EXTENSION_OBJECT}$/ => [
     RELEASE_SYM,
     object.source,
     object.name,
-    @ceedling[:file_path_utils].form_release_build_c_list_filepath( object.name ) )
+    @ceedling[:file_path_utils].form_release_build_c_list_filepath( object.name ),
+    @ceedling[:file_path_utils].form_release_dependencies_filepath( object.name ) )
 end
 
 

--- a/lib/ceedling/rules_tests.rake
+++ b/lib/ceedling/rules_tests.rake
@@ -20,7 +20,8 @@ rule(/#{PROJECT_TEST_BUILD_OUTPUT_PATH}\/#{'.+\\'+EXTENSION_OBJECT}$/ => [
     TEST_SYM,
     object.source,
     object.name,
-    @ceedling[:file_path_utils].form_test_build_list_filepath( object.name ) )
+    @ceedling[:file_path_utils].form_test_build_list_filepath( object.name ),
+    @ceedling[:file_path_utils].form_test_dependencies_filepath( object.name ) )
 end
 
 

--- a/lib/ceedling/test_invoker_helper.rb
+++ b/lib/ceedling/test_invoker_helper.rb
@@ -12,7 +12,11 @@ class TestInvokerHelper
     return if (not @configurator.project_use_deep_dependencies)
 
     dependencies_list = @file_path_utils.form_test_dependencies_filelist( files )
-    @task_invoker.invoke_test_dependencies_files( dependencies_list )
+
+    if @configurator.project_generate_deep_dependencies
+      @task_invoker.invoke_test_dependencies_files( dependencies_list )
+    end
+
     yield( dependencies_list ) if block_given?
   end
   


### PR DESCRIPTION
If the compiler can generate dependencies as a side-effect of compilation (e.g. gcc's -MMD option) then there is no need for a separate call to gcc to generate the dependency files. Add a new project option `generate_deep_dependencies` which can be set to false to skip this step, and add a ${4} parameter to `generate_object_file` to pass in the path to the output dependency file.