### PR TITLE
Auto Link Deep Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ ceedling.sublime-workspace
 ceedling-*.gem
 .DS_Store
 .ruby-version
+
+/.idea
+/.vscode

--- a/lib/ceedling/generator.rb
+++ b/lib/ceedling/generator.rb
@@ -19,7 +19,7 @@ class Generator
 
 
   def generate_shallow_includes_list(context, file)
-    @preprocessinator.preprocess_shallow_includes(file)
+    @preprocessinator.preprocess_includes(file)
   end
 
   def generate_preprocessed_file(context, file)

--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -8,7 +8,7 @@ class Preprocessinator
 
   def setup
     # fashion ourselves callbacks @preprocessinator_helper can use
-    @preprocess_includes_proc = Proc.new { |filepath| self.preprocess_shallow_includes(filepath) }
+    @preprocess_includes_proc = Proc.new { |filepath| self.preprocess_includes(filepath) }
     @preprocess_file_proc     = Proc.new { |filepath| self.preprocess_file(filepath) }
   end
 
@@ -27,9 +27,9 @@ class Preprocessinator
     return mocks_list
   end
 
-  def preprocess_shallow_includes(filepath)
+  def preprocess_includes(filepath)
     dependencies_rule = @preprocessinator_includes_handler.form_shallow_dependencies_rule(filepath)
-    includes          = @preprocessinator_includes_handler.extract_shallow_includes(dependencies_rule)
+    includes, _        = @preprocessinator_includes_handler.extract_includes(dependencies_rule)
 
     @preprocessinator_includes_handler.write_shallow_includes_list(
       @file_path_utils.form_preprocessed_includes_list_filepath(filepath), includes)

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -65,7 +65,7 @@ class PreprocessinatorIncludesHandler
     mock_headers = []
     if ignore_list.length > 0
       mock_headers, processed_ignore_list = ignore_list.partition {|hdr| hdr =~ /^mock_/ }
-      stripped_mocked_list = mock_headers.map { |hdr| hdr.delete_prefix("mock_") }
+      stripped_mocked_list = mock_headers.map { |hdr| hdr.sub("mock_", "") }
       processed_ignore_list += stripped_mocked_list
       dependencies -= processed_ignore_list
       new_dependencies = dependencies.select do |d|
@@ -107,7 +107,7 @@ class PreprocessinatorIncludesHandler
     if @configurator.project_config_hash.has_key?(:project_auto_link_deep_dependencies) && @configurator.project_config_hash[:project_auto_link_deep_dependencies]
       # Find corresponding source files from removed header files (if they exist):
       removed_headers.find_all do |removed_header|
-        source_file = removed_header.delete_suffix(hdr_ext) + src_ext
+        source_file = removed_header.chomp(hdr_ext) + src_ext
         if File.exist?(source_file)
           other_make_rule = self.form_shallow_dependencies_rule(source_file)
           other_deps, ignore_list = self.extract_includes(other_make_rule, ignore_list + removed_headers + real_headers + mock_headers)


### PR DESCRIPTION
See: https://github.com/ThrowTheSwitch/Ceedling/issues/142

This PR adds a project level configuration flag to enable deep linking of dependencies.

Usage: in project.yml:
```
:project:
  ...
  :auto_link_deep_dependencies: TRUE
  ...
```


* Update .gitignore

* Initial approach to implement Deep Dependency linking

* Skip mocked headers in deep linking

* Fix failing rspec tests

* Add test to for ignore_list param

* Cleanup

* Add test for recursive call for deep recursion

* Rename function

* Avoid parsing dependencies multiple times