### PR TITLE
Update default_gitignore with correct path to logs

### DIFF
--- a/assets/default_gitignore
+++ b/assets/default_gitignore
@@ -1,5 +1,5 @@
 build/artifacts
 build/gcov
-builld/logs 
+build/logs 
 build/temp
 build/test


### PR DESCRIPTION
Noticed the path to logs wasn't right. I just verified on my end that the logs directory got generated at `build/logs` and not `buildd/logs`