### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/ceedling/file_wrapper.rb
+++ b/lib/ceedling/file_wrapper.rb
@@ -33,15 +33,15 @@ class FileWrapper
   end
 
   def rm_f(filepath, options={})
-    FileUtils.rm_f(filepath, options)
+    FileUtils.rm_f(filepath, **options)
   end
 
   def rm_r(filepath, options={})
-    FileUtils.rm_r(filepath, options={})
+    FileUtils.rm_r(filepath, **options={})
   end
 
   def cp(source, destination, options={})
-    FileUtils.cp(source, destination, options)
+    FileUtils.cp(source, destination, **options)
   end
 
   def compare(from, to)
@@ -59,7 +59,7 @@ class FileWrapper
   end
 
   def touch(filepath, options={})
-    FileUtils.touch(filepath, options)
+    FileUtils.touch(filepath, **options)
   end
 
   def write(filepath, contents, flags='w')


### PR DESCRIPTION
Ruby 2.7 has deprecated the use of a Hash as the last argument to its
functions. A simple solution is just to add the splat to the hash or
remove curly braces