### PR TITLE
Recompilation after change preprocessor definitions for specific tests

### DIFF
--- a/lib/ceedling/cacheinator.rb
+++ b/lib/ceedling/cacheinator.rb
@@ -26,16 +26,21 @@ class Cacheinator
     return cached_filepath
   end
 
-  
   def diff_cached_test_config?(hash)
     cached_filepath = @file_path_utils.form_test_build_cache_path(INPUT_CONFIGURATION_CACHE_FILE)
-    
+
     return @cacheinator_helper.diff_cached_config?( cached_filepath, hash )
+  end
+
+  def diff_cached_test_defines?(files)
+    cached_filepath = @file_path_utils.form_test_build_cache_path(DEFINES_DEPENDENCY_CACHE_FILE)
+
+    return @cacheinator_helper.diff_cached_defines?( cached_filepath, files )
   end
 
   def diff_cached_release_config?(hash)
     cached_filepath = @file_path_utils.form_release_build_cache_path(INPUT_CONFIGURATION_CACHE_FILE)
-    
+
     return @cacheinator_helper.diff_cached_config?( cached_filepath, hash )
   end
   

--- a/lib/ceedling/cacheinator_helper.rb
+++ b/lib/ceedling/cacheinator_helper.rb
@@ -8,5 +8,24 @@ class CacheinatorHelper
     return true if ( (@file_wrapper.exist?(cached_filepath)) and (!(@yaml_wrapper.load(cached_filepath) == hash)) )
     return false
   end
-  
+
+  def diff_cached_defines?(cached_filepath, files)
+    current_defines = COLLECTION_DEFINES_TEST_AND_VENDOR.reject(&:empty?)
+
+    current_dependency = Hash[files.collect { |source| [source, current_defines.dup] }]
+    if not @file_wrapper.exist?(cached_filepath)
+      @yaml_wrapper.dump(cached_filepath, current_dependency)
+      return false
+    end
+
+    dependencies = @yaml_wrapper.load(cached_filepath)
+    if dependencies.values_at(*current_dependency.keys) != current_dependency.values
+      dependencies.merge!(current_dependency)
+      @yaml_wrapper.dump(cached_filepath, dependencies)
+      return true
+    end
+
+    return false
+  end
+
 end

--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -63,7 +63,7 @@ DEFAULT_CEEDLING_MAIN_PROJECT_FILE = 'project.yml' unless defined?(DEFAULT_CEEDL
 DEFAULT_CEEDLING_USER_PROJECT_FILE = 'user.yml'    unless defined?(DEFAULT_CEEDLING_USER_PROJECT_FILE) # supplemental user config file
 
 INPUT_CONFIGURATION_CACHE_FILE     = 'input.yml'   unless defined?(INPUT_CONFIGURATION_CACHE_FILE)     # input configuration file dump
-
+DEFINES_DEPENDENCY_CACHE_FILE      = 'defines_dependency.yml' unless defined?(DEFINES_DEPENDENCY_CACHE_FILE) # preprocessor definitions for files
 
 TEST_ROOT_NAME    = 'test'                unless defined?(TEST_ROOT_NAME)
 TEST_TASK_ROOT    = TEST_ROOT_NAME + ':'  unless defined?(TEST_TASK_ROOT)

--- a/lib/ceedling/dependinator.rb
+++ b/lib/ceedling/dependinator.rb
@@ -38,20 +38,23 @@ class Dependinator
 
 
   def enhance_runner_dependencies(runner_filepath)
-    @rake_wrapper[runner_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed)
+    @rake_wrapper[runner_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
+      @project_config_manager.test_defines_changed)
   end
 
 
   def enhance_shallow_include_lists_dependencies(include_lists)
     include_lists.each do |include_list_filepath|
-      @rake_wrapper[include_list_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed)
+      @rake_wrapper[include_list_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
+        @project_config_manager.test_defines_changed)
     end
   end
 
 
   def enhance_preprocesed_file_dependencies(files)
     files.each do |filepath|
-      @rake_wrapper[filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed)
+      @rake_wrapper[filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
+        @project_config_manager.test_defines_changed)
     end
   end
 
@@ -59,7 +62,8 @@ class Dependinator
   def enhance_mock_dependencies(mocks_list)
     # if input configuration or ceedling changes, make sure these guys get rebuilt
     mocks_list.each do |mock_filepath|
-      @rake_wrapper[mock_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed)
+      @rake_wrapper[mock_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
+        @project_config_manager.test_defines_changed)
       @rake_wrapper[mock_filepath].enhance( @configurator.cmock_unity_helper )                    if (@configurator.cmock_unity_helper)
     end
   end
@@ -67,25 +71,28 @@ class Dependinator
 
   def enhance_dependencies_dependencies(dependencies)
     dependencies.each do |dependencies_filepath|
-      @rake_wrapper[dependencies_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed)
+      @rake_wrapper[dependencies_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
+        @project_config_manager.test_defines_changed)
     end
   end
 
 
   def enhance_test_build_object_dependencies(objects)
     objects.each do |object_filepath|
-      @rake_wrapper[object_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed)
+      @rake_wrapper[object_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
+        @project_config_manager.test_defines_changed)
     end
   end
 
 
   def enhance_results_dependencies(result_filepath)
-    @rake_wrapper[result_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed)
+    @rake_wrapper[result_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
+      @project_config_manager.test_defines_changed)
   end
 
 
   def setup_test_executable_dependencies(test, objects)
-    @rake_wrapper.create_file_task( @file_path_utils.form_test_executable_filepath(test), objects)
+    @rake_wrapper.create_file_task( @file_path_utils.form_test_executable_filepath(test), objects )
   end
 
 end

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -174,6 +174,7 @@ task_invoker:
     - dependinator
     - rake_utils
     - rake_wrapper
+    - project_config_manager
 
 flaginator:
   compose:

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -41,7 +41,9 @@ project_file_loader:
 project_config_manager:
   compose:
     - cacheinator
+    - configurator
     - yaml_wrapper
+    - file_wrapper
 
 cacheinator:
   compose:

--- a/lib/ceedling/project_config_manager.rb
+++ b/lib/ceedling/project_config_manager.rb
@@ -3,16 +3,17 @@ require 'ceedling/constants'
 
 class ProjectConfigManager
 
-  attr_reader   :options_files, :release_config_changed, :test_config_changed
+  attr_reader   :options_files, :release_config_changed, :test_config_changed, :test_defines_changed
   attr_accessor :config_hash
 
-  constructor :cacheinator, :yaml_wrapper
+  constructor :cacheinator, :configurator, :yaml_wrapper, :file_wrapper
 
 
   def setup
     @options_files = []
     @release_config_changed = false
     @test_config_changed    = false
+    @test_defines_changed   = false
   end
 
 
@@ -34,4 +35,12 @@ class ProjectConfigManager
     @test_config_changed = @cacheinator.diff_cached_test_config?( @config_hash )
   end
 
+  def process_test_defines_change(files)
+    # has definitions changed since last test build
+    @test_defines_changed = @cacheinator.diff_cached_test_defines?( files )
+    if @test_defines_changed
+      # update timestamp for rake task prerequisites
+      @file_wrapper.touch( @configurator.project_test_force_rebuild_filepath )
+    end
+  end
 end

--- a/lib/ceedling/rules_tests.rake
+++ b/lib/ceedling/rules_tests.rake
@@ -66,7 +66,7 @@ namespace TEST_SYM do
         @ceedling[:file_finder].find_test_from_file_path(test)
       end
   ]) do |test|
-    @ceedling[:rake_wrapper][:directories].reenable if @ceedling[:project_config_manager].test_defines_changed
+    @ceedling[:rake_wrapper][:directories].reenable if @ceedling[:task_invoker].first_run == false && @ceedling[:project_config_manager].test_defines_changed
     @ceedling[:rake_wrapper][:directories].invoke
     @ceedling[:test_invoker].setup_and_invoke([test.source])
   end

--- a/lib/ceedling/rules_tests.rake
+++ b/lib/ceedling/rules_tests.rake
@@ -66,6 +66,7 @@ namespace TEST_SYM do
         @ceedling[:file_finder].find_test_from_file_path(test)
       end
   ]) do |test|
+    @ceedling[:rake_wrapper][:directories].reenable if @ceedling[:project_config_manager].test_defines_changed
     @ceedling[:rake_wrapper][:directories].invoke
     @ceedling[:test_invoker].setup_and_invoke([test.source])
   end

--- a/lib/ceedling/task_invoker.rb
+++ b/lib/ceedling/task_invoker.rb
@@ -2,11 +2,14 @@ require 'ceedling/par_map'
 
 class TaskInvoker
 
-  constructor :dependinator, :rake_utils, :rake_wrapper
+  attr_accessor :first_run
+
+  constructor :dependinator, :rake_utils, :rake_wrapper, :project_config_manager
 
   def setup
     @test_regexs = [/^#{TEST_ROOT_NAME}:/]
     @release_regexs = [/^#{RELEASE_ROOT_NAME}(:|$)/]
+    @first_run = true
   end
   
   def add_test_task_regex(regex)
@@ -46,17 +49,22 @@ class TaskInvoker
   
   def invoke_test_mocks(mocks)
     @dependinator.enhance_mock_dependencies( mocks )
-    mocks.each { |mock| @rake_wrapper[mock].invoke }
+    mocks.each { |mock|
+      @rake_wrapper[mock].reenable if @first_run == false && @project_config_manager.test_defines_changed
+      @rake_wrapper[mock].invoke
+    }
   end
   
   def invoke_test_runner(runner)
     @dependinator.enhance_runner_dependencies( runner )
+    @rake_wrapper[runner].reenable if @first_run == false && @project_config_manager.test_defines_changed
     @rake_wrapper[runner].invoke
   end
 
   def invoke_test_shallow_include_lists(files)
     @dependinator.enhance_shallow_include_lists_dependencies( files )
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
+      @rake_wrapper[file].reenable if @first_run == false && @project_config_manager.test_defines_changed
       @rake_wrapper[file].invoke
     end
   end
@@ -64,6 +72,7 @@ class TaskInvoker
   def invoke_test_preprocessed_files(files)
     @dependinator.enhance_preprocesed_file_dependencies( files )
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
+      @rake_wrapper[file].reenable if @first_run == false && @project_config_manager.test_defines_changed
       @rake_wrapper[file].invoke
     end
   end
@@ -71,30 +80,33 @@ class TaskInvoker
   def invoke_test_dependencies_files(files)
     @dependinator.enhance_dependencies_dependencies( files )
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
+      @rake_wrapper[file].reenable if @first_run == false && @project_config_manager.test_defines_changed
       @rake_wrapper[file].invoke
     end
   end
 
   def invoke_test_objects(objects)
     par_map(PROJECT_COMPILE_THREADS, objects) do |object|
-       @rake_wrapper[object].invoke
+      @rake_wrapper[object].reenable if @first_run == false && @project_config_manager.test_defines_changed
+      @rake_wrapper[object].invoke
     end
   end
 
   def invoke_test_results(result)
     @dependinator.enhance_results_dependencies( result )
+    @rake_wrapper[result].reenable if @first_run == false && @project_config_manager.test_defines_changed
     @rake_wrapper[result].invoke
   end
 
   def invoke_release_dependencies_files(files)
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
-       @rake_wrapper[file].invoke
+      @rake_wrapper[file].invoke
     end
   end
   
   def invoke_release_objects(objects)
     par_map(PROJECT_COMPILE_THREADS, objects) do |object|
-       @rake_wrapper[object].invoke
+      @rake_wrapper[object].invoke
     end
   end
   

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -157,6 +157,8 @@ class TestInvoker
       # store away what's been processed
       @mocks.concat( mock_list )
       @sources.concat( sources )
+
+      @task_invoker.first_run = false
     end
 
     # post-process collected mock list

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -107,6 +107,8 @@ class TestInvoker
         results_pass = @file_path_utils.form_pass_results_filepath( test )
         results_fail = @file_path_utils.form_fail_results_filepath( test )
 
+        @project_config_manager.process_test_defines_change(sources)
+
         # add the definition value in the build option for the unit test
         if @configurator.defines_use_test_definition
           add_test_definition(test)


### PR DESCRIPTION
This PR helps to solve issue #369.
Preprocessor definitions for specific tests can be set in project.yml file.
Recompilation is needed when the same files are used for tests with changed definitions to avoid test failure caused by using by ceedling object files created in former compilation. To do this special file defines_dependency.yml in cache directory is created. This file contains dependencies between source files and the preprocessor definitions from the project.yml. Changing the definitions for file used in the current test compilation forcing recompilation for all sources. Rake rules are enhanced with force_build file with new timestamp. Tasks must be reenabled to correctly call dependent rake tasks.
Examples to demonstrate issue can be found here: [first_example](https://github.com/CezaryGapinski/multidefines_example/tree/master), [second example](https://github.com/CezaryGapinski/multidefines_example/tree/second_example).