### PR TITLE
Explicitly state in gcov when there are no coverage results for a file

### DIFF
--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -95,6 +95,12 @@ class Gcov < Plugin
         @ceedling[:streaminator].stdout_puts(report + "\n\n")
       end
     end
+
+    COLLECTION_ALL_SOURCE.each do |source|
+      unless coverage_sources.include?(source)
+        @ceedling[:streaminator].stdout_puts("Could not find coverage results for " + source + "\n")
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This helps to address part of #329. It does not try to mess with overall coverage results, but will now explicitly state when there are no results for a file. 

