### PR TITLE
Add ruby-2.6 to travis and raise minimum ruby to 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ os:
   - linux
 
 rvm:
-  - "2.1"
+  - "2.3"
   - "2.4"
+  - "2.6"
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo pip install gcovr; fi


### PR DESCRIPTION
This pull requests does two things. First it adds ruby 2.6 to the ram matrix to test feeling out against the latest ruby release.  The second thing this does is raise the minimum ruby tested to 2.3. Travis recently started having bundler errors on their OSX for ruby 2.1 and 2.2 as seen on one of the recent pull requests here and have also both reached their end of life a while ago.