### PR TITLE
Make junit escape strings in test names

### DIFF
--- a/plugins/junit_tests_report/lib/junit_tests_report.rb
+++ b/plugins/junit_tests_report/lib/junit_tests_report.rb
@@ -98,6 +98,7 @@ class JunitTestsReport < Plugin
   end
 
   def write_test( test, stream )
+    test[:test].gsub!('"', '&quot;')
     case test[:result]
     when :success
       stream.puts('    <testcase name="%<test>s" />' % test)


### PR DESCRIPTION
Follow up to testing https://github.com/ThrowTheSwitch/Unity/pull/380. Unity works fine, but the junit xml generation was broken from the extra double quotes. This just scrubs and replaces double quotes with their encoded version.