### PR TITLE
Add library dependency support to gcov plugin

### DIFF
--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -14,6 +14,8 @@
       - -DCODE_COVERAGE
       - -c "${1}"
       - -o "${2}"
+      - -MMD
+      - -MF "${4}"
   :gcov_linker:
     :executable: gcc
     :arguments:
@@ -21,6 +23,7 @@
       - -ftest-coverage
       - ${1}
       - -o ${2}
+      - "${4}"
   :gcov_fixture:
     :executable: ${1}
   :gcov_report:

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -23,7 +23,8 @@ rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\' + EXTENSION_OBJECT}$/ => [
       GCOV_SYM,
       object.source,
       object.name,
-      @ceedling[:file_path_utils].form_test_build_list_filepath(object.name)
+      @ceedling[:file_path_utils].form_test_build_list_filepath(object.name),
+      @ceedling[:file_path_utils].form_test_dependencies_filepath(object.name)
     )
   else
     @ceedling[GCOV_SYM].generate_coverage_object_file(object.source, object.name)
@@ -31,12 +32,14 @@ rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\' + EXTENSION_OBJECT}$/ => [
 end
 
 rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\' + EXTENSION_EXECUTABLE}$/) do |bin_file|
+  lib_args = @ceedling[:test_invoker].convert_libraries_to_arguments()
   @ceedling[:generator].generate_executable_file(
     TOOLS_GCOV_LINKER,
     GCOV_SYM,
     bin_file.prerequisites,
     bin_file.name,
-    @ceedling[:file_path_utils].form_test_build_map_filepath(bin_file.name)
+    @ceedling[:file_path_utils].form_test_build_map_filepath(bin_file.name),
+    lib_args
   )
 end
 


### PR DESCRIPTION
Currently, it is possible to specify a set of libraries in `:libraries:` section of `project.yaml` that will be used during the linking step. Unfortunately, if you're also using `ceedling gcov:all` to obtain code coverage reports, test execution fails since libraries are not being linked into test executable. This PR attempts to address this problem.