### PR TITLE
Generate deleteme file in test/support to make it easier to use ceedling out of the box with git

### DIFF
--- a/bin/ceedling
+++ b/bin/ceedling
@@ -86,6 +86,9 @@ unless (project_found)
           end
         end
 
+        # Genarate gitkeep in test support path
+        FileUtils.touch(File.join(test_support_path, '.gitkeep'))
+
         # If documentation requested, create a place to dump them and do so
         if use_docs
           doc_path = File.join(ceedling_path, 'docs')

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -182,6 +182,8 @@ module CeedlingTestCases
         expect(File.exists?("project.yml")).to eq true
         expect(File.exists?("src")).to eq true
         expect(File.exists?("test")).to eq true
+        expect(File.exists?("test/support")).to eq true
+        expect(File.exists?("test/support/.gitkeep")).to eq true
       end
     end
   end


### PR DESCRIPTION
This attempts to alleviate some of the issues brought up in #182 by adding an empty file that can be added via git.