### PR TITLE
removed debug print in junit and expanded xml escaped characters in junit test names

### DIFF
--- a/plugins/junit_tests_report/lib/junit_tests_report.rb
+++ b/plugins/junit_tests_report/lib/junit_tests_report.rb
@@ -108,8 +108,12 @@ class JunitTestsReport < Plugin
   end
 
   def write_test( test, stream )
-    test[:test].gsub!('"', '&quot;')
-    pp test
+    test[:test].gsub!(/&/, '&amp;')
+    test[:test].gsub!(/</, '&lt;')
+    test[:test].gsub!(/>/, '&gt;')
+    test[:test].gsub!(/"/, '&quot;')
+    test[:test].gsub!(/'/, '&apos;')
+
     case test[:result]
     when :success
       stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>f"/>' % test)


### PR DESCRIPTION
This removes the debug print in the junit along with scrubbing more xml escaped characters in junit test names.