### PR TITLE
Scrub file in preprocessinator if it's not a valid incoding

### DIFF
--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -30,6 +30,11 @@ class PreprocessinatorIncludesHandler
     # that winds through the code). The decorated filenames indicate files that
     # are included directly by the test file.
     contents = @file_wrapper.read(filepath)
+
+    if !contents.valid_encoding?
+      contents = contents.encode("UTF-16be", :invalid=>:replace, :replace=>"?").encode('UTF-8')
+    end
+
     contents.gsub!( /^\s*#include\s+[\"<]\s*(\S+)\s*[\">]/, "#include \"\\1\"\n#include \"@@@@\\1\"" )
     contents.gsub!( /^\s*TEST_FILE\(\s*\"\s*(\S+)\s*\"\s*\)/, "#include \"\\1\"\n#include \"@@@@\\1\"")
     @file_wrapper.write( temp_filepath, contents )

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -42,6 +42,7 @@ describe PreprocessinatorIncludesHandler do
       expect(@file_path_utils).to receive(:form_temp_path).with('some_source_file.c','_').and_return('_some_source_file.c')
       contents_double = double('contents-double')
       expect(@file_wrapper).to receive(:read).with('some_source_file.c').and_return(contents_double)
+      expect(contents_double).to receive(:valid_encoding?).and_return(true)
       expect(contents_double).to receive(:gsub!).with(/^\s*#include\s+[\"<]\s*(\S+)\s*[\">]/, "#include \"\\1\"\n#include \"@@@@\\1\"")
       expect(contents_double).to receive(:gsub!).with(/^\s*TEST_FILE\(\s*\"\s*(\S+)\s*\"\s*\)/, "#include \"\\1\"\n#include \"@@@@\\1\"")
       expect(@file_wrapper).to receive(:write).with('_some_source_file.c', contents_double)


### PR DESCRIPTION
I've been working with a new client and one of the files in their repo generated the following error:

> 
> rake aborted!
> ArgumentError: invalid byte sequence in UTF-8
> /home/dom/.rvm/gems/ruby-2.5.1/gems/ceedling-0.28.2/lib/ceedling/preprocessinator_includes_handler.rb:33:in `gsub!'

After some investigating, I found ruby can scrub a string before trying process it with gsub. The error is now gone without changing the source file.