### PR TITLE
Exclude local copy of Ceedling vendor dir in GCov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ ceedling.sublime-workspace
 ceedling-*.gem
 .DS_Store
 .ruby-version
+/.idea
+/.vscode

--- a/plugins/gcov/lib/gcov_constants.rb
+++ b/plugins/gcov/lib/gcov_constants.rb
@@ -14,6 +14,6 @@ GCOV_ARTIFACTS_FILE_XML    = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverageResults
 
 GCOV_IGNORE_SOURCES    = %w(unity cmock cexception).freeze
 
-GCOV_FILTER_EXPR       = '^vendor.*|^build.*|^test.*|^lib.*'
+GCOV_FILTER_EXPR       = '.*[Cc]eedling.vendor.*|^vendor.*|^build.*|^test.*|^lib.*'
 
 


### PR DESCRIPTION
If you use local copy of Ceedling (--local argument), by default in the
GCov html report the local copy of the vendored Ceedling files are also
covered (unity.h, ...)

This change excludes the local Ceedling/vendor directory from the report.