### PR TITLE
utilize unity time results

### DIFF
--- a/lib/ceedling/generator_test_results.rb
+++ b/lib/ceedling/generator_test_results.rb
@@ -37,6 +37,10 @@ class GeneratorTestResults
         elements = extract_line_elements(line, results[:source][:file])
         results[:successes] << elements[0]
         results[:stdout] << elements[1] if (!elements[1].nil?)
+      when /(:PASS \(.* ms\)$)/
+        elements = extract_line_elements(line, results[:source][:file])
+        results[:successes] << elements[0]
+        results[:stdout] << elements[1] if (!elements[1].nil?)
       when /(:FAIL)/
         elements = extract_line_elements(line, results[:source][:file])
         results[:failures] << elements[0]
@@ -73,6 +77,7 @@ class GeneratorTestResults
     # handle anything preceding filename in line as extra output to be collected
     stdout = nil
     stdout_regex = /(.+)#{Regexp.escape(filename)}.+/i
+    unity_test_time = 0 
 
     if (line =~ stdout_regex)
       stdout = $1.clone
@@ -82,8 +87,14 @@ class GeneratorTestResults
     # collect up test results minus and extra output
     elements = (line.strip.split(':'))[1..-1]
 
-    return {:test => elements[1], :line => elements[0].to_i, :message => (elements[3..-1].join(':')).strip}, stdout if elements.size >= 3
-    return {:test => '???', :line => -1, :message => nil} #fallback safe option. TODO better handling
+    # find timestamp if available
+    if (elements[2] =~  / \((.*) ms\)/)
+      unity_test_time = $1.to_f / 1000
+      elements[2].sub!(/ \((.*) ms\)/, '') 
+    end
+
+    return {:test => elements[1], :line => elements[0].to_i, :message => (elements[3..-1].join(':')).strip, :unity_test_time => unity_test_time}, stdout if elements.size >= 3
+    return {:test => '???', :line => -1, :message => nil, :unity_test_time => unity_test_time} #fallback safe option. TODO better handling
   end
 
 end

--- a/plugins/junit_tests_report/lib/junit_tests_report.rb
+++ b/plugins/junit_tests_report/lib/junit_tests_report.rb
@@ -109,11 +109,12 @@ class JunitTestsReport < Plugin
 
   def write_test( test, stream )
     test[:test].gsub!('"', '&quot;')
+    pp test
     case test[:result]
     when :success
-      stream.puts('    <testcase name="%<test>s" />' % test)
+      stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>f"/>' % test)
     when :failed
-      stream.puts('    <testcase name="%<test>s">' % test)
+      stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>f">' % test)
       if test[:message].empty?
         stream.puts('      <failure />')
       else
@@ -121,7 +122,7 @@ class JunitTestsReport < Plugin
       end
       stream.puts('    </testcase>')
     when :ignored
-      stream.puts('    <testcase name="%<test>s">' % test)
+      stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>f">' % test)
       stream.puts('      <skipped />')
       stream.puts('    </testcase>')
     end

--- a/spec/support/test_example.fail
+++ b/spec/support/test_example.fail
@@ -7,9 +7,11 @@
 - :test: test_one
   :line: 257
   :message: ''
+  :unity_test_time: 0
 - :test: test_two
   :line: 269
   :message: ''
+  :unity_test_time: 0
 :ignores: []
 :counts:
   :total: 2

--- a/spec/support/test_example.pass
+++ b/spec/support/test_example.pass
@@ -6,9 +6,11 @@
 - :test: test_one
   :line: 257
   :message: ''
+  :unity_test_time: 0
 - :test: test_two
   :line: 269
   :message: ''
+  :unity_test_time: 0
 :failures: []
 :ignores: []
 :counts:

--- a/spec/support/test_example_ignore.pass
+++ b/spec/support/test_example_ignore.pass
@@ -8,9 +8,11 @@
 - :test: test_one
   :line: 257
   :message: ''
+  :unity_test_time: 0
 - :test: test_two
   :line: 269
   :message: ''
+  :unity_test_time: 0
 :counts:
   :total: 2
   :passed: 0

--- a/spec/support/test_example_mangled.pass
+++ b/spec/support/test_example_mangled.pass
@@ -6,6 +6,7 @@
 - :test: test_one
   :line: 257
   :message: ''
+  :unity_test_time: 0
 - 
 :failures: []
 :ignores: []

--- a/spec/support/test_example_with_time.pass
+++ b/spec/support/test_example_with_time.pass
@@ -6,9 +6,11 @@
 - :test: test_one
   :line: 257
   :message: ''
+  :unity_test_time: 0
 - :test: test_two
   :line: 269
   :message: ''
+  :unity_test_time: 0
 :failures: []
 :ignores: []
 :counts:

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -30,6 +30,7 @@ describe "Ceedling" do
     it { can_test_projects_with_success }
     it { can_test_projects_with_success_test_alias }
     it { can_test_projects_with_success_default }
+    it { can_test_projects_with_unity_exec_time }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_fail_alias }
     it { can_test_projects_with_fail_default }
@@ -76,6 +77,7 @@ describe "Ceedling" do
     it { can_test_projects_with_success }
     it { can_test_projects_with_success_test_alias }
     it { can_test_projects_with_success_default }
+    it { can_test_projects_with_unity_exec_time }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_fail_alias }
     it { can_test_projects_with_fail_default }
@@ -103,6 +105,7 @@ describe "Ceedling" do
     it { can_test_projects_with_success }
     it { can_test_projects_with_success_test_alias }
     it { can_test_projects_with_success_default }
+    it { can_test_projects_with_unity_exec_time }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_fail_alias }
     it { can_test_projects_with_fail_default }
@@ -122,6 +125,7 @@ describe "Ceedling" do
     it { can_test_projects_with_success }
     it { can_test_projects_with_success_test_alias }
     it { can_test_projects_with_success_default }
+    it { can_test_projects_with_unity_exec_time }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_fail_alias }
     it { can_test_projects_with_fail_default }
@@ -149,6 +153,7 @@ describe "Ceedling" do
     it { can_test_projects_with_success }
     it { can_test_projects_with_success_test_alias }
     it { can_test_projects_with_success_default }
+    it { can_test_projects_with_unity_exec_time }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }


### PR DESCRIPTION
This PR makes use of the test time functions in unity and makes it so the base usecases of Ceedling will work with it. 

Currently if UNITY_INCLUDE_EXEC_TIME is defined, the Ceedling sanity check will fail. After this PR, the sanity check will pass and the junit plugin will take advantage of the new outputs.
