### PR TITLE
Added method to remove include ".c" file from objects linker list.

### DIFF
--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -12,6 +12,9 @@ class Preprocessinator
     @preprocess_file_proc     = Proc.new { |filepath| self.preprocess_file(filepath) }
   end
 
+  def preprocess_shallow_source_includes(test)
+    @preprocessinator_helper.preprocess_source_includes(test)
+  end
 
   def preprocess_test_and_invoke_test_mocks(test)
     @preprocessinator_helper.preprocess_includes(test, @preprocess_includes_proc)

--- a/lib/ceedling/preprocessinator_helper.rb
+++ b/lib/ceedling/preprocessinator_helper.rb
@@ -15,6 +15,10 @@ class PreprocessinatorHelper
     end
   end
 
+  def preprocess_source_includes(test)
+    @test_includes_extractor.parse_test_file_source_include(test)
+  end
+
   def assemble_mocks_list(test)
     return @file_path_utils.form_mocks_source_filelist( @test_includes_extractor.lookup_raw_mock_list(test) )
   end

--- a/lib/ceedling/test_includes_extractor.rb
+++ b/lib/ceedling/test_includes_extractor.rb
@@ -86,11 +86,6 @@ class TestIncludesExtractor
       scan_results = line.scan(/#include\s+\"\s*(.+#{'\\'+source_extension})\s*\"/)
 
       source_includes << scan_results[0][0] if (scan_results.size > 0)
-
-      # look for TEST_FILE statement
-      scan_results = line.scan(/TEST_FILE\(\s*\"\s*(.+\.\w+)\s*\"\s*\)/)
-
-      source_includes << scan_results[0][0] if (scan_results.size > 0)
     end
 
     return source_includes.uniq

--- a/lib/ceedling/test_includes_extractor.rb
+++ b/lib/ceedling/test_includes_extractor.rb
@@ -19,6 +19,11 @@ class TestIncludesExtractor
     gather_and_store_includes( test, extract_from_file(test) )
   end
 
+  # open, scan for, and sort & store includes of test file
+  def parse_test_file_source_include(test)
+    return extract_source_include_from_file(test)
+  end
+
   # mocks with no file extension
   def lookup_raw_mock_list(test)
     file_key = form_file_key(test)
@@ -65,12 +70,38 @@ class TestIncludesExtractor
     return includes.uniq
   end
 
+  def extract_source_include_from_file(file)
+    source_includes = []
+    source_extension = @configurator.extension_source
+
+    contents = @file_wrapper.read(file)
+
+    # remove line comments
+    contents = contents.gsub(/\/\/.*$/, '')
+    # remove block comments
+    contents = contents.gsub(/\/\*.*?\*\//m, '')
+
+    contents.split("\n").each do |line|
+      # look for include statement
+      scan_results = line.scan(/#include\s+\"\s*(.+#{'\\'+source_extension})\s*\"/)
+
+      source_includes << scan_results[0][0] if (scan_results.size > 0)
+
+      # look for TEST_FILE statement
+      scan_results = line.scan(/TEST_FILE\(\s*\"\s*(.+\.\w+)\s*\"\s*\)/)
+
+      source_includes << scan_results[0][0] if (scan_results.size > 0)
+    end
+
+    return source_includes.uniq
+  end
+
   def gather_and_store_includes(file, includes)
     mock_prefix      = @configurator.cmock_mock_prefix
     header_extension = @configurator.extension_header
     file_key         = form_file_key(file)
     @mocks[file_key] = []
-
+    
     # add includes to lookup hash
     @includes[file_key] = includes
 

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -88,6 +88,10 @@ class TestInvoker
         results_pass = @file_path_utils.form_pass_results_filepath( test )
         results_fail = @file_path_utils.form_fail_results_filepath( test )
 
+        # identify all the objects shall not be linked and then remove them from objects list.
+        no_link_objects = @file_path_utils.form_test_build_objects_filelist(@preprocessinator.preprocess_shallow_source_includes( test ))
+        objects = objects.uniq - no_link_objects
+
         @project_config_manager.process_test_defines_change(@project_config_manager.filter_internal_sources(sources))
 
         # clean results files so we have a missing file with which to kick off rake's dependency rules


### PR DESCRIPTION
This pull request implements an automatic method to recognize .c files included to the test module. Once this .c file is included the preprocessor recognize and remove the module from object lists in order to avoid duplicate definition error. 

It allows the usage of #include for source files, procedure used to have access to private function and variables when unit testing.