### PR TITLE
Directly invoke test:all in test alias

### DIFF
--- a/lib/ceedling/tasks_tests.rake
+++ b/lib/ceedling/tasks_tests.rake
@@ -1,7 +1,7 @@
 require 'ceedling/constants'
 
 task :test => [:directories] do
-  @ceedling[:test_invoker].setup_and_invoke(COLLECTION_ALL_TESTS)
+  Rake.application['test:all'].invoke
 end
 
 namespace TEST_SYM do

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -260,6 +260,40 @@ module CeedlingTestCases
     end
   end
 
+  def can_test_projects_with_success_test_alias
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling test 2>&1`
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
+  def can_test_projects_with_success_default
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling 2>&1`
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
   def can_test_projects_with_fail
     @c.with_context do
       Dir.chdir @proj_name do
@@ -268,6 +302,39 @@ module CeedlingTestCases
         FileUtils.cp test_asset_path("test_example_file.c"), 'test/'
 
         output = `bundle exec ruby -S ceedling test:all 2>&1`
+        expect($?.exitstatus).to match(1) # Since a test fails, we return error here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+  def can_test_projects_with_fail_alias
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling test 2>&1`
+        expect($?.exitstatus).to match(1) # Since a test fails, we return error here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
+  def can_test_projects_with_fail_default
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling 2>&1`
         expect($?.exitstatus).to match(1) # Since a test fails, we return error here
         expect(output).to match(/TESTED:\s+\d/)
         expect(output).to match(/PASSED:\s+\d/)

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -28,7 +28,11 @@ describe "Ceedling" do
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
     it { can_test_projects_with_success }
+    it { can_test_projects_with_success_test_alias }
+    it { can_test_projects_with_success_default }
     it { can_test_projects_with_fail }
+    it { can_test_projects_with_fail_alias }
+    it { can_test_projects_with_fail_default }
     it { can_test_projects_with_compile_error }
     it { uses_raw_output_report_plugin }
     it { can_use_the_module_plugin }
@@ -70,7 +74,11 @@ describe "Ceedling" do
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
     it { can_test_projects_with_success }
+    it { can_test_projects_with_success_test_alias }
+    it { can_test_projects_with_success_default }
     it { can_test_projects_with_fail }
+    it { can_test_projects_with_fail_alias }
+    it { can_test_projects_with_fail_default }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
     it { can_use_the_module_plugin_path_extension }
@@ -93,7 +101,11 @@ describe "Ceedling" do
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
     it { can_test_projects_with_success }
+    it { can_test_projects_with_success_test_alias }
+    it { can_test_projects_with_success_default }
     it { can_test_projects_with_fail }
+    it { can_test_projects_with_fail_alias }
+    it { can_test_projects_with_fail_default }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
     it { can_use_the_module_plugin_path_extension }
@@ -108,7 +120,11 @@ describe "Ceedling" do
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
     it { can_test_projects_with_success }
+    it { can_test_projects_with_success_test_alias }
+    it { can_test_projects_with_success_default }
     it { can_test_projects_with_fail }
+    it { can_test_projects_with_fail_alias }
+    it { can_test_projects_with_fail_default }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }
     it { can_use_the_module_plugin_path_extension }
@@ -131,6 +147,8 @@ describe "Ceedling" do
     it { can_fetch_non_project_help }
     it { can_fetch_project_help }
     it { can_test_projects_with_success }
+    it { can_test_projects_with_success_test_alias }
+    it { can_test_projects_with_success_default }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }


### PR DESCRIPTION
This fixes #280 by directly invoking test:all when test is presented to make sure all hooks are triggered. Other plugins may need to follow suit if similar rake tasks are set up like this one.