### PR TITLE
Includes helper fixes

### DIFF
--- a/assets/auto_link_deep_dependencies/src/a.c
+++ b/assets/auto_link_deep_dependencies/src/a.c
@@ -1,0 +1,7 @@
+#include "a.h"
+#include "b.h"
+
+int function_from_a(int a)
+{
+  return 2 * function_from_b(a);
+}

--- a/assets/auto_link_deep_dependencies/src/b.c
+++ b/assets/auto_link_deep_dependencies/src/b.c
@@ -1,0 +1,7 @@
+#include "b.h"
+#include "c.h"
+
+int function_from_b(int b)
+{
+  return 2 * function_from_c(b);
+}

--- a/assets/auto_link_deep_dependencies/src/c.c
+++ b/assets/auto_link_deep_dependencies/src/c.c
@@ -1,0 +1,8 @@
+#include "c.h"
+#include "never_compiled.h"
+
+int function_from_c(int c)
+{
+  function_never_compiled(2);
+  return 2 * c;
+}

--- a/assets/auto_link_deep_dependencies/src/internal_inc/a.h
+++ b/assets/auto_link_deep_dependencies/src/internal_inc/a.h
@@ -1,0 +1,6 @@
+#ifndef A_H
+#define A_H
+
+int function_from_a(int a);
+
+#endif /* A_H */

--- a/assets/auto_link_deep_dependencies/src/internal_inc/b.h
+++ b/assets/auto_link_deep_dependencies/src/internal_inc/b.h
@@ -1,0 +1,6 @@
+#ifndef B_H
+#define B_H
+
+int function_from_b(int b);
+
+#endif /* B_H */

--- a/assets/auto_link_deep_dependencies/src/internal_inc/c.h
+++ b/assets/auto_link_deep_dependencies/src/internal_inc/c.h
@@ -1,0 +1,6 @@
+#ifndef C_H
+#define C_H
+
+int function_from_c(int c);
+
+#endif /* C_H */

--- a/assets/auto_link_deep_dependencies/src/internal_inc/never_compiled.h
+++ b/assets/auto_link_deep_dependencies/src/internal_inc/never_compiled.h
@@ -1,0 +1,6 @@
+#ifndef NEVER_COMPILED_H
+#define NEVER_COMPILED_H
+
+int function_never_compiled(int x);
+
+#endif /* NEVER_COMPILED_H */

--- a/assets/auto_link_deep_dependencies/src/never_compiled.c
+++ b/assets/auto_link_deep_dependencies/src/never_compiled.c
@@ -1,0 +1,6 @@
+#include "never_compiled.h"
+
+int function_never_compiled(int x)
+{
+  never runed function
+}

--- a/assets/auto_link_deep_dependencies/test/test_a.c
+++ b/assets/auto_link_deep_dependencies/test/test_a.c
@@ -1,0 +1,11 @@
+#include "unity.h"
+#include "a.h"
+#include "mock_never_compiled.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_function_from_a_should_return_16(void) {
+  function_never_compiled_ExpectAndReturn(2, 2);
+  TEST_ASSERT_EQUAL(16, function_from_a(2));
+}

--- a/assets/auto_link_deep_dependencies/test/test_b.c
+++ b/assets/auto_link_deep_dependencies/test/test_b.c
@@ -1,0 +1,11 @@
+#include "unity.h"
+#include "b.h"
+#include "mock_never_compiled.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_function_from_b_should_return_8(void) {
+  function_never_compiled_ExpectAndReturn(2, 2);
+  TEST_ASSERT_EQUAL(8, function_from_b(2));
+}

--- a/assets/auto_link_deep_dependencies/test/test_c.c
+++ b/assets/auto_link_deep_dependencies/test/test_c.c
@@ -1,0 +1,11 @@
+#include "unity.h"
+#include "c.h"
+#include "mock_never_compiled.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_function_from_c_should_return_4(void) {
+  function_never_compiled_ExpectAndReturn(2, 2);
+  TEST_ASSERT_EQUAL(4, function_from_c(2));
+}

--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -96,4 +96,4 @@ NULL_FILE_PATH = '/dev/null'
 TESTS_BASE_PATH   = TEST_ROOT_NAME
 RELEASE_BASE_PATH = RELEASE_ROOT_NAME
 
-VENDORS_FILES = %w(unity UnityHelper cmock cexception).freeze
+VENDORS_FILES = %w(unity UnityHelper cmock CException).freeze

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -253,6 +253,7 @@ preprocessinator_includes_handler:
     - file_path_utils
     - yaml_wrapper
     - file_wrapper
+    - file_finder
 
 preprocessinator_file_handler:
   compose:

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -2,7 +2,7 @@
 
 class PreprocessinatorIncludesHandler
 
-  constructor :configurator, :tool_executor, :task_invoker, :file_path_utils, :yaml_wrapper, :file_wrapper
+  constructor :configurator, :tool_executor, :task_invoker, :file_path_utils, :yaml_wrapper, :file_wrapper, :file_finder
   @@makefile_cache = {}
 
   # shallow includes: only those headers a source file explicitly includes
@@ -145,10 +145,8 @@ class PreprocessinatorIncludesHandler
             include_paths.none? {|include_path| hdr =~ /^#{include_path}\.*/})
           if File.exist?(hdr)
             to_process << hdr
-            source_file = hdr.chomp(hdr_ext) + src_ext
-            if source_file != hdr and File.exist?(source_file)
-              to_process << source_file
-            end
+            src = @file_finder.find_compilation_input_file(hdr, :ignore)
+            to_process << src if src
           end
         end
       end

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -93,7 +93,10 @@ class PreprocessinatorIncludesHandler
     # Extract the dependencies from the make rule
     hdr_ext = @configurator.extension_header
     make_rule = self.form_shallow_dependencies_rule(filepath)
-    dependencies = make_rule.split.find_all {|path| path.end_with?(hdr_ext) }.uniq
+    target_file = make_rule.split[0].gsub(':', '').gsub('\\','/')
+    base = File.basename(target_file, File.extname(target_file))
+    make_rule_dependencies = make_rule.gsub(/.*#{Regexp.escape(base)}\S*/, '').gsub(/\\$/, '')
+    dependencies = make_rule_dependencies.split.find_all {|path| path.end_with?(hdr_ext) }.uniq
     dependencies.map! {|hdr| hdr.gsub('\\','/') }
 
     # Separate the real files form the annotated ones and remove the '@@@@'
@@ -121,7 +124,7 @@ class PreprocessinatorIncludesHandler
 
     # Extract direct dependencies that were also added
     src_ext = @configurator.extension_source
-    sdependencies = make_rule.split.find_all {|path| path.end_with?(src_ext) }.uniq
+    sdependencies = make_rule_dependencies.split.find_all {|path| path.end_with?(src_ext) }.uniq
     sdependencies.map! {|hdr| hdr.gsub('\\','/') }
     list += sdependencies
 

--- a/lib/ceedling/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocessinator_includes_handler.rb
@@ -119,9 +119,9 @@ class PreprocessinatorIncludesHandler
       end.compact
 
       # Creating list of headers that should be recursively pre-processed
-      # Skipping mocks and unity.h
+      # Skipping mocks and vendor headers
       headers_to_deep_link = full_path_headers_dependencies.select do |hdr|
-        !(mocks.include? hdr) and (hdr.match(/^(.*\/)?unity\.h$/).nil?)
+        !(mocks.include? hdr) and (hdr.match(/^(.*\/)(#{VENDORS_FILES.join('|')})\.h$/).nil?)
       end
       headers_to_deep_link.map! {|hdr| File.expand_path(hdr) }
       headers_to_deep_link.compact!

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -78,9 +78,11 @@ describe PreprocessinatorIncludesHandler do
           source/some_header1.h \
           source/some_lib/some_header2.h \
           source/some_other_lib/some_header2.h \
+          source/DUMMY.c \
           @@@@some_header1.h \
           @@@@some_lib/some_header2.h \
-          @@@@some_other_lib/some_header2.h
+          @@@@some_other_lib/some_header2.h \
+          @@@@source/DUMMY.c
       }})
       # execute method
       results = subject.extract_includes_helper("/dummy_file_1.c", [], [], [])
@@ -88,7 +90,8 @@ describe PreprocessinatorIncludesHandler do
       expect(results).to eq [
         ['source/some_header1.h',
           'source/some_lib/some_header2.h',
-          'source/some_other_lib/some_header2.h'],
+          'source/some_other_lib/some_header2.h',
+          'source/DUMMY.c'],
         [], []
       ]
     end

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -88,8 +88,7 @@ describe PreprocessinatorIncludesHandler do
       expect(results).to eq [
         ['source/some_header1.h',
           'source/some_lib/some_header2.h',
-          'source/some_other_lib/some_header2.h',
-          'Build/temp/_test_DUMMY.c'],
+          'source/some_other_lib/some_header2.h'],
         [], []
       ]
     end
@@ -123,8 +122,7 @@ describe PreprocessinatorIncludesHandler do
         ['source/some_header1.h',
           'source/some_lib/some_header2.h',
           'source/some_lib1/some_lib/some_header2.h',
-          'source/some_other_lib/some_header2.h',
-          'Build/temp/_test_DUMMY.c'],
+          'source/some_other_lib/some_header2.h'],
         [], []
       ]
     end
@@ -150,7 +148,7 @@ describe PreprocessinatorIncludesHandler do
       results = subject.extract_includes_helper("/dummy_file_3.c", [], [], [])
       # validate results
       expect(results).to eq [
-        ['source/some_header1.h', 'Build/temp/_test_DUMMY.c'],
+        ['source/some_header1.h'],
         [], []
       ]
     end
@@ -184,8 +182,7 @@ describe PreprocessinatorIncludesHandler do
       expect(results).to eq [
         ['source/some_header1.h',
           'source/some_lib/some_header2.h',
-          'source/some_other_lib/some_header2.h',
-          'Build/temp/_test_DUMMY.c'],
+          'source/some_other_lib/some_header2.h'],
         [], []
       ]
     end

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -79,14 +79,17 @@ describe PreprocessinatorIncludesHandler do
           source/some_lib/some_header2.h \
           source/some_other_lib/some_header2.h \
           @@@@some_header1.h \
-          @@@@some_lib/some_header2.h
+          @@@@some_lib/some_header2.h \
           @@@@some_other_lib/some_header2.h
       }})
       # execute method
       results = subject.extract_includes_helper("/dummy_file_1.c", [], [])
       # validate results
       expect(results).to eq [
-        ['source/some_header1.h', 'source/some_lib/some_header2.h', 'source/some_other_lib/some_header2.h', 'Build/temp/_test_DUMMY.c'],
+        ['source/some_header1.h',
+          'source/some_lib/some_header2.h',
+          'source/some_other_lib/some_header2.h',
+          'Build/temp/_test_DUMMY.c'],
         []
       ]
     end
@@ -109,8 +112,8 @@ describe PreprocessinatorIncludesHandler do
           source\some_lib1\some_lib\some_header2.h \
           source\some_other_lib\some_header2.h \
           @@@@some_header1.h \
-          @@@@some_lib/some_header2.h
-          @@@@some_lib1/some_lib/some_header2.h
+          @@@@some_lib/some_header2.h \
+          @@@@some_lib1/some_lib/some_header2.h \
           @@@@some_other_lib/some_header2.h
       }})
       # execute method
@@ -164,7 +167,6 @@ describe PreprocessinatorIncludesHandler do
       expect(@file_wrapper).to receive(:write)
       expect(@tool_executor).to receive(:build_command_line).and_return({:line => "", :options => ""})
       expect(@tool_executor).to receive(:exec).and_return({ :output => %q{
-        _test_DUMMY.o: Build/temp/_test_DUMMY.c \
         _test_DUMMY.o: Build/temp/_test_DUMMY.c \
           source\some_header1.h \
           source\some_lib\some_header2.h \

--- a/spec/preprocessinator_includes_handler_spec.rb
+++ b/spec/preprocessinator_includes_handler_spec.rb
@@ -83,14 +83,14 @@ describe PreprocessinatorIncludesHandler do
           @@@@some_other_lib/some_header2.h
       }})
       # execute method
-      results = subject.extract_includes_helper("/dummy_file_1.c", [], [])
+      results = subject.extract_includes_helper("/dummy_file_1.c", [], [], [])
       # validate results
       expect(results).to eq [
         ['source/some_header1.h',
           'source/some_lib/some_header2.h',
           'source/some_other_lib/some_header2.h',
           'Build/temp/_test_DUMMY.c'],
-        []
+        [], []
       ]
     end
 
@@ -117,7 +117,7 @@ describe PreprocessinatorIncludesHandler do
           @@@@some_other_lib/some_header2.h
       }})
       # execute method
-      results = subject.extract_includes_helper("/dummy_file_2.c", [], [])
+      results = subject.extract_includes_helper("/dummy_file_2.c", [], [], [])
       # validate results
       expect(results).to eq [
         ['source/some_header1.h',
@@ -125,7 +125,7 @@ describe PreprocessinatorIncludesHandler do
           'source/some_lib1/some_lib/some_header2.h',
           'source/some_other_lib/some_header2.h',
           'Build/temp/_test_DUMMY.c'],
-        []
+        [], []
       ]
     end
 
@@ -147,11 +147,11 @@ describe PreprocessinatorIncludesHandler do
           @@@@some_lib/some_header2.h
       }})
       # execute method
-      results = subject.extract_includes_helper("/dummy_file_3.c", [], [])
+      results = subject.extract_includes_helper("/dummy_file_3.c", [], [], [])
       # validate results
       expect(results).to eq [
         ['source/some_header1.h', 'Build/temp/_test_DUMMY.c'],
-        []
+        [], []
       ]
     end
 
@@ -179,14 +179,14 @@ describe PreprocessinatorIncludesHandler do
           @@@@some_other_lib/some_header2.h
       }})
       # execute method
-      results = subject.extract_includes_helper("/dummy_file_4.c", [], [])
+      results = subject.extract_includes_helper("/dummy_file_4.c", [], [], [])
       # validate results
       expect(results).to eq [
         ['source/some_header1.h',
           'source/some_lib/some_header2.h',
           'source/some_other_lib/some_header2.h',
           'Build/temp/_test_DUMMY.c'],
-        []
+        [], []
       ]
     end
   end

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -56,6 +56,22 @@ def _add_define_in_section(project_file_path, define, section)
   end
 end
 
+def _add_option_in_project(project_file_path, option, value)
+  project_file_contents = File.readlines(project_file_path)
+  option_index = project_file_contents.index(":project:\n")
+
+  if option_index.nil?
+    # Something wrong with project.yml file, no paths?
+    return
+  end
+
+  project_file_contents.insert(option_index + 1, "  #{option}: #{value}\n")
+
+  File.open(project_file_path, "w+") do |f|
+    f.puts(project_file_contents)
+  end
+end
+
 def add_source_path(path)
   _add_path_in_section("project.yml", path, "source")
 end
@@ -66,6 +82,10 @@ end
 
 def add_test_define(define)
   _add_define_in_section("project.yml", define, "test")
+end
+
+def add_project_option(option, value)
+  _add_option_in_project("project.yml", option, value)
 end
 
 def add_module_generator_section(project_file_path, mod_gen)
@@ -325,6 +345,23 @@ module CeedlingTestCases
         FileUtils.cp test_asset_path("example_file.c"), 'src/'
         FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
         add_test_define("UNITY_INCLUDE_EXEC_TIME")
+
+        output = `bundle exec ruby -S ceedling 2>&1`
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
+  def can_test_projects_with_enabled_auto_link_deep_deependency_with_success
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.copy_entry test_asset_path("auto_link_deep_dependencies/src/"), 'src/'
+        FileUtils.cp_r test_asset_path("auto_link_deep_dependencies/test/."), 'test/'
+        add_project_option("auto_link_deep_dependencies", "TRUE")
 
         output = `bundle exec ruby -S ceedling 2>&1`
         expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -166,6 +166,17 @@ describe "Ceedling" do
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
   end
 
+  describe "deployed with auto link deep denendencies" do
+    before do
+      @c.with_context do
+        `bundle exec ruby -S ceedling new --local #{@proj_name} 2>&1`
+      end
+    end
+
+    it { can_create_projects }
+    it { can_test_projects_with_enabled_auto_link_deep_deependency_with_success }
+  end
+
   describe "command: `ceedling examples`" do
     before do
       @c.with_context do


### PR DESCRIPTION
This PR helps to solve few issues related to `auto_link_deep_dependencies` feature. I also made small refactor in `extract_includes_helper(...)` method.

The `auto_link_deep_dependencies` is really powerfull feature, but I have noticed that something was wrong when I was trying to use mocks :). The same issue exists for `temp_sensor` example, so I have been able to easily debug the problem.

It is easier to explain what I did in small steps:

- Incorrect mock includes handling can be noticed for `list` variable at the end of call `extract_includes(filepath)` method:

`list` variable from `extract_includes(filepath)` for master branch on the first run `ceedling test:AdcConductor`:

```
[0]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity.h'
[1]:'test/support/UnityHelper.h'
[2]:'src/Types.h'
[3]:'src/AdcConductor.h'
[4]:'MockAdcModel.h'
[5]:'MockAdcHardware.h'
[6]:'build/temp/_TestAdcConductor.c'
[7]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity_internals.h'
[8]:'build/temp/_UnityHelper.c'
[9]:'build/temp/_AdcConductor.c'
```

`list` variable from `extract_includes(filepath)` for master branch on the second run `ceedling test:AdcConductor`:

```
[0]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity.h'
[1]:'test/support/UnityHelper.h'
[2]:'src/Types.h'
[3]:'src/AdcConductor.h'
[4]:'build/test/mocks/MockAdcModel.h'
[5]:'build/test/mocks/MockAdcHardware.h'
[6]:'build/temp/_TestAdcConductor.c'
[7]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity_internals.h'
[8]:'build/temp/_UnityHelper.c'
[9]:'src/AdcModel.h' <- this file is included even if MockAdcModel.h is also included, what cause a problem
[10]:'src/AdcHardware.h' <- this file is included even if MockAdcHardware.h is also included, what cause a problem
[11]:'build/temp/_AdcConductor.c'
[12]:'src/TaskScheduler.h'
[13]:'src/TemperatureCalculator.h'
[14]:'src/TemperatureFilter.h'
[15]:'build/temp/_AdcModel.c'
[16]:'src/AdcHardwareConfigurator.h' <- because we had `src/AdcHardware.h`, so also `src/AdcHardware.c`. This c file has `#include AdcHardwareConfigurator.h`, but `src/AdcHardwareConfigurator.c` cannot be compiled, because of missing registers defines. Mocked version should be used.
[17]:'src/AdcTemperatureSensor.h'
```

Everything is fine, when we run the test for the first time, because in this step the mock files are not created yet. But in the second step both real headers and mocks exist and are added to the `list` what cause a problem and test can't be compiled.

- The `list` is cluttered by temporary files with `_` prefix. Files with this prefix are only temporary created to store gcc dependency results to parse annotated `@@@@` files and shouldn't be included anywhere. Here are listings after fixes:

`list` variable from `extract_includes(filepath)` for this PR branch on the first run `ceedling test:AdcConductor`

```
[0]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity.h'
[1]:'test/support/UnityHelper.h'
[2]:'src/Types.h'
[3]:'src/AdcConductor.h'
[4]:'MockAdcModel.h'
[5]:'MockAdcHardware.h'
[6]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity_internals.h'
```

`list` variable from `extract_includes(filepath)` for this PR branch on the second run `ceedling test:AdcConductor`

```
[0]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity.h'
[1]:'test/support/UnityHelper.h'
[2]:'src/Types.h'
[3]:'src/AdcConductor.h'
[4]:'build/test/mocks/MockAdcModel.h'
[5]:'build/test/mocks/MockAdcHardware.h'
[6]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity_internals.h'
```

- Another problem exist when we add source file by `TEST_FILE()` macro to the test. We can notice @@@@ anotated file on the output `list`. File with name `@@@@TemperatureCalculator.c` never exists, `@@@@` is only used to make annotation for files, so I think this also should be removed from the `list`.

`list` variable from `extract_includes(filepath)` for master branch on the first run `ceedling test:TemperatureCalculator`

```
[0]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity.h'
[1]:'src/Types.h'
[2]:'build/temp/_TestTemperatureCalculator.c'
[3]:'src/TemperatureCalculator.c'
[4]:'@@@@TemperatureCalculator.c'
```

`list` variable from `extract_includes(filepath)` for this PR branch on the first run `ceedling test:TemperatureCalculator`

```
[0]:'/home/x/repos/example/vendor/ceedling/vendor/unity/src/unity.h'
[1]:'src/Types.h'
[2]:'src/TemperatureCalculator.c'
```

- There was also a problem when source file in `auto_link_deep_dependencies` mode exists but in the different directory than the header files. I used `find_compilation_input_file()` method from `file_finder` to find the source files. It doesn't solve problem when C files have different name to header, but it is small step forward.
I've made a small example in commit `Add deployment test for project with auto link deep dependencies` to demonstrate this issue :).

@tobyjwebb would you be so nice to check if I didn't break anything? You are the author of `auto_link_deep_dependencies`, and you have a big knowledge about how to use it. I think you have a real project where auto_link_deep_dependency option is used and you can run my changes on it?

I have a hope that my changes will be useful for the ceedling community and @mvandervoord accept my changes. I was trying to split it into small steps to make a review easier and I made tests to confirm that my changes work :). Of course I'm opened to change something in this PR if there is a need.