### PR TITLE
Enable TEST_CASE() feature from Unity

### DIFF
--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -54,6 +54,7 @@ class Configurator
      :test_fixture,
      :test_includes_preprocessor,
      :test_file_preprocessor,
+     :test_file_preprocessor_directives,
      :test_dependencies_generator,
      :release_compiler,
      :release_assembler,

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -103,6 +103,26 @@ DEFAULT_TEST_FILE_PREPROCESSOR_TOOL = {
     ].freeze
   }
 
+DEFAULT_TEST_FILE_PREPROCESSOR_DIRECTIVES_TOOL = {
+  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :name => 'default_test_file_preprocessor_directives'.freeze,
+  :stderr_redirect => StdErrRedirect::NONE.freeze,
+  :background_exec => BackgroundExec::NONE.freeze,
+  :optional => false.freeze,
+  :arguments => [
+    '-E'.freeze,
+    {"-I\"$\"" => 'COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR'}.freeze,
+    {"-I\"$\"" => 'COLLECTION_PATHS_TEST_TOOLCHAIN_INCLUDE'}.freeze,
+    {"-D$" => 'COLLECTION_DEFINES_TEST_AND_VENDOR'}.freeze,
+    {"-D$" => 'DEFINES_TEST_PREPROCESS'}.freeze,
+    "-DGNU_COMPILER".freeze,
+    '-fdirectives-only'.freeze,
+    # '-nostdinc'.freeze, # disabled temporarily due to stdio access violations on OSX
+    "\"${1}\"".freeze,
+    "-o \"${2}\"".freeze
+    ].freeze
+  }
+
 # Disable the -MD flag for OSX LLVM Clang, since unsupported
 if RUBY_PLATFORM =~ /darwin/ && `gcc --version 2> /dev/null` =~ /Apple LLVM version .* \(clang/m # OSX w/LLVM Clang
   MD_FLAG = '' # Clang doesn't support the -MD flag
@@ -230,6 +250,7 @@ DEFAULT_TOOLS_TEST_PREPROCESSORS = {
   :tools => {
     :test_includes_preprocessor => DEFAULT_TEST_INCLUDES_PREPROCESSOR_TOOL,
     :test_file_preprocessor     => DEFAULT_TEST_FILE_PREPROCESSOR_TOOL,
+    :test_file_preprocessor_directives => DEFAULT_TEST_FILE_PREPROCESSOR_DIRECTIVES_TOOL,
     }
   }
 
@@ -374,6 +395,7 @@ DEFAULT_CEEDLING_CONFIG = {
     },
     :test_includes_preprocessor  => { :arguments => [] },
     :test_file_preprocessor      => { :arguments => [] },
+    :test_file_preprocessor_directives => { :arguments => [] },
     :test_dependencies_generator => { :arguments => [] },
     :release_compiler  => { :arguments => [] },
     :release_linker    => { :arguments => [] },

--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -6,8 +6,9 @@ class Preprocessinator
 
   def setup
     # fashion ourselves callbacks @preprocessinator_helper can use
-    @preprocess_includes_proc = Proc.new { |filepath| self.preprocess_shallow_includes(filepath) }
-    @preprocess_file_proc     = Proc.new { |filepath| self.preprocess_file(filepath) }
+    @preprocess_includes_proc  = Proc.new { |filepath| self.preprocess_shallow_includes(filepath) }
+    @preprocess_mock_file_proc = Proc.new { |filepath| self.preprocess_file(filepath) }
+    @preprocess_test_file_proc = Proc.new { |filepath| self.preprocess_file_directives(filepath) }
   end
 
   def preprocess_shallow_source_includes(test)
@@ -21,11 +22,11 @@ class Preprocessinator
 
     @project_config_manager.process_test_defines_change(mocks_list)
 
-    @preprocessinator_helper.preprocess_mockable_headers(mocks_list, @preprocess_file_proc)
+    @preprocessinator_helper.preprocess_mockable_headers(mocks_list, @preprocess_mock_file_proc)
 
     @task_invoker.invoke_test_mocks(mocks_list)
 
-    @preprocessinator_helper.preprocess_test_file(test, @preprocess_file_proc)
+    @preprocessinator_helper.preprocess_test_file(test, @preprocess_test_file_proc)
     
     return mocks_list
   end
@@ -42,4 +43,9 @@ class Preprocessinator
     @preprocessinator_file_handler.preprocess_file( filepath, @yaml_wrapper.load(@file_path_utils.form_preprocessed_includes_list_filepath(filepath)) )
   end
 
+  def preprocess_file_directives(filepath)
+    @preprocessinator_includes_handler.invoke_shallow_includes_list( filepath )
+    @preprocessinator_file_handler.preprocess_file_directives( filepath,
+      @yaml_wrapper.load( @file_path_utils.form_preprocessed_includes_list_filepath( filepath ) ) )
+  end
 end

--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -1,7 +1,5 @@
 
 class Preprocessinator
-
-  attr_reader :preprocess_file_proc
   
   constructor :preprocessinator_helper, :preprocessinator_includes_handler, :preprocessinator_file_handler, :task_invoker, :file_path_utils, :yaml_wrapper, :project_config_manager
 

--- a/lib/ceedling/preprocessinator_extractor.rb
+++ b/lib/ceedling/preprocessinator_extractor.rb
@@ -27,4 +27,27 @@ class PreprocessinatorExtractor
 
     return lines
   end
+
+  def extract_base_file_from_preprocessed_directives(filepath)
+    # preprocessing by way of toolchain preprocessor eliminates directives only
+    # like #ifdef's and leave other code
+
+    # iterate through all lines and only get last chunk of file after a last
+    # '#'line containing file name of our filepath
+
+    base_name  = File.basename(filepath)
+    pattern    = /^#.*(\s|\/|\\|\")#{Regexp.escape(base_name)}/
+    found_file = false # have we found the file we care about?
+
+    lines = []
+    File.readlines(filepath).each do |line|
+      lines << line
+
+      if line =~ pattern
+        lines = []
+      end
+    end
+
+    return lines
+  end
 end

--- a/lib/ceedling/preprocessinator_file_handler.rb
+++ b/lib/ceedling/preprocessinator_file_handler.rb
@@ -18,4 +18,17 @@ class PreprocessinatorFileHandler
     @file_wrapper.write(preprocessed_filepath, contents.join("\n"))
   end
 
+  def preprocess_file_directives(filepath, includes)
+    preprocessed_filepath = @file_path_utils.form_preprocessed_file_filepath(filepath)
+
+    command = @tool_executor.build_command_line(@configurator.tools_test_file_preprocessor_directives, [], filepath, preprocessed_filepath)
+    @tool_executor.exec(command[:line], command[:options])
+
+    contents = @preprocessinator_extractor.extract_base_file_from_preprocessed_directives(preprocessed_filepath)
+
+    includes.each{|include| contents.unshift("#include \"#{include}\"")}
+
+    @file_wrapper.write(preprocessed_filepath, contents.join("\n"))
+  end
+
 end

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -103,9 +103,7 @@ class PreprocessinatorIncludesHandler
     dependencies = make_rule.split.find_all {|path| path.end_with?(src_ext)}.uniq
     dependencies.map! {|src| src.gsub('\\','/') }
     dep_src = File.basename(make_rule.split[0].gsub(':', '')).ext(src_ext)
-    dep = dependencies.find {|src| !src.match(/(.*\/)?#{Regexp.escape(dep_src)}/).nil? }
-    list << dep
-    dependencies.delete(dep)
+    dependencies.delete(dependencies.find {|src| !src.match(/(.*\/)?#{Regexp.escape(dep_src)}/).nil? })
 
     # Extract the source dependencies from the make rule
     full_path_source_dependencies = extract_full_path_dependencies(dependencies)

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -90,53 +90,39 @@ class PreprocessinatorIncludesHandler
   end
 
   def extract_includes_helper(filepath, include_paths, ignore_list)
-    # Extract the dependencies from the make rule
+    # Extract the header dependencies from the make rule
     hdr_ext = @configurator.extension_header
     make_rule = self.form_shallow_dependencies_rule(filepath)
     dependencies = make_rule.split.find_all {|path| path.end_with?(hdr_ext) }.uniq
     dependencies.map! {|hdr| hdr.gsub('\\','/') }
 
-    # Separate the real files form the annotated ones and remove the '@@@@'
-    annotated_headers, real_headers = dependencies.partition {|hdr| hdr =~ /^@@@@/ }
-    annotated_headers.map! {|hdr| hdr.gsub('@@@@','') }
-    # Matching annotated_headers values against real_headers to ensure that
-    # annotated_headers contain full path entries (as returned by make rule)
-    annotated_headers.map! {|hdr| real_headers.find {|real_hdr| !real_hdr.match(/(.*\/)?#{Regexp.escape(hdr)}/).nil? } }
-    annotated_headers = annotated_headers.compact
-
-    # Find which of our annotated headers are "real" dependencies. This is
-    # intended to weed out dependencies that have been removed due to build
-    # options defined in the project yaml and/or in the headers themselves.
-    list = annotated_headers.find_all do |annotated_header|
-      # find the index of the "real" include that matches the annotated one.
-      idx = real_headers.find_index do |real_header|
-        real_header =~ /^(.*\/)?#{Regexp.escape(annotated_header)}$/
-      end
-      # If we found a real include, delete it from the array and return it,
-      # otherwise return nil. Since nil is falsy this has the effect of making
-      # find_all return only the annotated headers for which a real include was
-      # found/deleted
-      idx ? real_headers.delete_at(idx) : nil
-    end.compact
+    full_path_header_dependencies = extract_full_path_dependencies(dependencies)
 
     # Extract direct dependencies that were also added
     src_ext = @configurator.extension_source
-    sdependencies = make_rule.split.find_all {|path| path.end_with?(src_ext) }.uniq
-    sdependencies.map! {|hdr| hdr.gsub('\\','/') }
-    list += sdependencies
+    dependencies = make_rule.split.find_all {|path| path.end_with?(src_ext)}.uniq
+    dependencies.map! {|src| src.gsub('\\','/') }
+    dep_src = File.basename(make_rule.split[0].gsub(':', '')).ext(src_ext)
+    dep = dependencies.find {|src| !src.match(/(.*\/)?#{Regexp.escape(dep_src)}/).nil? }
+    list << dep
+    dependencies.delete(dep)
 
+    # Extract the source dependencies from the make rule
+    full_path_source_dependencies = extract_full_path_dependencies(dependencies)
+
+    list = full_path_header_dependencies + full_path_source_dependencies
     to_process = []
 
     if @configurator.project_config_hash.has_key?(:project_auto_link_deep_dependencies) && @configurator.project_config_hash[:project_auto_link_deep_dependencies]
       # Creating list of mocks
-      mocks = annotated_headers.find_all do |annotated_header|
-        File.basename(annotated_header) =~ /^#{@configurator.project_config_hash[:cmock_mock_prefix]}.*$/
+      mocks = full_path_header_dependencies.find_all do |hdr|
+        File.basename(hdr) =~ /^#{@configurator.project_config_hash[:cmock_mock_prefix]}.*$/
       end.compact
 
       # Creating list of headers that should be recursively pre-processed
       # Skipping mocks and unity.h
-      headers_to_deep_link = annotated_headers.select do |annotated_header|
-        !(mocks.include? annotated_header) and (annotated_header.match(/^(.*\/)?unity\.h$/).nil?)
+      headers_to_deep_link = full_path_header_dependencies.select do |hdr|
+        !(mocks.include? hdr) and (hdr.match(/^(.*\/)?unity\.h$/).nil?)
       end
       headers_to_deep_link.map! {|hdr| File.expand_path(hdr)}
 
@@ -177,5 +163,32 @@ class PreprocessinatorIncludesHandler
 
   def write_shallow_includes_list(filepath, list)
     @yaml_wrapper.dump(filepath, list)
+  end
+
+  private
+
+  def extract_full_path_dependencies(dependencies)
+    # Separate the real files form the annotated ones and remove the '@@@@'
+    annotated_files, real_files = dependencies.partition {|file| file =~ /^@@@@/}
+    annotated_files.map! {|file| file.gsub('@@@@','') }
+    # Matching annotated_files values against real_files to ensure that
+    # annotated_files contain full path entries (as returned by make rule)
+    annotated_files.map! {|file| real_files.find {|real| !real.match(/(.*\/)?#{Regexp.escape(file)}/).nil?}}
+    annotated_files = annotated_files.compact
+
+    # Find which of our annotated files are "real" dependencies. This is
+    # intended to weed out dependencies that have been removed due to build
+    # options defined in the project yaml and/or in the files themselves.
+    return annotated_files.find_all do |annotated_file|
+      # find the index of the "real" file that matches the annotated one.
+      idx = real_files.find_index do |real_file|
+        real_file =~ /^(.*\/)?#{Regexp.escape(annotated_file)}$/
+      end
+      # If we found a real file, delete it from the array and return it,
+      # otherwise return nil. Since nil is falsy this has the effect of making
+      # find_all return only the annotated filess for which a real file was
+      # found/deleted
+      idx ? real_files.delete_at(idx) : nil
+    end.compact
   end
 end

--- a/spec/preprocessinator_extractor_spec.rb
+++ b/spec/preprocessinator_extractor_spec.rb
@@ -42,4 +42,40 @@ describe PreprocessinatorExtractor do
     # # xit "should ignore formatting"
     # # xit "should ignore whitespace"
   end
+
+  context "#extract_base_file_from_preprocessed_directives" do
+    it "should extract last chunk of text after last '#'line containing file name of our filepath" do
+      file_path = "path/to/WANT.c"
+      input_str = [
+        '# 1 "some/file/we/do/not/care/about.c" 5',
+        '#pragma shit',
+        'some_text_we_do_not_want();',
+        '# 1 "some/file/we/DO/WANT.c" 99999',
+        'some_text_we_do_not_want();',
+        '#pragma want',
+        'some_creepy_text_we_not_want();',
+        '# 1 "some/useless/file.c" 9',
+        'a set of junk',
+        'more junk',
+        '# 1 "holy/shoot/yes/WANT.c" 10',
+        '#pragma want',
+        '#define INCREDIBLE_DEFINE 911',
+        'some_additional_awesome_want_text();',
+        'holy_crepes_more_awesome_text();',
+        '# oh darn',
+      ]
+
+      expect_str = [
+        '#pragma want',
+        '#define INCREDIBLE_DEFINE 911',
+        'some_additional_awesome_want_text();',
+        'holy_crepes_more_awesome_text();',
+        '# oh darn',
+      ]
+
+      expect(File).to receive(:readlines).with(file_path).and_return( input_str )
+
+      expect(subject.extract_base_file_from_preprocessed_directives(file_path)).to eq expect_str
+    end
+  end
 end

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -88,7 +88,7 @@ describe PreprocessinatorIncludesHandler do
       results = subject.extract_includes_helper("/dummy_file_1.c", [], [])
       # validate results
       expect(results).to eq [
-        ['source/some_header1.h', 'source/some_lib/some_header2.h', 'source/some_other_lib/some_header2.h', 'Build/temp/_test_DUMMY.c', 'source/DUMMY.c'],
+        ['source/some_header1.h', 'source/some_lib/some_header2.h', 'source/some_other_lib/some_header2.h', 'source/DUMMY.c'],
         []
       ]
     end
@@ -122,8 +122,7 @@ describe PreprocessinatorIncludesHandler do
         ['source/some_header1.h',
           'source/some_lib/some_header2.h',
           'source/some_lib1/some_lib/some_header2.h',
-          'source/some_other_lib/some_header2.h',
-          'Build/temp/_test_DUMMY.c'],
+          'source/some_other_lib/some_header2.h'],
         []
       ]
     end
@@ -149,7 +148,7 @@ describe PreprocessinatorIncludesHandler do
       results = subject.extract_includes_helper("/dummy_file_3.c", [], [])
       # validate results
       expect(results).to eq [
-        ['source/some_header1.h', 'Build/temp/_test_DUMMY.c'],
+        ['source/some_header1.h'],
         []
       ]
     end
@@ -183,8 +182,7 @@ describe PreprocessinatorIncludesHandler do
       expect(results).to eq [
         ['source/some_header1.h',
           'source/some_lib/some_header2.h',
-          'source/some_other_lib/some_header2.h',
-          'Build/temp/_test_DUMMY.c'],
+          'source/some_other_lib/some_header2.h'],
         []
       ]
     end

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -78,15 +78,17 @@ describe PreprocessinatorIncludesHandler do
           source/some_header1.h \
           source/some_lib/some_header2.h \
           source/some_other_lib/some_header2.h \
+          source/DUMMY.c \
           @@@@some_header1.h \
-          @@@@some_lib/some_header2.h
-          @@@@some_other_lib/some_header2.h
+          @@@@some_lib/some_header2.h \
+          @@@@some_other_lib/some_header2.h \
+          @@@@source/DUMMY.c
       }})
       # execute method
       results = subject.extract_includes_helper("/dummy_file_1.c", [], [])
       # validate results
       expect(results).to eq [
-        ['source/some_header1.h', 'source/some_lib/some_header2.h', 'source/some_other_lib/some_header2.h', 'Build/temp/_test_DUMMY.c'],
+        ['source/some_header1.h', 'source/some_lib/some_header2.h', 'source/some_other_lib/some_header2.h', 'Build/temp/_test_DUMMY.c', 'source/DUMMY.c'],
         []
       ]
     end
@@ -109,8 +111,8 @@ describe PreprocessinatorIncludesHandler do
           source\some_lib1\some_lib\some_header2.h \
           source\some_other_lib\some_header2.h \
           @@@@some_header1.h \
-          @@@@some_lib/some_header2.h
-          @@@@some_lib1/some_lib/some_header2.h
+          @@@@some_lib/some_header2.h \
+          @@@@some_lib1/some_lib/some_header2.h \
           @@@@some_other_lib/some_header2.h
       }})
       # execute method
@@ -164,7 +166,6 @@ describe PreprocessinatorIncludesHandler do
       expect(@file_wrapper).to receive(:write)
       expect(@tool_executor).to receive(:build_command_line).and_return({:line => "", :options => ""})
       expect(@tool_executor).to receive(:exec).and_return({ :output => %q{
-        _test_DUMMY.o: Build/temp/_test_DUMMY.c \
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source\some_header1.h \
           source\some_lib\some_header2.h \


### PR DESCRIPTION
This PR is trying to enable TEST_CASE() feature from Unity into Ceedling when use_test_preprocessor is enabled and fix issues related to TEST_FILE() in Ceedling itself.
Example to demonstrate problem with TEST_CASE() usage is shown [here](https://github.com/CezaryGapinski/multidefines_example/commit/c89991722eca146c69df3a15b7798c453be5af28). It can be compared with current master branch and with my changes.
I was trying to divide my work and address each one commit to only one issue. It should be much simpler to track changes during merge process.