### PR TITLE
Preprocessor defines for tests fixes

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -1300,7 +1300,7 @@ Example [:extension] YAML blurb
 
 * `use_test_definition`:
 
-  When this option is used the `-D<test_name>` flag is added to the build option of your test file.
+  When this option is used the `-D<test_name>` flag is added to the build option.
 
   **Default**: FALSE
 

--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -95,3 +95,5 @@ NULL_FILE_PATH = '/dev/null'
 
 TESTS_BASE_PATH   = TEST_ROOT_NAME
 RELEASE_BASE_PATH = RELEASE_ROOT_NAME
+
+VENDORS_FILES = %w(unity UnityHelper cmock cexception).freeze

--- a/lib/ceedling/dependinator.rb
+++ b/lib/ceedling/dependinator.rb
@@ -86,8 +86,7 @@ class Dependinator
 
 
   def enhance_results_dependencies(result_filepath)
-    @rake_wrapper[result_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
-      @project_config_manager.test_defines_changed)
+    @rake_wrapper[result_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if @project_config_manager.test_config_changed
   end
 
 

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -17,11 +17,11 @@ reportinator:
 
 rake_utils:
   compose:
-    - rake_wrapper  
+    - rake_wrapper
 
 system_utils:
   compose:
-    - system_wrapper  
+    - system_wrapper
 
 file_path_utils:
   compose:
@@ -203,13 +203,13 @@ generator_helper:
 
 generator_test_results:
   compose:
-    - configurator  
+    - configurator
     - generator_test_results_sanity_checker
-    - yaml_wrapper  
+    - yaml_wrapper
 
 generator_test_results_sanity_checker:
   compose:
-    - configurator  
+    - configurator
     - streaminator
 
 generator_test_runner:
@@ -223,43 +223,44 @@ dependinator:
     - configurator
     - project_config_manager
     - test_includes_extractor
-    - file_path_utils        
+    - file_path_utils 
     - rake_wrapper
     - file_wrapper
 
 preprocessinator:
   compose:
-    - preprocessinator_helper          
+    - preprocessinator_helper
     - preprocessinator_includes_handler
     - preprocessinator_file_handler
-    - task_invoker    
+    - task_invoker
     - file_path_utils
     - yaml_wrapper
+    - project_config_manager
 
 preprocessinator_helper:
-  compose:                    
-    - configurator            
-    - test_includes_extractor 
-    - task_invoker            
-    - file_finder             
-    - file_path_utils         
+  compose:
+    - configurator
+    - test_includes_extractor
+    - task_invoker
+    - file_finder
+    - file_path_utils
 
 preprocessinator_includes_handler:
   compose:
-    - configurator    
-    - tool_executor   
-    - task_invoker    
-    - file_path_utils 
-    - yaml_wrapper    
-    - file_wrapper    
+    - configurator
+    - tool_executor
+    - task_invoker
+    - file_path_utils
+    - yaml_wrapper
+    - file_wrapper
 
 preprocessinator_file_handler:
   compose:
     - preprocessinator_extractor
-    - configurator   
-    - tool_executor  
+    - configurator
+    - tool_executor
     - file_path_utils
-    - file_wrapper   
+    - file_wrapper
 
 preprocessinator_extractor:
 

--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -3,7 +3,7 @@ class Preprocessinator
 
   attr_reader :preprocess_file_proc
   
-  constructor :preprocessinator_helper, :preprocessinator_includes_handler, :preprocessinator_file_handler, :task_invoker, :file_path_utils, :yaml_wrapper
+  constructor :preprocessinator_helper, :preprocessinator_includes_handler, :preprocessinator_file_handler, :task_invoker, :file_path_utils, :yaml_wrapper, :project_config_manager
 
 
   def setup
@@ -17,6 +17,8 @@ class Preprocessinator
     @preprocessinator_helper.preprocess_includes(test, @preprocess_includes_proc)
 
     mocks_list = @preprocessinator_helper.assemble_mocks_list(test)
+
+    @project_config_manager.process_test_defines_change(mocks_list)
 
     @preprocessinator_helper.preprocess_mockable_headers(mocks_list, @preprocess_file_proc)
 

--- a/lib/ceedling/project_config_manager.rb
+++ b/lib/ceedling/project_config_manager.rb
@@ -21,9 +21,15 @@ class ProjectConfigManager
     @options_files << File.basename( option_filepath )
     config_hash.deep_merge!( @yaml_wrapper.load( option_filepath ) )
   end 
-  
 
-  
+
+  def filter_internal_sources(sources)
+    filtered_sources = sources.clone
+    filtered_sources.delete_if { |item| item =~ /#{CMOCK_MOCK_PREFIX}.+#{EXTENSION_SOURCE}$/ }
+    filtered_sources.delete_if { |item| item =~ /#{VENDORS_FILES.map{|source| '\b' + source.ext(EXTENSION_SOURCE) + '\b'}.join('|')}$/ }
+    return filtered_sources
+  end
+
   def process_release_config_change
     # has project configuration changed since last release build
     @release_config_changed = @cacheinator.diff_cached_release_config?( @config_hash )

--- a/lib/ceedling/rules_tests.rake
+++ b/lib/ceedling/rules_tests.rake
@@ -66,7 +66,6 @@ namespace TEST_SYM do
         @ceedling[:file_finder].find_test_from_file_path(test)
       end
   ]) do |test|
-    @ceedling[:rake_wrapper][:directories].reenable if @ceedling[:task_invoker].first_run == false && @ceedling[:project_config_manager].test_defines_changed
     @ceedling[:rake_wrapper][:directories].invoke
     @ceedling[:test_invoker].setup_and_invoke([test.source])
   end

--- a/lib/ceedling/task_invoker.rb
+++ b/lib/ceedling/task_invoker.rb
@@ -98,7 +98,6 @@ class TaskInvoker
 
   def invoke_test_results(result)
     @dependinator.enhance_results_dependencies( result )
-    @rake_wrapper[result].reenable if @first_run == false && @project_config_manager.test_defines_changed
     @rake_wrapper[result].invoke
   end
 

--- a/lib/ceedling/task_invoker.rb
+++ b/lib/ceedling/task_invoker.rb
@@ -46,25 +46,31 @@ class TaskInvoker
     return @rake_utils.task_invoked?(regex)
   end
 
-  
+  def reset_rake_task_for_changed_defines(file)
+    if !(file =~ /#{VENDORS_FILES.map{|ignore| '\b' + ignore.ext(File.extname(file)) + '\b'}.join('|')}$/)
+      @rake_wrapper[file].clear_actions if @first_run == false && @project_config_manager.test_defines_changed
+      @rake_wrapper[file].reenable if @first_run == false && @project_config_manager.test_defines_changed
+    end
+  end
+
   def invoke_test_mocks(mocks)
     @dependinator.enhance_mock_dependencies( mocks )
     mocks.each { |mock|
-      @rake_wrapper[mock].reenable if @first_run == false && @project_config_manager.test_defines_changed
+      reset_rake_task_for_changed_defines( mock )
       @rake_wrapper[mock].invoke
     }
   end
   
   def invoke_test_runner(runner)
     @dependinator.enhance_runner_dependencies( runner )
-    @rake_wrapper[runner].reenable if @first_run == false && @project_config_manager.test_defines_changed
+    reset_rake_task_for_changed_defines( runner )
     @rake_wrapper[runner].invoke
   end
 
   def invoke_test_shallow_include_lists(files)
     @dependinator.enhance_shallow_include_lists_dependencies( files )
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
-      @rake_wrapper[file].reenable if @first_run == false && @project_config_manager.test_defines_changed
+      reset_rake_task_for_changed_defines( file )
       @rake_wrapper[file].invoke
     end
   end
@@ -72,7 +78,7 @@ class TaskInvoker
   def invoke_test_preprocessed_files(files)
     @dependinator.enhance_preprocesed_file_dependencies( files )
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
-      @rake_wrapper[file].reenable if @first_run == false && @project_config_manager.test_defines_changed
+      reset_rake_task_for_changed_defines( file )
       @rake_wrapper[file].invoke
     end
   end
@@ -80,14 +86,14 @@ class TaskInvoker
   def invoke_test_dependencies_files(files)
     @dependinator.enhance_dependencies_dependencies( files )
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
-      @rake_wrapper[file].reenable if @first_run == false && @project_config_manager.test_defines_changed
+      reset_rake_task_for_changed_defines( file )
       @rake_wrapper[file].invoke
     end
   end
 
   def invoke_test_objects(objects)
     par_map(PROJECT_COMPILE_THREADS, objects) do |object|
-      @rake_wrapper[object].reenable if @first_run == false && @project_config_manager.test_defines_changed
+      reset_rake_task_for_changed_defines( object )
       @rake_wrapper[object].invoke
     end
   end

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -23,36 +23,6 @@ class TestInvoker
     @mocks   = []
   end
 
-  def get_test_definition_str(test)
-    return "-D" + File.basename(test, File.extname(test)).upcase.sub(/@.*$/, "")
-  end
-
-  def get_tools_compilers
-    tools_compilers = Hash.new
-    tools_compilers["for unit test"] = TOOLS_TEST_COMPILER if defined? TOOLS_TEST_COMPILER
-    tools_compilers["for gcov"]      = TOOLS_GCOV_COMPILER if defined? TOOLS_GCOV_COMPILER
-    return tools_compilers
-  end
-
-  def add_test_definition(test)
-    test_definition_str = get_test_definition_str(test)
-    get_tools_compilers.each do |tools_compiler_key, tools_compiler_value|
-      tools_compiler_value[:arguments].push("-D#{File.basename(test, ".*").strip.upcase.sub(/@.*$/, "")}")
-      @streaminator.stdout_puts("Add the definition value in the build option #{tools_compiler_value[:arguments][-1]} #{tools_compiler_key}", Verbosity::OBNOXIOUS)
-    end
-  end
-
-  def delete_test_definition(test)
-    test_definition_str = get_test_definition_str(test)
-    get_tools_compilers.each do |tools_compiler_key, tools_compiler_value|
-      num_options = tools_compiler_value[:arguments].size
-      @streaminator.stdout_puts("Delete the definition value in the build option #{tools_compiler_value[:arguments][-1]} #{tools_compiler_key}", Verbosity::OBNOXIOUS)
-      tools_compiler_value[:arguments].delete_if{|i| i == test_definition_str}
-      if num_options > tools_compiler_value[:arguments].size + 1
-        @streaminator.stderr_puts("WARNING: duplicated test definition.")
-      end
-    end
-  end
 
   # Convert libraries configuration form YAML configuration
   # into a string that can be given to the compiler.
@@ -83,18 +53,24 @@ class TestInvoker
         test_name ="#{File.basename(test)}".chomp('.c')
         def_test_key="defines_#{test_name.downcase}"
 
-        # Re-define the project out path and pre-processor defines.
-        if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
-          @project_config_manager.test_config_changed
+        if @configurator.project_config_hash.has_key?(def_test_key.to_sym) || @configurator.defines_use_test_definition
           defs_bkp = Array.new(COLLECTION_DEFINES_TEST_AND_VENDOR)
-          printf " ************** Specific test definitions for #{test_name} !!! \n"
-          tst_defs_cfg = @configurator.project_config_hash[def_test_key.to_sym]
+          tst_defs_cfg = Array.new(defs_bkp)
+          if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
+            tst_defs_cfg.replace(@configurator.project_config_hash[def_test_key.to_sym])
+          end
+          if @configurator.defines_use_test_definition
+            tst_defs_cfg << File.basename(test, ".*").strip.upcase.sub(/@.*$/, "")
+          end
+          COLLECTION_DEFINES_TEST_AND_VENDOR.replace(tst_defs_cfg)
+        end
 
+        # redefine the project out path and preprocessor defines
+        if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
+          printf " ************** Specific test definitions for #{test_name} !!! \n"
           orig_path = @configurator.project_test_build_output_path
           @configurator.project_config_hash[:project_test_build_output_path] = File.join(@configurator.project_test_build_output_path, test_name)
           @file_wrapper.mkdir(@configurator.project_test_build_output_path)
-          COLLECTION_DEFINES_TEST_AND_VENDOR.replace(tst_defs_cfg)
-          # printf " *  new defines = #{COLLECTION_DEFINES_TEST_AND_VENDOR}\n"
         end
 
         # collect up test fixture pieces & parts
@@ -108,11 +84,6 @@ class TestInvoker
         results_fail = @file_path_utils.form_fail_results_filepath( test )
 
         @project_config_manager.process_test_defines_change(@project_config_manager.filter_internal_sources(sources))
-
-        # add the definition value in the build option for the unit test
-        if @configurator.defines_use_test_definition
-          add_test_definition(test)
-        end
 
         # clean results files so we have a missing file with which to kick off rake's dependency rules
         @test_invoker_helper.clean_results( {:pass => results_pass, :fail => results_fail}, options )
@@ -146,18 +117,14 @@ class TestInvoker
       rescue => e
         @build_invoker_utils.process_exception( e, context )
       ensure
-        # delete the definition value in the build option for the unit test
-        if @configurator.defines_use_test_definition
-          delete_test_definition(test)
-        end
         @plugin_manager.post_test( test )
         # restore the project test defines
-        if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
-          # @configurator.project_config_hash[:defines_test] =
+        if @configurator.project_config_hash.has_key?(def_test_key.to_sym) || @configurator.defines_use_test_definition
           COLLECTION_DEFINES_TEST_AND_VENDOR.replace(defs_bkp)
-          # printf " ---- Restored defines at #{defs_bkp}"
-          @configurator.project_config_hash[:project_test_build_output_path] = orig_path
-          printf " ************** Restored defines and build path\n"
+          if @configurator.project_config_hash.has_key?(def_test_key.to_sym) 
+            @configurator.project_config_hash[:project_test_build_output_path] = orig_path
+            printf " ************** Restored defines and build path\n"
+          end
         end
       end
 

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -107,7 +107,7 @@ class TestInvoker
         results_pass = @file_path_utils.form_pass_results_filepath( test )
         results_fail = @file_path_utils.form_fail_results_filepath( test )
 
-        @project_config_manager.process_test_defines_change(sources)
+        @project_config_manager.process_test_defines_change(@project_config_manager.filter_internal_sources(sources))
 
         # add the definition value in the build option for the unit test
         if @configurator.defines_use_test_definition

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -16,7 +16,7 @@ rule(/#{GCOV_BUILD_OUTPUT_PATH}\/#{'.+\\' + EXTENSION_OBJECT}$/ => [
        end
      ]) do |object|
 
-  if File.basename(object.source) =~ /^(#{PROJECT_TEST_FILE_PREFIX}|#{CMOCK_MOCK_PREFIX})|(#{GCOV_IGNORE_SOURCES.map{|source| '\b' + source + '\b'}.join('|')})/
+  if File.basename(object.source) =~ /^(#{PROJECT_TEST_FILE_PREFIX}|#{CMOCK_MOCK_PREFIX})|(#{VENDORS_FILES.map{|source| '\b' + source + '\b'}.join('|')})/
     @ceedling[:generator].generate_object_file(
       TOOLS_GCOV_COMPILER,
       OPERATION_COMPILE_SYM,

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -82,10 +82,7 @@ class Gcov < Plugin
     banner = @ceedling[:plugin_reportinator].generate_banner "#{GCOV_ROOT_NAME.upcase}: CODE COVERAGE SUMMARY"
     @ceedling[:streaminator].stdout_puts "\n" + banner
 
-    coverage_sources = sources.clone
-    coverage_sources.delete_if { |item| item =~ /#{CMOCK_MOCK_PREFIX}.+#{EXTENSION_SOURCE}$/ }
-    coverage_sources.delete_if { |item| item =~ /#{GCOV_IGNORE_SOURCES.map{|source| '\b' + source.ext(EXTENSION_SOURCE) + '\b'}.join('|')}$/ }
-
+    coverage_sources = @ceedling[:project_config_manager].filter_internal_sources(sources)
     coverage_sources.each do |source|
       basename         = File.basename(source)
       command          = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_REPORT, [], [basename])

--- a/plugins/gcov/lib/gcov_constants.rb
+++ b/plugins/gcov/lib/gcov_constants.rb
@@ -14,6 +14,4 @@ GCOV_ARTIFACTS_FILE_COBERTURA   = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverageCo
 GCOV_ARTIFACTS_FILE_SONARQUBE   = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverageSonarQube.xml")
 GCOV_ARTIFACTS_FILE_JSON        = File.join(GCOV_ARTIFACTS_PATH, "GcovCoverage.json")
 
-GCOV_IGNORE_SOURCES             = %w(unity UnityHelper cmock cexception).freeze
-
 GCOV_FILTER_EXCLUDE             = '^vendor.*|^build.*|^test.*|^lib.*'


### PR DESCRIPTION
This Pull Request fixing issues related to compilation procedure for changed preprocessor definitions for tests.

- Invoke_test_preprocessed_files() and invoke_test_mocks() were called before processing preprocessor definitions changes. Changed defines must be checked separately before this methods.

- When defines have changed clear actions to correctly generate files. The issue was discovered for mocks, where header for mock is placed in cache. When prerequisites for mock are called then header from prerequisites is compared between current cached file and generated preprocessed file from `preprocess/files` directory.
When mock is generated once, and must be generated again because defines changes, method find_header_input_for_mock_file() to compare cache and preprocessed file for rule /#{CMOCK_MOCK_PREFIX}[^\/\\]+#{'\\'+EXTENSION_SOURCE}$/ is not called again.
Clear action for rake task helps to solve this issue and find_header_input_for_mock_file() is called again. We cannot use clear method for rake task, because prerequisites are already collected.
The same for other rake tasks.
Example to show this issue is placed [here](https://github.com/CezaryGapinski/multidefines_example/tree/test_temp_sensor_mock_defines_changed).
Steps to reproduce:
1. Run ceedling clobber
2. Run ceedling test:all
3. Rerun ceedling test:all <- mock for TestAdcHardwareSpecial is incorrect and do not have Adc_ResetDummy function to mock

- Ignore unity, cmock, files during compilation for changed defines. This files are profided by vendors and do not have to be updated after project specific defines changes.

- Based on TE-HiroakiYamazoe#2 and PR #88 preprocessor define with test name should be added to all source files not only for test file to recompile correctly sources for the new define. This is the same problem like in #369
Lets put use_test_definitions to be handled like the standard behavior for changed defines. Code will be much simpler, and it just works.
Example to show issue is placed [here](https://github.com/CezaryGapinski/multidefines_example/tree/use_test_definition_example).
Steps to reproduce:
1. Run ceedling clobber to be sure that all temp files will be deleted.
2. Run ceedling test:all <- foo.c is not recompiled and we have multiple definitions for FOO_func1 and undefined reference to FOO_func2

The easiest way is to check for current master branch and for these fixes to compare results.