### PR TITLE
Spec output cleanup & made sure all deploy tests were called correctly.

### DIFF
--- a/spec/gcov/gcov_test_cases_spec.rb
+++ b/spec/gcov/gcov_test_cases_spec.rb
@@ -33,7 +33,7 @@ module GcovTestCases
         FileUtils.cp test_asset_path("example_file.c"), 'src/'
         FileUtils.cp test_asset_path("test_example_file.c"), 'test/'
 
-        output = `bundle exec ruby -S ceedling gcov:all`
+        output = `bundle exec ruby -S ceedling gcov:all 2>&1`
         expect($?.exitstatus).to match(1) # Since a test fails, we return error here
         expect(output).to match(/TESTED:\s+\d/)
         expect(output).to match(/PASSED:\s+\d/)
@@ -51,7 +51,7 @@ module GcovTestCases
         FileUtils.cp test_asset_path("example_file.c"), 'src/'
         FileUtils.cp test_asset_path("test_example_file_boom.c"), 'test/'
 
-        output = `bundle exec ruby -S ceedling test:all`
+        output = `bundle exec ruby -S ceedling test:all 2>&1`
         expect($?.exitstatus).to match(1) # Since a test explodes, we return error here
         expect(output).to match(/ERROR: Ceedling Failed/)
       end

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -423,7 +423,7 @@ module CeedlingTestCases
         expect($?.exitstatus).to match(0)
         expect(output).to match(/Generate Complete/i)
 
-        output = `bundle exec ruby -S ceedling module:create[myUnicorn:unicorns]`
+        output = `bundle exec ruby -S ceedling module:create[myUnicorn:unicorns] 2>&1`
         expect($?.exitstatus).to match(1)
         expect(output).to match(/ERROR: Ceedling Failed/)
       end

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -31,8 +31,11 @@ describe "Ceedling" do
     it { can_test_projects_with_fail }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { can_use_the_module_plugin_path_extension }
+    it { can_use_the_module_plugin_with_include_path }
     it { handles_creating_the_same_module_twice_using_the_module_plugin }
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
   end
 
   describe "deployed in a project's `vendor` directory." do
@@ -68,8 +71,11 @@ describe "Ceedling" do
     it { can_test_projects_with_fail }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { can_use_the_module_plugin_path_extension }
+    it { can_use_the_module_plugin_with_include_path }
     it { handles_creating_the_same_module_twice_using_the_module_plugin }
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
   end
 
   describe "ugrade a project's `vendor` directory" do
@@ -88,8 +94,11 @@ describe "Ceedling" do
     it { can_test_projects_with_fail }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { can_use_the_module_plugin_path_extension }
+    it { can_use_the_module_plugin_with_include_path }
     it { handles_creating_the_same_module_twice_using_the_module_plugin }
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
 
     it { can_upgrade_projects }
     it { contains_a_vendor_directory }
@@ -99,8 +108,11 @@ describe "Ceedling" do
     it { can_test_projects_with_fail }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { can_use_the_module_plugin_path_extension }
+    it { can_use_the_module_plugin_with_include_path }
     it { handles_creating_the_same_module_twice_using_the_module_plugin }
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
   end
 
   describe "deployed as a gem" do
@@ -118,8 +130,11 @@ describe "Ceedling" do
     it { can_test_projects_with_fail }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
+    it { can_use_the_module_plugin_path_extension }
+    it { can_use_the_module_plugin_with_include_path }
     it { handles_creating_the_same_module_twice_using_the_module_plugin }
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
+    it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
   end
 
   describe "command: `ceedling examples`" do


### PR DESCRIPTION
This PR cleans up the output on some of the deploy spec tests that did not pip STDERR to STROUT. While doing this, I also noticed several of the module create deployment tests were never called so I added them to the appropriate deployment tests.