### PR TITLE
Specific defintions refactor

### DIFF
--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -83,15 +83,11 @@ class TestInvoker
         test_name ="#{File.basename(test)}".chomp('.c')
         def_test_key="defines_#{test_name.downcase}"
 
-        # Re-define the project out path and pre-processor defines.
+        # redefine the project preprocessor definitions
         if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
           defs_bkp = Array.new(COLLECTION_DEFINES_TEST_AND_VENDOR)
           printf " ************** Specific test definitions for #{test_name} !!! \n"
           tst_defs_cfg = @configurator.project_config_hash[def_test_key.to_sym]
-
-          orig_path = @configurator.project_test_build_output_path
-          @configurator.project_config_hash[:project_test_build_output_path] = File.join(@configurator.project_test_build_output_path, test_name)
-          @file_wrapper.mkdir(@configurator.project_test_build_output_path)
           COLLECTION_DEFINES_TEST_AND_VENDOR.replace(tst_defs_cfg)
         end
 
@@ -145,8 +141,7 @@ class TestInvoker
         # restore the project test defines
         if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
           COLLECTION_DEFINES_TEST_AND_VENDOR.replace(defs_bkp)
-          @configurator.project_config_hash[:project_test_build_output_path] = orig_path
-          printf " ************** Restored defines and build path\n"
+          printf " ************** Restored defines\n"
         end
       end
 

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -86,7 +86,7 @@ class TestInvoker
         # redefine the project preprocessor definitions
         if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
           defs_bkp = Array.new(COLLECTION_DEFINES_TEST_AND_VENDOR)
-          printf " ************** Specific test definitions for #{test_name} !!! \n"
+          @streaminator.stdout_puts("******* Specific test definitions for #{test_name} *******\n", Verbosity::NORMAL)
           tst_defs_cfg = @configurator.project_config_hash[def_test_key.to_sym]
           COLLECTION_DEFINES_TEST_AND_VENDOR.replace(tst_defs_cfg)
         end
@@ -138,10 +138,10 @@ class TestInvoker
           delete_test_definition(test)
         end
         @plugin_manager.post_test( test )
-        # restore the project test defines
+        # restore the project test definitons
         if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
           COLLECTION_DEFINES_TEST_AND_VENDOR.replace(defs_bkp)
-          printf " ************** Restored defines\n"
+          @streaminator.stdout_puts("******* Restored test definitions *******\n", Verbosity::NORMAL)
         end
       end
 

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -85,7 +85,6 @@ class TestInvoker
 
         # Re-define the project out path and pre-processor defines.
         if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
-          @project_config_manager.test_config_changed
           defs_bkp = Array.new(COLLECTION_DEFINES_TEST_AND_VENDOR)
           printf " ************** Specific test definitions for #{test_name} !!! \n"
           tst_defs_cfg = @configurator.project_config_hash[def_test_key.to_sym]
@@ -94,7 +93,6 @@ class TestInvoker
           @configurator.project_config_hash[:project_test_build_output_path] = File.join(@configurator.project_test_build_output_path, test_name)
           @file_wrapper.mkdir(@configurator.project_test_build_output_path)
           COLLECTION_DEFINES_TEST_AND_VENDOR.replace(tst_defs_cfg)
-          # printf " *  new defines = #{COLLECTION_DEFINES_TEST_AND_VENDOR}\n"
         end
 
         # collect up test fixture pieces & parts
@@ -146,9 +144,7 @@ class TestInvoker
         @plugin_manager.post_test( test )
         # restore the project test defines
         if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
-          # @configurator.project_config_hash[:defines_test] =
           COLLECTION_DEFINES_TEST_AND_VENDOR.replace(defs_bkp)
-          # printf " ---- Restored defines at #{defs_bkp}"
           @configurator.project_config_hash[:project_test_build_output_path] = orig_path
           printf " ************** Restored defines and build path\n"
         end


### PR DESCRIPTION
Handful of fixes for specific test definitions procedure in `setup_and_invoke()`.
The most important is about subdirectory creation for output test file when custom preprocessor definitions are specified in `project.yml` which is in my opinion unnecessary.