### PR TITLE
Add xml report option to utils:gcov

### DIFF
--- a/assets/project_as_gem.yml
+++ b/assets/project_as_gem.yml
@@ -61,7 +61,9 @@
     bool:     UINT8
 
 :gcov:
-    :html_report_type: basic
+    :html_report: true # Enables the output of an HTML report for utils:gcov
+    :html_report_type: basic  # Options are 'basic' or 'detailed'.
+    :xml_report: false # Enables the output of an XML report for utils:gcov
 
 #:tools:
 # Ceedling defaults to using gcc for compiling, linking, etc.

--- a/assets/project_with_guts.yml
+++ b/assets/project_with_guts.yml
@@ -61,7 +61,9 @@
     bool:     UINT8
 
 :gcov:
-    :html_report_type: basic
+    :html_report: true # Enables the output of an HTML report for utils:gcov
+    :html_report_type: basic  # Options are 'basic' or 'detailed'.
+    :xml_report: false # Enables the output of an XML report for utils:gcov
 
 #:tools:
 # Ceedling defaults to using gcc for compiling, linking, etc.

--- a/assets/project_with_guts_gcov.yml
+++ b/assets/project_with_guts_gcov.yml
@@ -61,7 +61,9 @@
     bool:     UINT8
 
 :gcov:
-    :html_report_type: basic
+    :html_report: true # Enables the output of an HTML report for utils:gcov
+    :html_report_type: basic  # Options are 'basic' or 'detailed'.
+    :xml_report: false # Enables the output of an XML report for utils:gcov
 
 #:tools:
 # Ceedling defaults to using gcc for compiling, linking, etc.

--- a/plugins/gcov/README.md
+++ b/plugins/gcov/README.md
@@ -1,13 +1,16 @@
 ceedling-gcov
 =============
 
+# Plugin Overview
+
 Plugin for integrating GNU GCov code coverage tool into Ceedling projects.
 Currently only designed for the gcov command (like LCOV for example). In the
 future we could configure this to work with other code coverage tools.
 
+This plugin currently uses `gcovr` to generate HTML and/or XML reports as a
+utility. The normal gcov plugin _must_ be run first for this report to generate.
 
-This plugin currently uses `gcovr` to generate HTML reports as a utility. The
-normal gcov plugin _must_ be run first for this report to generate.
+## Installation
 
 Gcovr can be installed via pip like so:
 
@@ -15,27 +18,53 @@ Gcovr can be installed via pip like so:
 pip install gcovr
 ```
 
+## Configuration
+
+The gcov plugin supports configuration options via your `project.yml` provided
+by Ceedling.
+
+Generation of HTML reports may be enabled or disabled with the following
+config. Set to `true` to enable or set to `false` to disable.
+
+```
+:gcov:
+  :html_report: true
+```
+
+Generation of XML reports may be enabled or disabled with the following
+config. Set to `true` to enable or set to `false` to disable.
+
+```
+:gcov:
+  :xml_report: true
+```
+
 There are two types of gcovr HTML reports that can be configured in your
-`project.yml`. To create a basic HTML report with only the overall file
-information use the following config. 
+`project.yml`. To create a basic HTML report, with only the overall file
+information, use the following config.
 
 ```
 :gcov:
   :html_report_type: basic
 ```
-To create a detailed HTML report with line by line breakdown of the coverage use
-the following config.
+
+To create a detailed HTML report, with line by line breakdown of the
+coverage, use the following config.
 
 ```
 :gcov:
   :html_report_type: detailed
 ```
 
-These reports will be found in `build/artifacts/gcov`.
+These HTML and XML reports will be found in `build/artifacts/gcov`.
 
+## Example Usage
 
+```
+ceedling gcov:all utils:gcov
+```
 
-# To-Do list
+## To-Do list
 
 - Generate overall report (combined statistics from all files with coverage)
 - Generate coverage output files

--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -62,6 +62,15 @@
         - --html-details
         - -r .
         - -o  "$": GCOV_ARTIFACTS_FILE
-
+  :gcov_post_report_xml:
+    :executable: gcovr
+    :optional: TRUE
+    :arguments:
+        - -p
+        - -b
+        - -e "${1}"
+        - --xml
+        - -r .
+        - -o  "$": GCOV_ARTIFACTS_FILE_XML
 
 ...

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -160,21 +160,47 @@ namespace UTILS_SYM do
 
     filter = @ceedling[:configurator].project_config_hash[:gcov_html_report_filter] || GCOV_FILTER_EXPR
 
-    if @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'basic'
-      puts "Creating a basic html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
-      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [], filter)
-      @ceedling[:tool_executor].exec(command[:line], command[:options])
-    elsif @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'detailed'
-      puts "Creating a detailed html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
-      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_ADVANCED, [], filter)
-      @ceedling[:tool_executor].exec(command[:line], command[:options])
+    if @ceedling[:configurator].project_config_hash[:gcov_html_report].nil?
+      puts "In your project.yml, define: \n\n:gcov:\n  :html_report:\n\n to true or false to refine this feature."
+      puts "For now, assumimg you want an html report generated."
+      html_enabled = true
     else
-      puts "In your project.yml, define: \n\n:gcov:\n  :html_report_type:\n\n to basic or detailed to refine this feature."
-      puts "For now, just creating basic."
-      puts "Creating a basic html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
-      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [], filter)
+      html_enabled = @ceedling[:configurator].project_config_hash[:gcov_html_report]
+    end
+
+    if @ceedling[:configurator].project_config_hash[:gcov_xml_report].nil?
+      puts "In your project.yml, define: \n\n:gcov:\n  :xml_report:\n\n to true or false to refine this feature."
+      puts "For now, assumimg you want an xml report generated."
+      xml_enabled = true
+    else
+      xml_enabled = @ceedling[:configurator].project_config_hash[:gcov_xml_report]
+    end
+
+    if html_enabled
+      if @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'basic'
+        puts "Creating a basic html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
+        command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [], filter)
+        @ceedling[:tool_executor].exec(command[:line], command[:options])
+      elsif @ceedling[:configurator].project_config_hash[:gcov_html_report_type] == 'detailed'
+        puts "Creating a detailed html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
+        command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_ADVANCED, [], filter)
+        @ceedling[:tool_executor].exec(command[:line], command[:options])
+
+      else
+        puts "In your project.yml, define: \n\n:gcov:\n  :html_report_type:\n\n to basic or detailed to refine this feature."
+        puts "For now, just creating basic."
+        puts "Creating a basic html report of gcov results in #{GCOV_ARTIFACTS_FILE}..."
+        command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_BASIC, [], filter)
+        @ceedling[:tool_executor].exec(command[:line], command[:options])
+      end
+    end
+
+    if xml_enabled
+      puts "Creating an xml report of gcov results in #{GCOV_ARTIFACTS_FILE_XML}..."
+      command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_POST_REPORT_XML, [], filter)
       @ceedling[:tool_executor].exec(command[:line], command[:options])
     end
+
     puts "Done."
   end
 end

--- a/plugins/gcov/lib/gcov_constants.rb
+++ b/plugins/gcov/lib/gcov_constants.rb
@@ -10,6 +10,7 @@ GCOV_DEPENDENCIES_PATH = File.join(GCOV_BUILD_PATH, "dependencies")
 GCOV_ARTIFACTS_PATH    = File.join(PROJECT_BUILD_ARTIFACTS_ROOT, GCOV_ROOT_NAME)
 
 GCOV_ARTIFACTS_FILE    = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverageResults.html")
+GCOV_ARTIFACTS_FILE_XML    = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverageResults.xml")
 
 GCOV_IGNORE_SOURCES    = %w(unity cmock cexception).freeze
 


### PR DESCRIPTION
Adds a new feature for #331. Now the gcov options support both enabling an xml report and enabling an xml report separately. 

```
:gcov:
    :html_report: TRUE
    :html_report_type: basic
    :xml_report: TRUE
```

If not supplied, all of the options above will have safe defaults (both reports enabled and basic html report type).