### PR TITLE
Update documentation

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -1294,6 +1294,11 @@ Example [:extension] YAML blurb
 
   **Default**: [] (empty)
 
+* `use_test_definition`:
+
+  When this option is used the `-D<test_name>` flag is added to the build option of your test file.
+
+  **Default**: FALSE
 
 Example [:defines] YAML blurb
 

--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -1267,6 +1267,18 @@ Example [:extension] YAML blurb
 
   **Default**: [] (empty)
 
+* `<test_name>`:
+
+  Add preprocessor definitions for specified `<test_name>`. For example:
+```yaml
+  :defines:
+    :test_foo_config:
+      - FOO_SPECIFIC_FEATURE
+```
+  `ceedling test:foo_config` will now have `FOO_SPECIFIC_FEATURE` defined, none of the other tests will.
+
+  **Default**: [] (empty)
+
 * `release`:
 
   Defines needed for the release build binary artifact.

--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -524,7 +524,7 @@ void setUp(void) {}    // every test file requires this function;
                        // setUp() is called by the generated runner before each test case function
 
 void tearDown(void) {} // every test file requires this function;
-                       // tearDown() is called by the generated runner before each test case function
+                       // tearDown() is called by the generated runner after each test case function
 
 // a test case function
 void test_Foo_Function1_should_Call_Bar_AndGrill(void)


### PR DESCRIPTION
Add description about preprocessor definitions for tests and `use_test_definition` option.
There is also a small copy/pase fix in comment about `tearDown()` function.