### PR TITLE
Use the libraries section in the YAML file when doing tests

### DIFF
--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -64,6 +64,8 @@ class Configurator
   end
 
 
+  # The default values defined in defaults.rb (eg. DEFAULT_TOOLS_TEST) are populated
+  # into @param config
   def populate_defaults(config)
     new_config = DEFAULT_CEEDLING_CONFIG.deep_clone
     new_config.deep_merge!(config)

--- a/lib/ceedling/generator.rb
+++ b/lib/ceedling/generator.rb
@@ -92,6 +92,8 @@ class Generator
                                          arg_hash[:list],
                                          arg_hash[:dependencies])
 
+    @streaminator.stdout_puts("Command: #{command}", Verbosity::DEBUG)
+
     begin
       shell_result = @tool_executor.exec( command[:line], command[:options] )
     rescue ShellExecutionException => ex
@@ -124,6 +126,7 @@ class Generator
                                          arg_hash[:map],
                                          arg_hash[:libraries]
                                        )
+    @streaminator.stdout_puts("Command: #{command}", Verbosity::DEBUG)
 
     begin
       shell_result = @tool_executor.exec( command[:line], command[:options] )
@@ -157,6 +160,7 @@ class Generator
     # Unity's exit code is equivalent to the number of failed tests, so we tell @tool_executor not to fail out if there are failures
     # so that we can run all tests and collect all results
     command = @tool_executor.build_command_line(arg_hash[:tool], [], arg_hash[:executable])
+    @streaminator.stdout_puts("Command: #{command}", Verbosity::DEBUG)
     command[:options][:boom] = false
     shell_result = @tool_executor.exec( command[:line], command[:options] )
     shell_result[:exit_code] = 0 #Don't Let The Failure Count Make Us Believe Things Aren't Working

--- a/lib/ceedling/rules_tests.rake
+++ b/lib/ceedling/rules_tests.rake
@@ -35,8 +35,7 @@ end
 
 rule(/#{PROJECT_TEST_BUILD_OUTPUT_PATH}\/#{'.+\\'+EXTENSION_EXECUTABLE}$/) do |bin_file|
 
-  lib_args = ((defined? LIBRARIES_SYSTEM) ? LIBRARIES_SYSTEM : [])
-  lib_args.map! {|v| LIBRARIES_FLAG.gsub(/\$\{1\}/, v) } if (defined? LIBRARIES_FLAG)
+  lib_args = @ceedling[:test_invoker].convert_libraries_to_arguments()
 
   @ceedling[:generator].generate_executable_file(
     TOOLS_TEST_LINKER,

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -54,6 +54,19 @@ class TestInvoker
     end
   end
 
+  # Convert libraries configuration form YAML configuration
+  # into a string that can be given to the compiler.
+  def convert_libraries_to_arguments()
+    if @configurator.project_config_hash.has_key?(:libraries_test)
+      lib_args = @configurator.project_config_hash[:libraries_test]
+      lib_args.flatten!
+      lib_flag = @configurator.project_config_hash[:libraries_flag]
+      lib_args.map! {|v| lib_flag.gsub(/\$\{1\}/, v) } if (defined? lib_flag)
+      return lib_args
+    end
+  end
+
+
   def setup_and_invoke(tests, context=TEST_SYM, options={:force_run => true})
 
     @tests = tests


### PR DESCRIPTION
It appeared that the libraries configuration section was never used, at least when linking tests.