### PR TITLE
Gcov fix code coverage summary

### DIFF
--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -16,7 +16,7 @@ rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\' + EXTENSION_OBJECT}$/ => [
        end
      ]) do |object|
 
-  if File.basename(object.source) =~ /^(#{PROJECT_TEST_FILE_PREFIX}|#{CMOCK_MOCK_PREFIX}|#{GCOV_IGNORE_SOURCES.join('|')})/i
+  if File.basename(object.source) =~ /^(#{PROJECT_TEST_FILE_PREFIX}|#{CMOCK_MOCK_PREFIX})|(#{GCOV_IGNORE_SOURCES.map{|source| '\b' + source + '\b'}.join('|')})/
     @ceedling[:generator].generate_object_file(
       TOOLS_GCOV_COMPILER,
       OPERATION_COMPILE_SYM,

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -84,7 +84,7 @@ class Gcov < Plugin
 
     coverage_sources = sources.clone
     coverage_sources.delete_if { |item| item =~ /#{CMOCK_MOCK_PREFIX}.+#{EXTENSION_SOURCE}$/ }
-    coverage_sources.delete_if { |item| item =~ /#{GCOV_IGNORE_SOURCES.join('|')}#{EXTENSION_SOURCE}$/ }
+    coverage_sources.delete_if { |item| item =~ /#{GCOV_IGNORE_SOURCES.map{|source| '\b' + source.ext(EXTENSION_SOURCE) + '\b'}.join('|')}$/ }
 
     coverage_sources.each do |source|
       basename         = File.basename(source)

--- a/plugins/gcov/lib/gcov_constants.rb
+++ b/plugins/gcov/lib/gcov_constants.rb
@@ -12,7 +12,7 @@ GCOV_ARTIFACTS_PATH    = File.join(PROJECT_BUILD_ARTIFACTS_ROOT, GCOV_ROOT_NAME)
 GCOV_ARTIFACTS_FILE    = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverageResults.html")
 GCOV_ARTIFACTS_FILE_XML    = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverageResults.xml")
 
-GCOV_IGNORE_SOURCES    = %w(unity cmock cexception).freeze
+GCOV_IGNORE_SOURCES    = %w(unity UnityHelper cmock cexception).freeze
 
 GCOV_FILTER_EXCLUDE    = '^vendor.*|^build.*|^test.*|^lib.*'
 


### PR DESCRIPTION
Two changes for gcov report:
- Regular expression should looks like this:
\bunity.c\b|\bcmock.c\b|\bcexception.c\b
to match exact source files with this names not sources with substring contains these words.
Previous expression:
unity|cmock|cexcpetion.c
cause removing files from GCOV: CODE COVERAGE SUMMARY when the source file contains 'unity' or 'cmock' substring in its name.

- UnityHelper.c file is not filtered in report_per_file_coverage_results() method what cause 'build/gcov/out/UnityHelper.gcno:no functions found' message in GCOV: CODE COVERAGE SUMMARY

The same issue is for bullseye, but unfortunately I do not have a licence to this tool to test these changes.