### PR TITLE
Allow ability to specify keys for imports

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -1454,13 +1454,23 @@ common code modules, etc).
 
 These can be recursively nested, the included files can include other files.
 
-Example [:import] YAML blurb
+To import config files, either provide an array of files to import, or use hashes to set imports. The former is useful if you do not anticipate needing to replace a given file for different configurations (project: or options:). If you need to replace/remove imports based on different configuration files, use the hashed version. The two methods cannot be mixed in the same .yml.
+
+Example [:import] YAML blurb using array
 
 ```yaml
 :import:
   - path/to/config.yml
   - path/to/another/config.yml
 ```
+Example [:import] YAML blurb using hashes
+
+```yaml
+:import:
+  :configA: path/to/config.yml
+  :configB: path/to/another/config.yml
+```
+
 
 Ceedling sets values for a subset of CMock settings. All CMock
 options are available to be set, but only those options set by

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -203,10 +203,17 @@ class Configurator
 
   def merge_imports(config)
     if config[:import]
-      until config[:import].empty?
-        path = config[:import].shift
-        path = @system_wrapper.module_eval(path) if (path =~ RUBY_STRING_REPLACEMENT_PATTERN)
-        config.deep_merge!(@yaml_wrapper.load(path))
+      if config[:import].is_a? Array
+        until config[:import].empty?
+          path = config[:import].shift
+          path = @system_wrapper.module_eval(path) if (path =~ RUBY_STRING_REPLACEMENT_PATTERN)
+          config.deep_merge!(@yaml_wrapper.load(path))
+        end
+      else
+        config[:import].each_value do |path|
+          path = @system_wrapper.module_eval(path) if (path =~ RUBY_STRING_REPLACEMENT_PATTERN)
+          config.deep_merge!(@yaml_wrapper.load(path))
+        end
       end
     end
     config.delete(:import)

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -211,8 +211,10 @@ class Configurator
         end
       else
         config[:import].each_value do |path|
-          path = @system_wrapper.module_eval(path) if (path =~ RUBY_STRING_REPLACEMENT_PATTERN)
-          config.deep_merge!(@yaml_wrapper.load(path))
+          if !path.nil?
+            path = @system_wrapper.module_eval(path) if (path =~ RUBY_STRING_REPLACEMENT_PATTERN)
+            config.deep_merge!(@yaml_wrapper.load(path))
+          end
         end
       end
     end


### PR DESCRIPTION
Instead of using an array of imports, you can use hashes so that certain imports can be replaced by option files.

Not sure what other use cases there might be for this, but in my case, I was having to use 2 separate .ymls for two different types of test runs: host and simulator. I would have preferred that it defaults to the host without any "option:" or "project:" command line arguments. Unfortunately, there are certain things that need to be removed from the host configuration, to make the simulator configuration run correctly. This isn't possible when the host configuration uses the overall project.yml.

My solution to the problem was to change the :import: section of the project.yml to hashes so that the base configuration imports can be replaced by name in the option/project specific .ymls. This was in lieu of recoding the yaml_merger to allow replacement instead of addition. For backwards compatibility, I kept the old method of iterating the array and just ran a test to see if :import: was an array or not.

I will caveat all of my changes with I am not very familiar with Ruby at all. I can almost guarantee there is a better/more efficient/more robust/safer way to do this, it was just my initial hack at it. I would also understand if this isn't desirable behavior for most people and won't be implemented.