### PR TITLE
Don't clobber the collected defines in gcov

### DIFF
--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -11,6 +11,7 @@
       - -I"$": COLLECTION_PATHS_TEST_TOOLCHAIN_INCLUDE
       - -D$: COLLECTION_DEFINES_TEST_AND_VENDOR
       - -DGCOV_COMPILER
+      - -DCODE_COVERAGE
       - -c "${1}"
       - -o "${2}"
   :gcov_linker:

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -14,7 +14,6 @@ class Gcov < Plugin
       project_test_results_path: GCOV_RESULTS_PATH,
       project_test_dependencies_path: GCOV_DEPENDENCIES_PATH,
       defines_test: DEFINES_TEST + ['CODE_COVERAGE'],
-      collection_defines_test_and_vendor: COLLECTION_DEFINES_TEST_AND_VENDOR + ['CODE_COVERAGE'],
       gcov_html_report_filter: GCOV_FILTER_EXPR
     }
 


### PR DESCRIPTION
Fixes #293. What ended up happening was the `collection_defines_test_and_vendor` in gcov would take precedence over the completely merged version of `collection_defines_test_and_vendor`. This fix moves the default define to the default config and just lets the rest of ceedling set up `collection_defines_test_and_vendor`.