### PR TITLE
Refactor/project create

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,43 +29,71 @@ If bundler isn't installed on your system or you run into problems, you might ha
 
     > sudo gem install bundler
 
-Putting Ceedling Inside a New Project
-=====================================
+Creating A Project
+==================
 
-Ceedling can deploy all of its guts into a folder. This allows it
-to be used without having to worry about external dependencies.
-You don't have to worry about Ceedling changing for this particular
-project just because you updated your gems.
+Creating a project with Ceedling is easy. Simply tell ceedling the
+name of the project, and it will create a subdirectory called that
+name and fill it with a default directory structure and configuration.
 
     ceedling new YourNewProjectName
 
-This will install all of Unity, CMock, and Ceedling into a new folder
-named `YourNewProjectName`. It will also create a simple directory structure
-for you with `src` and `test` folders. SCORE! It also creates a sample
-`project.yml` file that you can tweak to your own needs. 
+You can add files to your src and test directories and they will
+instantly become part of your test build. Need a different structure?
+You can start to tweak the `project.yml` file immediately with your new
+path or tool requirements.
 
-It'll also include documentation for all of these tools, unless you
-specify `--nodocs` at when you issue the command above... then it skips
-that step for you.
+You can upgrade to the latest version of Ceedling at any time,
+automatically gaining access to the packaged Unity and CMock that
+come with it.
 
-Previous versions of Ceedling generated and depended on a `rakefile`, but that is no longer the case.
-Today, configuration is done with the `project.yml` file and the `ceedling`
-command is used to execute tests. Some old tutorials may still reference using `rake` commands, but
-the `ceedling` command should be used now, instead. For example, `ceedling test:all` will execute all tests. 
+    gem update ceedling
 
-Using Ceedling from a Ruby Gem
+Documentation
+=============
+
+Are you just getting started with Ceedling? Maybe you'd like your
+project to be installed with some of its handy documentation? No problem!
+You can do this when you create a new project.
+
+    ceedling new --docs MyAwesomeProject
+
+Bonding Your Tools And Project
 ==============================
 
-Ceedling can also be used as a gem. By installing it this way, you
-can automatically update to the latest version of Ceedling, Unity,
-and CMock just by running an update on your gems. Use this if you
-are only running one project OR if you feel you want to keep all
-your projects up to date.
+Ceedling can deploy all of its guts into the project as well. This
+allows it to be used without having to worry about external dependencies.
+You don't have to worry about Ceedling changing for this particular
+project just because you updated your gems... no need to worry about
+changes in Unity or CMock breaking your build in the future. If you'd like
+to use Ceedling this way, tell it you want a local copy when you create
+your project:
 
-    ceedling new YourNewProjectName --as_gem
+    ceedling new --local YourNewProjectName
 
-This creates a new folder named `YourNewProjectName`. Inside it will be your
-shiny new `project.yml` file and a couple of `src` and `test` directories
-to get you started. You can then tweak all of those things to your heart's
-content.
+This will install all of Unity, CMock, and Ceedling into a new folder
+named `vendor` inside your project `YourNewProjectName`. It will still create
+the simple directory structure for you with `src` and `test` folders.
 
+SCORE!
+
+If you want to force a locally installed version of Ceedling to upgrade
+to match your latest gem later, it's easy! Just issue the following command:
+
+    ceedling upgrade --local YourNewProjectName
+
+Just like the `new` command, it's called from the parent directory of your
+project.
+
+Are you afraid of losing all your local changes when this happens? You can keep
+Ceedling from updating your project file by issuing `no_configs`.
+
+    ceedling upgrade --local --no_configs TheProject
+
+Git Integration
+===============
+
+Are you using Git? You might want to automatically have Ceedling create a
+`gitignore` file for you by adding `--gitignore` to your `new` call.
+
+*HAPPY TESTING!*

--- a/bin/ceedling
+++ b/bin/ceedling
@@ -31,78 +31,91 @@ unless (project_found)
     include Thor::Actions
 
     desc "new PROJECT_NAME", "create a new ceedling project"
-    method_option :no_docs, :type => :boolean, :default => false, :desc => "No docs in vendor directory"
-    method_option :nodocs, :type => :boolean, :default => false
-    method_option :as_gem, :type => :boolean, :default => false, :desc => "Create the scaffold using Ceedling as a gem instead of filling in the vendor directory. Implies --no-docs."
-    method_option :asgem, :type => :boolean, :default => false
-    method_option :with_ignore, :type => :boolean, :default => false, :desc => "Create a gitignore file for ignoring ceedling generated files."
-    method_option :withignore, :type => :boolean, :default => false
-    method_option :no_configs, :type => :boolean, :default => false, :desc => "Don't install starter configuration files."
+    method_option :docs, :type => :boolean, :default => false, :desc => "Add docs in project vendor directory"
+    method_option :local, :type => :boolean, :default => false, :desc => "Create a copy of Ceedling in the project vendor directory"
+    method_option :gitignore, :type => :boolean, :default => false, :desc => "Create a gitignore file for ignoring ceedling generated files"
+    method_option :no_configs, :type => :boolean, :default => false, :desc => "Don't install starter configuration files"
     method_option :noconfigs, :type => :boolean, :default => false
+
+    #deprecated:
+    method_option :no_docs, :type => :boolean, :default => false
+    method_option :nodocs, :type => :boolean, :default => false
+    method_option :as_gem, :type => :boolean, :default => false
+    method_option :asgem, :type => :boolean, :default => false
+    method_option :with_ignore, :type => :boolean, :default => false
+    method_option :withignore, :type => :boolean, :default => false
     def new(name, silent = false)
       copy_assets_and_create_structure(name, silent, false, options)
     end
 
     desc "upgrade PROJECT_NAME", "upgrade ceedling for a project (not req'd if gem used)"
-    method_option :no_docs, :type => :boolean, :default => false, :desc => "No docs in vendor directory"
-    method_option :nodocs, :type => :boolean, :default => false
-    method_option :no_configs, :type => :boolean, :default => true, :desc => "Don't install starter configuration files."
+    method_option :docs, :type => :boolean, :default => false, :desc => "Add docs in project vendor directory"
+    method_option :local, :type => :boolean, :default => false, :desc => "Create a copy of Ceedling in the project vendor directory"
+    method_option :no_configs, :type => :boolean, :default => false, :desc => "Don't install starter configuration files"
     method_option :noconfigs, :type => :boolean, :default => false
+
+    #deprecated:
+    method_option :no_docs, :type => :boolean, :default => false
+    method_option :nodocs, :type => :boolean, :default => false
     def upgrade(name, silent = false)
-      copy_assets_and_create_structure(name, silent, true, options)
+      copy_assets_and_create_structure(name, silent, true, options || {:upgrade => true})
     end
 
     no_commands do
       def copy_assets_and_create_structure(name, silent=false, force=false, options = {})
 
-        no_docs     = options[:no_docs]     || options[:nodocs]     || false
-        no_configs  = options[:no_configs]  || options[:noconfigs]  || false
-        as_gem      = options[:as_gem]      || options[:asgem]      || false
-        with_ignore = options[:with_ignore] || options[:withignore] || false
+        puts "WARNING: --no_docs deprecated. It is now the default. Specify -docs if you want docs installed." if (options[:no_docs] || options[:nodocs])
+        puts "WARNING: --as_gem deprecated. It is now the default. Specify -local if you want ceedling installed to this project." if (options[:as_gem] || options[:asgem])
+        puts "WARNING: --with_ignore deprecated. It is now called -gitignore" if (options[:with_ignore] || options[:with_ignore])
+
+        use_docs     = options[:docs] || false
+        use_configs  = !(options[:no_configs] || options[:noconfigs] || false)
+        use_gem      = !(options[:local])
+        use_ignore   = options[:gitignore] || false
+        is_upgrade   = options[:upgrade] || false
 
         ceedling_path     = File.join(name, 'vendor', 'ceedling')
         source_path       = File.join(name, 'src')
         test_path         = File.join(name, 'test')
         test_support_path = File.join(name, 'test/support')
 
-        [source_path, test_path, test_support_path].each do |d|
-          FileUtils.mkdir_p d
+        # If it's not an upgrade, make sure we have the paths we expect
+        if (!is_upgrade)
+          [source_path, test_path, test_support_path].each do |d|
+            FileUtils.mkdir_p d
+          end
         end
 
-        unless as_gem
+        # If documentation requested, create a place to dump them and do so
+        if use_docs
+          doc_path = File.join(ceedling_path, 'docs')
+          FileUtils.mkdir_p doc_path
+
+          in_doc_path = lambda {|f| File.join(doc_path, f)}
+
+          doc_files = [
+                        'docs/CeedlingPacket.md',
+                        'vendor/c_exception/docs/CException.md',
+                        'vendor/cmock/docs/CMock_Summary.md',
+                        'vendor/unity/docs/UnityAssertionsCheatSheetSuitableforPrintingandPossiblyFraming.pdf',
+                        'vendor/unity/docs/UnityAssertionsReference.md',
+                        'vendor/unity/docs/UnityConfigurationGuide.md',
+                        'vendor/unity/docs/UnityGettingStartedGuide.md',
+                        'vendor/unity/docs/UnityHelperScriptsGuide.md',
+                        'vendor/unity/docs/ThrowTheSwitchCodingStandard.md',
+                      ]
+
+          doc_files.each do |f|
+            copy_file(f, in_doc_path.call(File.basename(f)), :force => force)
+          end
+        end
+
+        # If installed locally to project, copy ceedling, unity, cmock, & supports to vendor
+        unless use_gem
           FileUtils.mkdir_p ceedling_path
 
-          unless no_docs
-            doc_path = File.join(ceedling_path, 'docs')
-            FileUtils.mkdir_p doc_path
-
-            in_doc_path = lambda {|f| File.join(doc_path, f)}
-
-            doc_files = [
-                          'docs/CeedlingPacket.md',
-                          'vendor/c_exception/docs/CException.md',
-                          'vendor/cmock/docs/CMock_Summary.md',
-                          'vendor/unity/docs/UnityAssertionsCheatSheetSuitableforPrintingandPossiblyFraming.pdf',
-                          'vendor/unity/docs/UnityAssertionsReference.md',
-                          'vendor/unity/docs/UnityConfigurationGuide.md',
-                          'vendor/unity/docs/UnityGettingStartedGuide.md',
-                          'vendor/unity/docs/UnityHelperScriptsGuide.md',
-                          'vendor/unity/docs/ThrowTheSwitchCodingStandard.md',
-                        ]
-
-            doc_files.each do |f|
-              copy_file(f, in_doc_path.call(File.basename(f)), :force => force)
-            end
-          end
-
-          folders = if as_gem
-            %w{plugins lib}
-          else
-            %w{plugins lib bin}
-          end
-
           #copy full folders from ceedling gem into project
-          folders.map do |f|
+          %w{plugins lib}.map do |f|
             {:src => f, :dst => File.join(ceedling_path, f)}
           end.each do |f|
             directory(f[:src], f[:dst], :force => force)
@@ -128,8 +141,9 @@ unless (project_found)
           end
         end
 
+        # We're copying in a configuration file if we haven't said not to
         unless (no_configs)
-          if as_gem
+          if use_gem
             copy_file(File.join('assets', 'project_as_gem.yml'), File.join(name, 'project.yml'), :force => force)
           else
             copy_file(File.join('assets', 'project_with_guts.yml'), File.join(name, 'project.yml'), :force => force)
@@ -141,14 +155,15 @@ unless (project_found)
           end
         end
 
-        if (with_ignore)
+        # Copy the gitignore file if requested
+        if (gitignore)
           copy_file(File.join('assets', 'default_gitignore'), File.join(name, '.gitignore'), :force => force)
         end
 
         unless silent
           puts "\n"
           puts "Project '#{name}' #{force ? "upgraded" : "created"}!"
-          puts " - Tool documentation is located in vendor/ceedling/docs" if (not no_docs) and (not as_gem)
+          puts " - Tool documentation is located in vendor/ceedling/docs" if use_docs
           puts " - Execute 'ceedling help' to view available test & build tasks"
           puts ''
         end

--- a/bin/ceedling
+++ b/bin/ceedling
@@ -156,7 +156,7 @@ unless (project_found)
         end
 
         # Copy the gitignore file if requested
-        if (gitignore)
+        if (use_ignore)
           copy_file(File.join('assets', 'default_gitignore'), File.join(name, '.gitignore'), :force => force)
         end
 

--- a/bin/ceedling
+++ b/bin/ceedling
@@ -182,7 +182,7 @@ unless (project_found)
     def example(proj_name, dest=nil)
       if dest.nil? then dest = proj_name end
 
-      invoke :new, [dest, true]
+      copy_assets_and_create_structure(dest, true, false, {:local=>true, :docs=>true})
 
       dest_src      = File.join(dest,'src')
       dest_test     = File.join(dest,'test')

--- a/bin/ceedling
+++ b/bin/ceedling
@@ -142,7 +142,7 @@ unless (project_found)
         end
 
         # We're copying in a configuration file if we haven't said not to
-        unless (no_configs)
+        if (use_configs)
           if use_gem
             copy_file(File.join('assets', 'project_as_gem.yml'), File.join(name, 'project.yml'), :force => force)
           else

--- a/lib/ceedling/version.rb
+++ b/lib/ceedling/version.rb
@@ -2,7 +2,7 @@
 module Ceedling
   module Version
     # @private
-    GEM = "0.28.2"
+    GEM = "0.28.3"
     # @private
     CEEDLING = GEM
     # @private

--- a/spec/gcov/gcov_deployment_spec.rb
+++ b/spec/gcov/gcov_deployment_spec.rb
@@ -20,7 +20,7 @@ describe "Ceedling" do
     describe "basic operations" do
       before do
         @c.with_context do
-          `bundle exec ruby -S ceedling new #{@proj_name} 2>&1`
+          `bundle exec ruby -S ceedling new --local #{@proj_name} 2>&1`
         end
       end
 

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -196,7 +196,7 @@ module CeedlingTestCases
 
   def can_upgrade_projects
     @c.with_context do
-      output = `bundle exec ruby -S ceedling upgrade --local #{@proj_name} 2>&1`
+      output = `bundle exec ruby -S ceedling upgrade --local --docs #{@proj_name} 2>&1`
       expect($?.exitstatus).to match(0)
       expect(output).to match(/upgraded!/i)
       Dir.chdir @proj_name do

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -196,7 +196,7 @@ module CeedlingTestCases
 
   def can_upgrade_projects
     @c.with_context do
-      output = `bundle exec ruby -S ceedling upgrade #{@proj_name} 2>&1`
+      output = `bundle exec ruby -S ceedling upgrade --local #{@proj_name} 2>&1`
       expect($?.exitstatus).to match(0)
       expect(output).to match(/upgraded!/i)
       Dir.chdir @proj_name do

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -18,7 +18,7 @@ describe "Ceedling" do
   describe "deployed in a project's `vendor` directory." do
     before do
       @c.with_context do
-        `bundle exec ruby -S ceedling new #{@proj_name} 2>&1`
+        `bundle exec ruby -S ceedling new --local --docs #{@proj_name} 2>&1`
       end
     end
 
@@ -39,10 +39,10 @@ describe "Ceedling" do
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
   end
 
-  describe "deployed in a project's `vendor` directory." do
+  describe "deployed as gem with gitignore." do
     before do
       @c.with_context do
-        `bundle exec ruby -S ceedling new --with-ignore #{@proj_name} 2>&1`
+        `bundle exec ruby -S ceedling new --gitignore #{@proj_name} 2>&1`
       end
     end
 
@@ -59,7 +59,7 @@ describe "Ceedling" do
   describe "deployed in a project's `vendor` directory without docs." do
     before do
       @c.with_context do
-        `bundle exec ruby -S ceedling new --nodocs #{@proj_name} 2>&1`
+        `bundle exec ruby -S ceedling new --local #{@proj_name} 2>&1`
       end
     end
 
@@ -82,7 +82,7 @@ describe "Ceedling" do
   describe "ugrade a project's `vendor` directory" do
     before do
       @c.with_context do
-        `bundle exec ruby -S ceedling new --nodocs #{@proj_name} 2>&1`
+        `bundle exec ruby -S ceedling new --local #{@proj_name} 2>&1`
       end
     end
 
@@ -119,7 +119,7 @@ describe "Ceedling" do
   describe "deployed as a gem" do
     before do
       @c.with_context do
-        `bundle exec ruby -S ceedling new --as-gem #{@proj_name} 2>&1`
+        `bundle exec ruby -S ceedling new #{@proj_name} 2>&1`
       end
     end
 

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -39,10 +39,10 @@ describe "Ceedling" do
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
   end
 
-  describe "deployed as gem with gitignore." do
+  describe "deployed in a project's `vendor` directory with gitignore." do
     before do
       @c.with_context do
-        `bundle exec ruby -S ceedling new --gitignore #{@proj_name} 2>&1`
+        `bundle exec ruby -S ceedling new --local --docs --gitignore #{@proj_name} 2>&1`
       end
     end
 


### PR DESCRIPTION
It has come to my attention that Ceedling's default installation options are mostly backwards from the way most users want to work. Therefore I've switched the default behavior and changed the wording. 

Now, by default...

- Ceedling will run as a gem. To install it locally to your project, add `--local`. The `--as_gem` option is deprecated and will return a warning (but still be accepted).
- Ceedling will not install documentation to each project. To add the documentation, add `--docs`. The `--no_docs` option is deprecated and will return a warning (but still be accepted).
- The `--withignore` option has been renamed to `--gitignore` to make it more clear what type of ignore is being added. The old syntax is again deprecated but accepted.

