### PR TITLE
Fix convert_libraries_to_arguments() to not overwrite project config

### DIFF
--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -58,7 +58,7 @@ class TestInvoker
   # into a string that can be given to the compiler.
   def convert_libraries_to_arguments()
     if @configurator.project_config_hash.has_key?(:libraries_test)
-      lib_args = @configurator.project_config_hash[:libraries_test]
+      lib_args = @configurator.project_config_hash[:libraries_test].clone
       lib_args.flatten!
       lib_flag = @configurator.project_config_hash[:libraries_flag]
       lib_args.map! {|v| lib_flag.gsub(/\$\{1\}/, v) } if (defined? lib_flag)


### PR DESCRIPTION
Project config_hash can be overwritten in convert_libraries_to_arguments() because lib_args works on original config_hash.
project.yml won't match to input.yml in @project_config_manager.process_test_config_change even if nothing has changed in the project.yml

Steps to reproduce:
1. Add to project.yml libraries section:
:libraries:
  :placement: :end
  :flag: "${1}"  # or "-L ${1}" for example
  :common: &common_libraries []
  :test:
    - *common_libraries
  :release:
    - *common_libraries

2. Check @project_config_manager.config_hash[:libraries][:test][0] before call convert_libraries_to_arguments() - there is one empty element in the array
3. Check after convert_libraries_to_arguments() call - there is no empty element.
4. Overwritten config_hash is written to cache input.yml file
5. After next call ceedling test:all the project.yml won't match to input.yml in @project_config_manager.process_test_config_change even if nothing has changed in project.yml.