### PR TITLE
Add preprocessing feature to expand only directives and conditional statements

### DIFF
--- a/assets/test_example_with_parameterized_tests.c
+++ b/assets/test_example_with_parameterized_tests.c
@@ -1,0 +1,19 @@
+#include "unity.h"
+
+#define TEST_CASE(...)
+#define TEST_RANGE(...)
+
+void setUp(void) {}
+void tearDown(void) {}
+
+TEST_CASE(25)
+TEST_CASE(125)
+TEST_CASE(5)
+void test_should_handle_divisible_by_5_for_parameterized_test_case(int num) {
+ TEST_ASSERT_EQUAL_MESSAGE(0, (num % 5), "All The Values Are Divisible By 5");
+}
+
+TEST_RANGE([10, 100, 10], [5, 10, 5])
+void test_should_handle_a_divisible_by_b_for_parameterized_test_range(int a, int b) {
+  TEST_ASSERT_EQUAL_MESSAGE(0, (a % b), "All The a Values Are Divisible By b");
+}

--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -818,6 +818,23 @@ project: global project settings
 
   **Default**: FALSE
 
+* `use_preprocessor_directives`:
+
+  After standard preprocessing when `use_test_preprocessor` is used
+  macros are fully expanded to C code. Some features, for example
+  TEST_CASE() or TEST_RANGE() from Unity require not-fully preprocessed
+  file to be detected by Ceedling. To do this gcc directives-only
+  option is used to expand only conditional compilation statements,
+  handle directives, but do not expand macros preprocessor and leave
+  the other content of file untouched.
+
+  With this option enabled, `use_test_preprocessor` must be also enabled
+  and gcc must exist in an accessible system search path. For other
+  compilers behavior can be changed by `test_file_preprocessor_directives`
+  compiler tool.
+
+  **Default**: FALSE
+
 * `use_deep_dependencies`:
 
   The base rules and tasks that Ceedling creates using Rake capture most
@@ -1680,9 +1697,18 @@ tools.
 * `test_file_preprocessor`:
 
   Preprocessor of test files (macros, conditional compilation statements)
-
    - `${1}`: input source file
    - `${2}`: preprocessed output source file
+
+  **Default**: `gcc`
+
+* `test_file_preprocessor_directives`:
+
+  Preprocessor of test files to expand only conditional compilation statements,
+  handle directives, but do not expand macros
+
+   - `${1}`: input source file
+   - `${2}`: not-fully preprocessed output source file
 
   **Default**: `gcc`
 

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -54,6 +54,7 @@ class Configurator
      :test_fixture,
      :test_includes_preprocessor,
      :test_file_preprocessor,
+     :test_file_preprocessor_directives,
      :test_dependencies_generator,
      :release_compiler,
      :release_assembler,

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -103,6 +103,26 @@ DEFAULT_TEST_FILE_PREPROCESSOR_TOOL = {
     ].freeze
   }
 
+DEFAULT_TEST_FILE_PREPROCESSOR_DIRECTIVES_TOOL = {
+  :executable => FilePathUtils.os_executable_ext('gcc').freeze,
+  :name => 'default_test_file_preprocessor_directives'.freeze,
+  :stderr_redirect => StdErrRedirect::NONE.freeze,
+  :background_exec => BackgroundExec::NONE.freeze,
+  :optional => false.freeze,
+  :arguments => [
+    '-E'.freeze,
+    {"-I\"$\"" => 'COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR'}.freeze,
+    {"-I\"$\"" => 'COLLECTION_PATHS_TEST_TOOLCHAIN_INCLUDE'}.freeze,
+    {"-D$" => 'COLLECTION_DEFINES_TEST_AND_VENDOR'}.freeze,
+    {"-D$" => 'DEFINES_TEST_PREPROCESS'}.freeze,
+    "-DGNU_COMPILER".freeze,
+    '-fdirectives-only'.freeze,
+    # '-nostdinc'.freeze, # disabled temporarily due to stdio access violations on OSX
+    "\"${1}\"".freeze,
+    "-o \"${2}\"".freeze
+    ].freeze
+  }
+
 # Disable the -MD flag for OSX LLVM Clang, since unsupported
 if RUBY_PLATFORM =~ /darwin/ && `gcc --version 2> /dev/null` =~ /Apple LLVM version .* \(clang/m # OSX w/LLVM Clang
   MD_FLAG = '' # Clang doesn't support the -MD flag
@@ -230,6 +250,7 @@ DEFAULT_TOOLS_TEST_PREPROCESSORS = {
   :tools => {
     :test_includes_preprocessor => DEFAULT_TEST_INCLUDES_PREPROCESSOR_TOOL,
     :test_file_preprocessor     => DEFAULT_TEST_FILE_PREPROCESSOR_TOOL,
+    :test_file_preprocessor_directives => DEFAULT_TEST_FILE_PREPROCESSOR_DIRECTIVES_TOOL,
     }
   }
 
@@ -270,6 +291,7 @@ DEFAULT_CEEDLING_CONFIG = {
       :compile_threads => 1,
       :test_threads => 1,
       :use_test_preprocessor => false,
+      :use_preprocessor_directives => false,
       :use_deep_dependencies => false,
       :generate_deep_dependencies => true, # only applicable if use_deep_dependencies is true
       :test_file_prefix => 'test_',
@@ -374,6 +396,7 @@ DEFAULT_CEEDLING_CONFIG = {
     },
     :test_includes_preprocessor  => { :arguments => [] },
     :test_file_preprocessor      => { :arguments => [] },
+    :test_file_preprocessor_directives => { :arguments => [] },
     :test_dependencies_generator => { :arguments => [] },
     :release_compiler  => { :arguments => [] },
     :release_linker    => { :arguments => [] },

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -236,6 +236,7 @@ preprocessinator:
     - file_path_utils
     - yaml_wrapper
     - project_config_manager
+    - configurator
 
 preprocessinator_helper:
   compose:

--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -1,8 +1,6 @@
 
 class Preprocessinator
 
-  attr_reader :preprocess_file_proc
-  
   constructor :preprocessinator_helper, :preprocessinator_includes_handler, :preprocessinator_file_handler, :task_invoker, :file_path_utils, :yaml_wrapper, :project_config_manager
 
 

--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -1,13 +1,15 @@
 
 class Preprocessinator
 
-  constructor :preprocessinator_helper, :preprocessinator_includes_handler, :preprocessinator_file_handler, :task_invoker, :file_path_utils, :yaml_wrapper, :project_config_manager
+  constructor :preprocessinator_helper, :preprocessinator_includes_handler, :preprocessinator_file_handler, :task_invoker, :file_path_utils, :yaml_wrapper, :project_config_manager, :configurator
 
 
   def setup
     # fashion ourselves callbacks @preprocessinator_helper can use
-    @preprocess_includes_proc = Proc.new { |filepath| self.preprocess_shallow_includes(filepath) }
-    @preprocess_file_proc     = Proc.new { |filepath| self.preprocess_file(filepath) }
+    @preprocess_includes_proc  = Proc.new { |filepath| self.preprocess_shallow_includes(filepath) }
+    @preprocess_mock_file_proc = Proc.new { |filepath| self.preprocess_file(filepath) }
+    @preprocess_test_file_directives_proc = Proc.new { |filepath| self.preprocess_file_directives(filepath) }
+    @preprocess_test_file_proc = Proc.new { |filepath| self.preprocess_file(filepath) }
   end
 
   def preprocess_shallow_source_includes(test)
@@ -21,12 +23,16 @@ class Preprocessinator
 
     @project_config_manager.process_test_defines_change(mocks_list)
 
-    @preprocessinator_helper.preprocess_mockable_headers(mocks_list, @preprocess_file_proc)
+    @preprocessinator_helper.preprocess_mockable_headers(mocks_list, @preprocess_mock_file_proc)
 
     @task_invoker.invoke_test_mocks(mocks_list)
 
-    @preprocessinator_helper.preprocess_test_file(test, @preprocess_file_proc)
-    
+    if (@configurator.project_use_preprocessor_directives)
+      @preprocessinator_helper.preprocess_test_file(test, @preprocess_test_file_directives_proc)
+    else
+      @preprocessinator_helper.preprocess_test_file(test, @preprocess_test_file_proc)
+    end
+
     return mocks_list
   end
 
@@ -42,4 +48,9 @@ class Preprocessinator
     @preprocessinator_file_handler.preprocess_file( filepath, @yaml_wrapper.load(@file_path_utils.form_preprocessed_includes_list_filepath(filepath)) )
   end
 
+  def preprocess_file_directives(filepath)
+    @preprocessinator_includes_handler.invoke_shallow_includes_list( filepath )
+    @preprocessinator_file_handler.preprocess_file_directives( filepath,
+      @yaml_wrapper.load( @file_path_utils.form_preprocessed_includes_list_filepath( filepath ) ) )
+  end
 end

--- a/lib/ceedling/preprocessinator_extractor.rb
+++ b/lib/ceedling/preprocessinator_extractor.rb
@@ -27,4 +27,27 @@ class PreprocessinatorExtractor
 
     return lines
   end
+
+  def extract_base_file_from_preprocessed_directives(filepath)
+    # preprocessing by way of toolchain preprocessor eliminates directives only
+    # like #ifdef's and leave other code
+
+    # iterate through all lines and only get last chunk of file after a last
+    # '#'line containing file name of our filepath
+
+    base_name  = File.basename(filepath)
+    pattern    = /^#.*(\s|\/|\\|\")#{Regexp.escape(base_name)}/
+    found_file = false # have we found the file we care about?
+
+    lines = []
+    File.readlines(filepath).each do |line|
+      lines << line
+
+      if line =~ pattern
+        lines = []
+      end
+    end
+
+    return lines
+  end
 end

--- a/lib/ceedling/preprocessinator_file_handler.rb
+++ b/lib/ceedling/preprocessinator_file_handler.rb
@@ -18,4 +18,17 @@ class PreprocessinatorFileHandler
     @file_wrapper.write(preprocessed_filepath, contents.join("\n"))
   end
 
+  def preprocess_file_directives(filepath, includes)
+    preprocessed_filepath = @file_path_utils.form_preprocessed_file_filepath(filepath)
+
+    command = @tool_executor.build_command_line(@configurator.tools_test_file_preprocessor_directives, [], filepath, preprocessed_filepath)
+    @tool_executor.exec(command[:line], command[:options])
+
+    contents = @preprocessinator_extractor.extract_base_file_from_preprocessed_directives(preprocessed_filepath)
+
+    includes.each{|include| contents.unshift("#include \"#{include}\"")}
+
+    @file_wrapper.write(preprocessed_filepath, contents.join("\n"))
+  end
+
 end

--- a/spec/preprocessinator_extractor_spec.rb
+++ b/spec/preprocessinator_extractor_spec.rb
@@ -42,4 +42,40 @@ describe PreprocessinatorExtractor do
     # # xit "should ignore formatting"
     # # xit "should ignore whitespace"
   end
+
+  context "#extract_base_file_from_preprocessed_directives" do
+    it "should extract last chunk of text after last '#'line containing file name of our filepath" do
+      file_path = "path/to/WANT.c"
+      input_str = [
+        '# 1 "some/file/we/do/not/care/about.c" 5',
+        '#pragma trash',
+        'some_text_we_do_not_want();',
+        '# 1 "some/file/we/DO/WANT.c" 99999',
+        'some_text_we_do_not_want();',
+        '#pragma want',
+        'some_creepy_text_we_not_want();',
+        '# 1 "some/useless/file.c" 9',
+        'a set of junk',
+        'more junk',
+        '# 1 "holy/shoot/yes/WANT.c" 10',
+        '#pragma want',
+        '#define INCREDIBLE_DEFINE 911',
+        'some_additional_awesome_want_text();',
+        'holy_crepes_more_awesome_text();',
+        '# oh darn',
+      ]
+
+      expect_str = [
+        '#pragma want',
+        '#define INCREDIBLE_DEFINE 911',
+        'some_additional_awesome_want_text();',
+        'holy_crepes_more_awesome_text();',
+        '# oh darn',
+      ]
+
+      expect(File).to receive(:readlines).with(file_path).and_return( input_str )
+
+      expect(subject.extract_base_file_from_preprocessed_directives(file_path)).to eq expect_str
+    end
+  end
 end

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -72,6 +72,23 @@ def _add_option_in_project(project_file_path, option, value)
   end
 end
 
+def _add_option_in_unity(project_file_path, option, value)
+  project_file_contents = File.readlines(project_file_path)
+  option_index = project_file_contents.index(":unity:\n")
+
+  if option_index.nil?
+    # Silently add before last '...' element
+    project_file_contents.insert(-2, ":unity:\n")
+    option_index = project_file_contents.index(":unity:\n")
+  end
+
+  project_file_contents.insert(option_index + 1, "  :#{option}: #{value}\n")
+
+  File.open(project_file_path, "w+") do |f|
+    f.puts(project_file_contents)
+  end
+end
+
 def add_source_path(path)
   _add_path_in_section("project.yml", path, "source")
 end
@@ -86,6 +103,10 @@ end
 
 def add_project_option(option, value)
   _add_option_in_project("project.yml", option, value)
+end
+
+def add_unity_option(option, value)
+  _add_option_in_unity("project.yml", option, value)
 end
 
 def add_module_generator_section(project_file_path, mod_gen)
@@ -362,6 +383,23 @@ module CeedlingTestCases
         FileUtils.copy_entry test_asset_path("auto_link_deep_dependencies/src/"), 'src/'
         FileUtils.cp_r test_asset_path("auto_link_deep_dependencies/test/."), 'test/'
         add_project_option("auto_link_deep_dependencies", "TRUE")
+
+        output = `bundle exec ruby -S ceedling 2>&1`
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
+  def can_test_projects_with_enabled_preprocessor_directives_with_success
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("test_example_with_parameterized_tests.c"), 'test/'
+        add_project_option("use_preprocessor_directives", "TRUE")
+        add_unity_option("use_param_tests", "TRUE")
 
         output = `bundle exec ruby -S ceedling 2>&1`
         expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -61,11 +61,11 @@ def _add_option_in_project(project_file_path, option, value)
   option_index = project_file_contents.index(":project:\n")
 
   if option_index.nil?
-    # Something wrong with project.yml file, no paths?
+    # Something wrong with project.yml file, no project section?
     return
   end
 
-  project_file_contents.insert(option_index + 1, "  #{option}: #{value}\n")
+  project_file_contents.insert(option_index + 1, "  :#{option}: #{value}\n")
 
   File.open(project_file_path, "w+") do |f|
     f.puts(project_file_contents)

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -177,6 +177,17 @@ describe "Ceedling" do
     it { can_test_projects_with_enabled_auto_link_deep_deependency_with_success }
   end
 
+  describe "deployed with enabled preprocessor directives" do
+    before do
+      @c.with_context do
+        `bundle exec ruby -S ceedling new --local #{@proj_name} 2>&1`
+      end
+    end
+
+    it { can_create_projects }
+    it { can_test_projects_with_enabled_preprocessor_directives_with_success }
+  end
+
   describe "command: `ceedling examples`" do
     before do
       @c.with_context do


### PR DESCRIPTION
This PR is continuation of #445, but after #491 many of changes are already implemented and this PR becomes more straight forward.

Unity allows to use parameterized tests by TEST_CASE() and TEST_RANGE() macros.
After standard preprocessing when `use_test_preprocessor` option is enabled then macros are fully expanded to C code, so input file in the Unity test runner can not parse special macros and correctly handle parameterized tests.
Luckily in gcc compiler we can use `-fdirectives-only` flag to expand the conditional preprocessor, directives and leave the other content of the file untouched.

For example file with the parameterized tests can looks like below:

```c
#include "unity.h"

#define TEST_CASE(...)
#define TEST_RANGE(...)

void setUp(void) {}
void tearDown(void) {}

TEST_CASE(25)
TEST_CASE(125)
TEST_CASE(5)
void test_should_handle_divisible_by_5_for_parameterized_test_case(int num) {
 TEST_ASSERT_EQUAL_MESSAGE(0, (num % 5), "All The Values Are Divisible By 5");
}

TEST_RANGE([10, 100, 10], [5, 10, 5])
void test_should_handle_a_divisible_by_b_for_parameterized_test_range(int a, int b) {
  TEST_ASSERT_EQUAL_MESSAGE(0, (a % b), "All The a Values Are Divisible By b");
}
```

After standard preprocessing file looks like this:
```c
#include "/x/vendor/ceedling/vendor/unity/src/unity.h"








void setUp(void) {}

void tearDown(void) {}









void test_should_handle_divisible_by_5_for_parameterized_test_case(int num) {

 UnityAssertEqualNumber((UNITY_INT)((0)), (UNITY_INT)(((num % 5))), (("All The Values Are Divisible By 5")), (UNITY_UINT)(13), UNITY_DISPLAY_STYLE_INT);

}





void test_should_handle_a_divisible_by_b_for_parameterized_test_range(int a, int b) {

  UnityAssertEqualNumber((UNITY_INT)((0)), (UNITY_INT)(((a % b))), (("All The a Values Are Divisible By b")), (UNITY_UINT)(18), UNITY_DISPLAY_STYLE_INT);

}

```

As we can see TEST_CASE() and TEST_RANGE() dissapears.

And when directives only flag is enabled:

```c
#include "/x/vendor/ceedling/vendor/unity/src/unity.h"


#define TEST_CASE(...) 

#define TEST_RANGE(...) 



void setUp(void) {}

void tearDown(void) {}



TEST_CASE(25)

TEST_CASE(125)

TEST_CASE(5)

void test_should_handle_divisible_by_5_for_parameterized_test_case(int num) {

 TEST_ASSERT_EQUAL_MESSAGE(0, (num % 5), "All The Values Are Divisible By 5");

}



TEST_RANGE([10, 100, 10], [5, 10, 5])

void test_should_handle_a_divisible_by_b_for_parameterized_test_range(int a, int b) {

  TEST_ASSERT_EQUAL_MESSAGE(0, (a % b), "All The a Values Are Divisible By b");

}

```

situation is much better and TEST_CASE() and TEST_RANGE() can be correctly handled by the Unity test runner an we can enjoy with these nice features :).

The new preprocessor feature can be enabled by `use_preprocessor_directives` option. Maybe this option should be enabled by default, but I was worried about backward compatibility, and the additional `use_preprocessor_directives` option is much safer solution.