### PR TITLE
Downcase test names for specific test definitions

### DIFF
--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -81,7 +81,7 @@ class TestInvoker
       begin
         @plugin_manager.pre_test( test )
         test_name ="#{File.basename(test)}".chomp('.c')
-        def_test_key="defines_#{test_name}"
+        def_test_key="defines_#{test_name.downcase}"
 
         # Re-define the project out path and pre-processor defines.
         if @configurator.project_config_hash.has_key?(def_test_key.to_sym)


### PR DESCRIPTION
Keys in project_config_hash are stored as a downcase names, therefore specific test definitions for test with uppercase names cannot be found (like for temp_sensor test names).
To fix it test definition is adjusted to match project_config_hash key.