### PR TITLE
defaults: allow configuring gcc and friends via environment

### DIFF
--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -7,17 +7,20 @@ CEEDLING_VENDOR = File.expand_path(File.dirname(__FILE__) + '/../../vendor') unl
 CEEDLING_PLUGINS = [] unless defined? CEEDLING_PLUGINS
 
 DEFAULT_TEST_COMPILER_TOOL = {
-  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :executable => ENV['CC'].nil? ? FilePathUtils.os_executable_ext('gcc').freeze : ENV['CC'].split[0],
   :name => 'default_test_compiler'.freeze,
   :stderr_redirect => StdErrRedirect::NONE.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
   :optional => false.freeze,
   :arguments => [
+    ENV['CC'].nil? ? "" : ENV['CC'].split[1..-1],
+    ENV['CPPFLAGS'].nil? ? "" : ENV['CPPFLAGS'].split,
     {"-I\"$\"" => 'COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR'}.freeze,
     {"-I\"$\"" => 'COLLECTION_PATHS_TEST_TOOLCHAIN_INCLUDE'}.freeze,
     {"-D$" => 'COLLECTION_DEFINES_TEST_AND_VENDOR'}.freeze,
     "-DGNU_COMPILER".freeze,
     "-g".freeze,
+    ENV['CFLAGS'].nil? ? "" : ENV['CFLAGS'].split,
     "-c \"${1}\"".freeze,
     "-o \"${2}\"".freeze,
     # gcc's list file output options are complex; no use of ${3} parameter in default config
@@ -27,16 +30,20 @@ DEFAULT_TEST_COMPILER_TOOL = {
   }
 
 DEFAULT_TEST_LINKER_TOOL = {
-  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :executable => ENV['CCLD'].nil? ? FilePathUtils.os_executable_ext('gcc').freeze : ENV['CCLD'].split[0],
   :name => 'default_test_linker'.freeze,
   :stderr_redirect => StdErrRedirect::NONE.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
   :optional => false.freeze,
   :arguments => [
+    ENV['CCLD'].nil? ? "" : ENV['CCLD'].split[1..-1],
+    ENV['CFLAGS'].nil? ? "" : ENV['CFLAGS'].split,
+    ENV['LDFLAGS'].nil? ? "" : ENV['LDFLAGS'].split,
     "\"${1}\"".freeze,
     "-o \"${2}\"".freeze,
     "".freeze,
-    "${4}".freeze
+    "${4}".freeze,
+    ENV['LDLIBS'].nil? ? "" : ENV['LDLIBS'].split
     ].freeze
   }
 
@@ -50,12 +57,14 @@ DEFAULT_TEST_FIXTURE_TOOL = {
   }
 
 DEFAULT_TEST_INCLUDES_PREPROCESSOR_TOOL = {
-  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :executable => ENV['CC'].nil? ? FilePathUtils.os_executable_ext('gcc').freeze : ENV['CC'].split[0],
   :name => 'default_test_includes_preprocessor'.freeze,
   :stderr_redirect => StdErrRedirect::NONE.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
   :optional => false.freeze,
   :arguments => [
+    ENV['CC'].nil? ? "" : ENV['CC'].split[1..-1],
+    ENV['CPPFLAGS'].nil? ? "" : ENV['CPPFLAGS'].split,
     '-E'.freeze, # OSX clang
     '-MM'.freeze,
     '-MG'.freeze,
@@ -67,19 +76,20 @@ DEFAULT_TEST_INCLUDES_PREPROCESSOR_TOOL = {
     {"-D$" => 'COLLECTION_DEFINES_TEST_AND_VENDOR'}.freeze,
     {"-D$" => 'DEFINES_TEST_PREPROCESS'}.freeze,
     "-DGNU_COMPILER".freeze, # OSX clang
-    '-w'.freeze,
     # '-nostdinc'.freeze, # disabled temporarily due to stdio access violations on OSX
     "\"${1}\"".freeze
     ].freeze
   }
 
 DEFAULT_TEST_FILE_PREPROCESSOR_TOOL = {
-  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :executable => ENV['CC'].nil? ? FilePathUtils.os_executable_ext('gcc').freeze : ENV['CC'].split[0],
   :name => 'default_test_file_preprocessor'.freeze,
   :stderr_redirect => StdErrRedirect::NONE.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
   :optional => false.freeze,
   :arguments => [
+    ENV['CC'].nil? ? "" : ENV['CC'].split[1..-1],
+    ENV['CPPFLAGS'].nil? ? "" : ENV['CPPFLAGS'].split,
     '-E'.freeze,
     {"-I\"$\"" => 'COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR'}.freeze,
     {"-I\"$\"" => 'COLLECTION_PATHS_TEST_TOOLCHAIN_INCLUDE'}.freeze,
@@ -100,12 +110,14 @@ else
 end
 
 DEFAULT_TEST_DEPENDENCIES_GENERATOR_TOOL = {
-  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :executable => ENV['CC'].nil? ? FilePathUtils.os_executable_ext('gcc').freeze : ENV['CC'].split[0],
   :name => 'default_test_dependencies_generator'.freeze,
   :stderr_redirect => StdErrRedirect::NONE.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
   :optional => false.freeze,
   :arguments => [
+    ENV['CC'].nil? ? "" : ENV['CC'].split[1..-1],
+    ENV['CPPFLAGS'].nil? ? "" : ENV['CPPFLAGS'].split,
     '-E'.freeze,
     {"-I\"$\"" => 'COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR'}.freeze,
     {"-I\"$\"" => 'COLLECTION_PATHS_TEST_TOOLCHAIN_INCLUDE'}.freeze,
@@ -123,12 +135,14 @@ DEFAULT_TEST_DEPENDENCIES_GENERATOR_TOOL = {
   }
 
 DEFAULT_RELEASE_DEPENDENCIES_GENERATOR_TOOL = {
-  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :executable => ENV['CC'].nil? ? FilePathUtils.os_executable_ext('gcc').freeze : ENV['CC'].split[0],
   :name => 'default_release_dependencies_generator'.freeze,
   :stderr_redirect => StdErrRedirect::NONE.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
   :optional => false.freeze,
   :arguments => [
+    ENV['CC'].nil? ? "" : ENV['CC'].split[1..-1],
+    ENV['CPPFLAGS'].nil? ? "" : ENV['CPPFLAGS'].split,
     '-E'.freeze,
     {"-I\"$\"" => 'COLLECTION_PATHS_SOURCE_INCLUDE_VENDOR'}.freeze,
     {"-I\"$\"" => 'COLLECTION_PATHS_RELEASE_TOOLCHAIN_INCLUDE'}.freeze,
@@ -147,16 +161,19 @@ DEFAULT_RELEASE_DEPENDENCIES_GENERATOR_TOOL = {
 
 
 DEFAULT_RELEASE_COMPILER_TOOL = {
-  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :executable => ENV['CC'].nil? ? FilePathUtils.os_executable_ext('gcc').freeze : ENV['CC'].split[0],
   :name => 'default_release_compiler'.freeze,
   :stderr_redirect => StdErrRedirect::NONE.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
   :optional => false.freeze,
   :arguments => [
+    ENV['CC'].nil? ? "" : ENV['CC'].split[1..-1],
+    ENV['CPPFLAGS'].nil? ? "" : ENV['CPPFLAGS'].split,
     {"-I\"$\"" => 'COLLECTION_PATHS_SOURCE_INCLUDE_VENDOR'}.freeze,
     {"-I\"$\"" => 'COLLECTION_PATHS_RELEASE_TOOLCHAIN_INCLUDE'}.freeze,
     {"-D$" => 'COLLECTION_DEFINES_RELEASE_AND_VENDOR'}.freeze,
     "-DGNU_COMPILER".freeze,
+    ENV['CFLAGS'].nil? ? "" : ENV['CFLAGS'].split,
     "-c \"${1}\"".freeze,
     "-o \"${2}\"".freeze,
     # gcc's list file output options are complex; no use of ${3} parameter in default config
@@ -166,12 +183,14 @@ DEFAULT_RELEASE_COMPILER_TOOL = {
   }
 
 DEFAULT_RELEASE_ASSEMBLER_TOOL = {
-  :executable => FilePathUtils.os_executable_ext('as').freeze,
+  :executable => ENV['AS'].nil? ? FilePathUtils.os_executable_ext('as').freeze : ENV['AS'].split[0],
   :name => 'default_release_assembler'.freeze,
   :stderr_redirect => StdErrRedirect::NONE.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
   :optional => false.freeze,
   :arguments => [
+    ENV['AS'].nil? ? "" : ENV['AS'].split[1..-1],
+    ENV['ASFLAGS'].nil? ? "" : ENV['ASFLAGS'].split,
     {"-I\"$\"" => 'COLLECTION_PATHS_SOURCE_AND_INCLUDE'}.freeze,
     "\"${1}\"".freeze,
     "-o \"${2}\"".freeze,
@@ -179,16 +198,20 @@ DEFAULT_RELEASE_ASSEMBLER_TOOL = {
   }
 
 DEFAULT_RELEASE_LINKER_TOOL = {
-  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :executable => ENV['CCLD'].nil? ? FilePathUtils.os_executable_ext('gcc').freeze : ENV['CCLD'].split[0],
   :name => 'default_release_linker'.freeze,
   :stderr_redirect => StdErrRedirect::NONE.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
   :optional => false.freeze,
   :arguments => [
+    ENV['CCLD'].nil? ? "" : ENV['CCLD'].split[1..-1],
+    ENV['CFLAGS'].nil? ? "" : ENV['CFLAGS'].split,
+    ENV['LDFLAGS'].nil? ? "" : ENV['LDFLAGS'].split,
     "\"${1}\"".freeze,
     "-o \"${2}\"".freeze,
     "".freeze,
-    "${4}".freeze
+    "${4}".freeze,
+    ENV['LDLIBS'].nil? ? "" : ENV['LDLIBS'].split
     ].freeze
   }
 


### PR DESCRIPTION
It is standard practice to define CC and friends
via the environment
    * CC, CCLD, AS

Similarly, the environment usually defines CFLAGS & LDFLAGS
& ASFLAGS & LDLIBS to use, e.g. when enabling compile-time
hardening. Ceedling shouldn't ignore those either.

This also means that '-w' (to disable all warnings) should
be removed, as otherwise having them in the environment,
in particular as part of ${CC} doesn't work. I don't believe
it's good practice to disable all warnings anyway.

These changes also allows for easy cross-compilation, as cross
compilation environments typically set all those variables to
do the right thing.

Signed-off-by: André Draszik <git@andred.net>