### PR TITLE
Mention git submodule in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ First make sure Ruby is installed on your system (if it's not already). Then, fr
     > git clone --recursive https://github.com/throwtheswitch/ceedling.git
     > cd ceedling
     > bundle install # Ensures you have all RubyGems needed
+    > git submodule update --init --recursive # Updates all submodules
     > bundle exec rake # Run all Ceedling library tests
 
 If bundler isn't installed on your system or you run into problems, you might have to install it:


### PR DESCRIPTION
Without initializing the submodules, we won't be able to test the gem.

Fixes issue #472.