### PR TITLE
Only call plugin if it responds to the given method

### DIFF
--- a/lib/ceedling/plugin_manager.rb
+++ b/lib/ceedling/plugin_manager.rb
@@ -14,7 +14,7 @@ class PluginManager
 
     script_plugins.each do |plugin|
       # protect against instantiating object multiple times due to processing config multiple times (option files, etc)
-			next if (@plugin_manager_helper.include?(@plugin_objects, plugin))
+      next if (@plugin_manager_helper.include?(@plugin_objects, plugin))
       begin
         @system_wrapper.require_file( "#{plugin}.rb" )
         object = @plugin_manager_helper.instantiate_plugin_script( camelize(plugin), system_objects, plugin )
@@ -96,7 +96,7 @@ class PluginManager
   def execute_plugins(method, *args)
     @plugin_objects.each do |plugin|
       begin
-        plugin.send(method, *args)
+        plugin.send(method, *args) if plugin.respond_to?(method)
       rescue
         puts "Exception raised in plugin: #{plugin.name}, in method #{method}"
         raise


### PR DESCRIPTION
This fixes ceedling calling plugins with methods they don't support by checking if they respond to the method first. When doing other clean up, I noticed this error was occurring on `post_error` for the `StdoutPrettyTestsReport` plugin.

```
Traceback (most recent call last):
	4: from vendor/ceedling/lib/../lib/ceedling/rakefile.rb:84:in `block in <top (required)>'
	3: from /tmp/d20180607-6210-1ceqetp/fake_project/vendor/ceedling/lib/ceedling/plugin_manager.rb:86:in `post_error'
	2: from /tmp/d20180607-6210-1ceqetp/fake_project/vendor/ceedling/lib/ceedling/plugin_manager.rb:97:in `execute_plugins'
	1: from /tmp/d20180607-6210-1ceqetp/fake_project/vendor/ceedling/lib/ceedling/plugin_manager.rb:97:in `each'
/tmp/d20180607-6210-1ceqetp/fake_project/vendor/ceedling/lib/ceedling/plugin_manager.rb:99:in `block in execute_plugins': undefined method `post_error' for #<StdoutPrettyTestsReport:0x000055baeb62c680> (NoMethodError)
Did you mean?  post_test
```