### PR TITLE
colour_report plugin

### DIFF
--- a/lib/ceedling/stream_wrapper.rb
+++ b/lib/ceedling/stream_wrapper.rb
@@ -1,8 +1,16 @@
 
 class StreamWrapper
 
+  def stdout_override(&fnc)
+    @stdout_overide_fnc = fnc
+  end
+
   def stdout_puts(string)
-    $stdout.puts(string)
+    if @stdout_overide_fnc
+      @stdout_overide_fnc.call(string)
+    else
+      $stdout.puts(string)
+    end
   end
 
   def stdout_flush

--- a/plugins/colour_report/lib/colour_report.rb
+++ b/plugins/colour_report/lib/colour_report.rb
@@ -1,0 +1,16 @@
+require 'ceedling/plugin'
+require 'ceedling/streaminator'
+require 'ceedling/constants'
+
+class ColourReport < Plugin
+
+  def setup
+    @ceedling[:stream_wrapper].stdout_override(&ColourReport.method(:colour_stdout))
+  end
+
+  def self.colour_stdout(string)
+    require 'colour_reporter.rb'
+    report string
+  end
+
+end


### PR DESCRIPTION
Addresses #149 by adding a very thin plugin called colour_report that very thinly wraps that module. Here is an output with the `stdout_pretty_tests_report` disabled. 

![image](https://user-images.githubusercontent.com/5647348/50377748-ded06500-05f0-11e9-8ded-e9667c9975b4.png)

It needs more work to fully work with the `stdout_pretty_tests_report`, but I think these changes will have to be done to the colour_reporter module in Unity.