### PR TITLE
Fix rebuild files after changed defines

### DIFF
--- a/lib/ceedling/project_config_manager.rb
+++ b/lib/ceedling/project_config_manager.rb
@@ -46,7 +46,7 @@ class ProjectConfigManager
     @test_defines_changed = @cacheinator.diff_cached_test_defines?( files )
     if @test_defines_changed
       # update timestamp for rake task prerequisites
-      @file_wrapper.touch( @configurator.project_test_force_rebuild_filepath )
+      @file_wrapper.touch( @configurator.project_test_force_rebuild_filepath, :mtime => Time.now + 10 )
     end
   end
 end

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -84,7 +84,7 @@ class TestInvoker
         sources      = @test_invoker_helper.extract_sources( test )
         extras       = @configurator.collection_test_fixture_extra_link_objects
         core         = [test] + mock_list + sources
-        objects      = @file_path_utils.form_test_build_objects_filelist( [runner] + core + extras )
+        objects      = @file_path_utils.form_test_build_objects_filelist( [runner] + core + extras ).uniq
         results_pass = @file_path_utils.form_pass_results_filepath( test )
         results_fail = @file_path_utils.form_fail_results_filepath( test )
 

--- a/lib/ceedling/test_invoker_helper.rb
+++ b/lib/ceedling/test_invoker_helper.rb
@@ -11,7 +11,7 @@ class TestInvokerHelper
   def process_deep_dependencies(files)
     return if (not @configurator.project_use_deep_dependencies)
 
-    dependencies_list = @file_path_utils.form_test_dependencies_filelist( files )
+    dependencies_list = @file_path_utils.form_test_dependencies_filelist( files ).uniq
 
     if @configurator.project_generate_deep_dependencies
       @task_invoker.invoke_test_dependencies_files( dependencies_list )


### PR DESCRIPTION
- Avoid situation where force_build file has the same timestamp like target file and rake task target is not rebuilt.
- Remove duplication of rake task used in tests.

Details in the commit messages.
