### PR TITLE
Add two configuration tokens to configure output file name for junit_tests_report and xml_tests_report plugins.

### DIFF
--- a/plugins/junit_tests_report/README.md
+++ b/plugins/junit_tests_report/README.md
@@ -1,0 +1,32 @@
+junit_tests_report
+====================
+
+## Overview
+
+The junit_tests_report plugin creates an XML file of test results in JUnit
+format, which is handy for Continuous Integration build servers or as input
+into other reporting tools. The XML file is output to the appropriate
+`<build_root>/artifacts/` directory (e.g. `artifacts/test/` for test tasks,
+`artifacts/gcov/` for gcov, or `artifacts/bullseye/` for bullseye runs).
+
+## Setup
+
+Enable the plugin in your project.yml by adding `junit_tests_report`
+to the list of enabled plugins.
+
+``` YAML
+:plugins:
+  :enabled:
+    - junit_tests_report
+```
+
+## Configuration
+
+Optionally configure the output / artifact filename in your project.yml with
+the `artifact_filename` configuration option. The default filename is
+`report.xml`.
+
+``` YAML
+:junit_tests_report:
+  :artifact_filename: report_junit.xml
+```

--- a/plugins/junit_tests_report/lib/junit_tests_report.rb
+++ b/plugins/junit_tests_report/lib/junit_tests_report.rb
@@ -22,7 +22,12 @@ class JunitTestsReport < Plugin
   def post_build
     @results_list.each_key do |context|
       results = @ceedling[:plugin_reportinator].assemble_test_results(@results_list[context])
-      file_path = File.join( PROJECT_BUILD_ARTIFACTS_ROOT, context.to_s, 'report.xml' )
+
+      artifact_filename = @ceedling[:configurator].project_config_hash[:junit_tests_report_artifact_filename]
+
+      artifact_filename = artifact_filename || 'report.xml'
+
+      file_path = File.join( PROJECT_BUILD_ARTIFACTS_ROOT, context.to_s, artifact_filename)
 
       @ceedling[:file_wrapper].open( file_path, 'w' ) do |f|
         @testsuite_counter = 0

--- a/plugins/xml_tests_report/README.md
+++ b/plugins/xml_tests_report/README.md
@@ -1,0 +1,32 @@
+xml_tests_report
+====================
+
+## Overview
+
+The xml_tests_report plugin creates an XML file of test results in xUnit
+format, which is handy for Continuous Integration build servers or as input
+into other reporting tools. The XML file is output to the appropriate
+`<build_root>/artifacts/` directory (e.g. `artifacts/test/` for test tasks,
+`artifacts/gcov/` for gcov, or `artifacts/bullseye/` for bullseye runs).
+
+## Setup
+
+Enable the plugin in your project.yml by adding `xml_tests_report` to the list
+of enabled plugins.
+
+``` YAML
+:plugins:
+  :enabled:
+    - xml_tests_report
+```
+
+## Configuration
+
+Optionally configure the output / artifact filename in your project.yml with
+the `artifact_filename` configuration option. The default filename is
+`report.xml`.
+
+``` YAML
+:xml_tests_report:
+  :artifact_filename: report_xunit.xml
+```

--- a/plugins/xml_tests_report/lib/xml_tests_report.rb
+++ b/plugins/xml_tests_report/lib/xml_tests_report.rb
@@ -19,7 +19,11 @@ class XmlTestsReport < Plugin
     @results_list.each_key do |context|
       results = @ceedling[:plugin_reportinator].assemble_test_results(@results_list[context])
 
-      file_path = File.join(PROJECT_BUILD_ARTIFACTS_ROOT, context.to_s, 'report.xml')
+      artifact_filename = @ceedling[:configurator].project_config_hash[:xml_tests_report_artifact_filename]
+
+      artifact_filename = artifact_filename || 'report.xml'
+
+      file_path = File.join(PROJECT_BUILD_ARTIFACTS_ROOT, context.to_s, artifact_filename)
 
       @ceedling[:file_wrapper].open(file_path, 'w') do |f|
         @test_counter = 1


### PR DESCRIPTION
#323
If configuration tokens are not used, behavior isn't modified.
Otherwise, this makes it possible to change the output file of junit_tests_report or/and xml_tests_report plugins.

