### PR TITLE
Feature #252: raw output plugin

### DIFF
--- a/assets/project_with_guts.yml
+++ b/assets/project_with_guts.yml
@@ -87,4 +87,5 @@
   :enabled:
     - stdout_pretty_tests_report
     - module_generator
+    - raw_output_report
 ...

--- a/assets/test_example_file_verbose.c
+++ b/assets/test_example_file_verbose.c
@@ -1,0 +1,12 @@
+#include "unity.h"
+#include "example_file.h"
+#include <stdio.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_add_numbers_adds_numbers(void) {
+  printf("1 + 1 = 2\n");
+  TEST_ASSERT_EQUAL(2, add_numbers(1,1));
+}
+

--- a/plugins/raw_output_report/lib/raw_output_report.rb
+++ b/plugins/raw_output_report/lib/raw_output_report.rb
@@ -1,0 +1,41 @@
+require 'ceedling/plugin'
+require 'ceedling/constants'
+
+class RawOutputReport < Plugin
+  def setup
+    @log_paths = {}
+  end
+
+  def post_test_fixture_execute(arg_hash)
+    output = strip_output(arg_hash[:shell_result][:output])
+    write_raw_output_log(arg_hash, output)
+  end
+
+  private
+
+  def strip_output(raw_output)
+    output = ""
+    raw_output.each_line do |line|
+      next if line =~ /^\n$/
+      next if line =~ /^.*:\d+:.*:(IGNORE|PASS|FAIL)/
+      return output if line =~/^-----------------------\n$/
+      output << line
+    end
+  end
+  def write_raw_output_log(arg_hash, output)
+    logging = generate_log_path(arg_hash)
+    @ceedling[:file_wrapper].write(logging[:path], output , logging[:flags]) unless logging.nil?
+  end
+
+  def generate_log_path(arg_hash)
+    f_name = File.basename(arg_hash[:result_file], '.pass')
+    base_path = File.join(PROJECT_BUILD_ARTIFACTS_ROOT, arg_hash[:context].to_s)
+    file_path = File.join(base_path, f_name + '.log')
+
+    if @ceedling[:file_wrapper].exist?(base_path)
+      return { path: file_path, flags: 'w' }
+    end
+
+    nil
+  end
+end

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -291,6 +291,24 @@ module CeedlingTestCases
     end
   end
 
+  def uses_raw_output_report_plugin
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_verbose.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling test:all 2>&1`
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+        expect(File.exists?("build/artifacts/test/test_example_file_verbose.log")).to eq true
+      end
+    end
+  end
+
 
   def can_fetch_non_project_help
     @c.with_context do

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -30,6 +30,7 @@ describe "Ceedling" do
     it { can_test_projects_with_success }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_compile_error }
+    it { uses_raw_output_report_plugin }
     it { can_use_the_module_plugin }
     it { can_use_the_module_plugin_path_extension }
     it { can_use_the_module_plugin_with_include_path }


### PR DESCRIPTION
This pull request add a raw output plugin as described in #252. For each test it will include an individual logging output in the artifacts directory. So if you had tests `test_foo.c` and `test_bar.c` the test artifacts directory would contain `test_foo.log` and `test_bar.log`.