### PR TITLE
Restore run tests for test:all task

### DIFF
--- a/lib/ceedling/tasks_tests.rake
+++ b/lib/ceedling/tasks_tests.rake
@@ -8,7 +8,7 @@ namespace TEST_SYM do
 
   desc "Run all unit tests (also just 'test' works)."
   task :all => [:directories] do
-    @ceedling[:test_invoker].setup_and_invoke(COLLECTION_ALL_TESTS, TEST_SYM, {:force_run => false})
+    @ceedling[:test_invoker].setup_and_invoke(COLLECTION_ALL_TESTS)
   end
 
   desc "Run single test ([*] real test or source file name, no path)."


### PR DESCRIPTION
As mentioned in #424 test:all should always run all tests even if nothing changed in sources.
TEST_SYM, and force_run => true are default options for setup_and_invoke() method.