### PR TITLE
Implement an abort-on-uncovered option to gcov

### DIFF
--- a/assets/project_with_guts_gcov_abortonuncovered.yml
+++ b/assets/project_with_guts_gcov_abortonuncovered.yml
@@ -1,0 +1,93 @@
+---
+
+# Notes:
+# Sample project C code is not presently written to produce a release artifact.
+# As such, release build options are disabled.
+# This sample, therefore, only demonstrates running a collection of unit tests.
+
+:project:
+  :use_exceptions: FALSE
+  :use_test_preprocessor: TRUE
+  :use_auxiliary_dependencies: TRUE
+  :build_root: build
+#  :release_build: TRUE
+  :test_file_prefix: test_
+  :which_ceedling: vendor/ceedling
+  :ceedling_version: '?'
+  :default_tasks:
+    - test:all
+
+:environment:
+
+:extension:
+  :executable: .out
+
+:paths:
+  :test:
+    - +:test/**
+    - -:test/support
+  :source:
+    - src/**
+  :support:
+    - test/support
+
+:defines:
+  # in order to add common defines:
+  #  1) remove the trailing [] from the :common: section
+  #  2) add entries to the :common: section (e.g. :test: has TEST defined)
+  :common: &common_defines []
+  :test:
+    - *common_defines
+    - TEST
+  :test_preprocess:
+    - *common_defines
+    - TEST
+
+:cmock:
+  :mock_prefix: mock_
+  :when_no_prototypes: :warn
+  :enforce_strict_ordering: TRUE
+  :plugins:
+    - :ignore
+    - :callback
+  :treat_as:
+    uint8:    HEX8
+    uint16:   HEX16
+    uint32:   UINT32
+    int8:     INT8
+    bool:     UINT8
+
+# Add -gcov to the plugins list to make sure of the gcov plugin
+# You will need to have gcov and gcovr both installed to make it work.
+# For more information on these options, see docs in plugins/gcov
+:gcov:
+  :reports:
+    - HtmlDetailed  # Make an HTML report with line by line coverage of each source file. (gcovr --html-details)
+  :abort_on_uncovered: true
+  :uncovered_ignore_list:
+    - src/foo_file.c
+
+#:tools:
+# Ceedling defaults to using gcc for compiling, linking, etc.
+# As [:tools] is blank, gcc will be used (so long as it's in your system path)
+# See documentation to configure a given toolchain for use
+
+# LIBRARIES
+# These libraries are automatically injected into the build process. Those specified as
+# common will be used in all types of builds. Otherwise, libraries can be injected in just
+# tests or releases. These options are MERGED with the options in supplemental yaml files.
+:libraries:
+  :placement: :end
+  :flag: "${1}"  # or "-L ${1}" for example
+  :system: []    # for example, you might list -lm to grab the math library
+  :test: []
+  :release: []
+
+:plugins:
+  :load_paths:
+    - vendor/ceedling/plugins
+  :enabled:
+    - stdout_pretty_tests_report
+    - module_generator
+    - gcov
+...

--- a/assets/uncovered_example_file.c
+++ b/assets/uncovered_example_file.c
@@ -1,0 +1,5 @@
+// This file is to test abort on uncovered files feature
+
+int multiply_numbers(int a, int b) {
+  return a * b;
+}

--- a/plugins/gcov/README.md
+++ b/plugins/gcov/README.md
@@ -43,6 +43,25 @@ for additional options and information. All generated reports will be found in `
     - JSON          # Make a JSON report. (gcovr --json)
 ```
 
+```
+:gcov:
+  :abort_on_uncovered: true
+```
+
+When scanning the code coverage, if any files are found that do not have
+associated coverage data, the command will abort with an error message.
+
+```
+:gcov:
+  :uncovered_ignore_list:
+    - src/foo_file.c
+    - src/bar_file.c
+```
+
+When using the ``abort_on_uncovered`` option, the files in this list will not
+trigger a failure.
+
+
 ### Gcovr HTML Reports
 
 Generation of Gcovr HTML reports may be modified with the following configuration items.

--- a/plugins/gcov/README.md
+++ b/plugins/gcov/README.md
@@ -43,25 +43,6 @@ for additional options and information. All generated reports will be found in `
     - JSON          # Make a JSON report. (gcovr --json)
 ```
 
-```
-:gcov:
-  :abort_on_uncovered: true
-```
-
-When scanning the code coverage, if any files are found that do not have
-associated coverage data, the command will abort with an error message.
-
-```
-:gcov:
-  :uncovered_ignore_list:
-    - src/foo_file.c
-    - src/bar_file.c
-```
-
-When using the ``abort_on_uncovered`` option, the files in this list will not
-trigger a failure.
-
-
 ### Gcovr HTML Reports
 
 Generation of Gcovr HTML reports may be modified with the following configuration items.
@@ -271,6 +252,14 @@ default behaviors of gcovr:
 
     # Set the number of threads to use in parallel. (gcovr -j).
     :num_parallel_threads: <num_threads>
+
+  # When scanning the code coverage, if any files are found that do not have
+  # associated coverage data, the command will abort with an error message.
+  :abort_on_uncovered: true
+
+  # When using the ``abort_on_uncovered`` option, the files in this list will not
+  # trigger a failure.
+  :uncovered_ignore_list: []
 ```
 
 ## Example Usage

--- a/spec/gcov/gcov_deployment_spec.rb
+++ b/spec/gcov/gcov_deployment_spec.rb
@@ -26,6 +26,8 @@ describe "Ceedling" do
 
       it { can_test_projects_with_gcov_with_success }
       it { can_test_projects_with_gcov_with_fail }
+      it { can_test_projects_with_gcov_with_fail_because_of_uncovered_files }
+      it { can_test_projects_with_gcov_with_success_because_of_ignore_uncovered_list }
       it { can_test_projects_with_gcov_with_compile_error }
       it { can_fetch_project_help_for_gcov }
       it { can_create_html_report }


### PR DESCRIPTION
This allows CI to fail if any files are detected that do not have any gcov coverage info (which would render the coverage report not very reliable).