### PR TITLE
Feature/286 fix gcov linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ ceedling.sublime-workspace
 ceedling-*.gem
 .DS_Store
 .ruby-version
+
+/.idea
+/.vscode

--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -21,6 +21,7 @@
       - -ftest-coverage
       - ${1}
       - -o ${2}
+      - ${3}
   :gcov_fixture:
     :executable: ${1}
   :gcov_report:

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -31,11 +31,14 @@ rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\' + EXTENSION_OBJECT}$/ => [
 end
 
 rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\' + EXTENSION_EXECUTABLE}$/) do |bin_file|
+  lib_args = @ceedling[:test_invoker].convert_libraries_to_arguments()
+
   @ceedling[:generator].generate_executable_file(
     TOOLS_GCOV_LINKER,
     GCOV_SYM,
     bin_file.prerequisites,
     bin_file.name,
+    lib_args,
     @ceedling[:file_path_utils].form_test_build_map_filepath(bin_file.name)
   )
 end

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -22,13 +22,15 @@ class Gcov < Plugin
   end
 
   def generate_coverage_object_file(source, object)
+    lib_args = @ceedling[:test_invoker].convert_libraries_to_arguments()
     compile_command =
       @ceedling[:tool_executor].build_command_line(
         TOOLS_GCOV_COMPILER,
         @ceedling[:flaginator].flag_down(OPERATION_COMPILE_SYM, GCOV_SYM, source),
         source,
         object,
-        @ceedling[:file_path_utils].form_test_build_list_filepath(object)
+        @ceedling[:file_path_utils].form_test_build_list_filepath(object),
+        lib_args
       )
     @ceedling[:streaminator].stdout_puts("Compiling #{File.basename(source)} with coverage...")
     @ceedling[:tool_executor].exec(compile_command[:line], compile_command[:options])


### PR DESCRIPTION
Currently, when running Ceedling with GCov, the external libraries aren't linked, which makes the linker (ld) return an error.

This PR attempts to fix this issue.