### PR TITLE
Safe JUnit XML report generation

### DIFF
--- a/plugins/junit_tests_report/lib/junit_tests_report.rb
+++ b/plugins/junit_tests_report/lib/junit_tests_report.rb
@@ -90,7 +90,14 @@ class JunitTestsReport < Plugin
 
     unless suite[:stdout].empty?
       stream.puts('    <system-out>')
-      suite[:stdout].each{|line| stream.puts line }
+      suite[:stdout].each do |line|
+        line.gsub!(/&/, '&amp;')
+        line.gsub!(/</, '&lt;')
+        line.gsub!(/>/, '&gt;')
+        line.gsub!(/"/, '&quot;')
+        line.gsub!(/'/, '&apos;')
+        stream.puts(line)
+      end
       stream.puts('    </system-out>')
     end
 


### PR DESCRIPTION
Added XML special character substitution to the JUnit report plugin so that special characters in stdout do not cause malformed XML.