### PR TITLE
Add support for mock generation to match the original headers Subdirectory

### DIFF
--- a/lib/ceedling/configurator_builder.rb
+++ b/lib/ceedling/configurator_builder.rb
@@ -316,7 +316,7 @@ class ConfiguratorBuilder
       in_hash[:collection_paths_include]
 
     paths.each do |path|
-      all_headers.include( File.join(path, "*#{in_hash[:extension_header]}") )
+      all_headers.include( File.join(path, "**/*#{in_hash[:extension_header]}") )
     end
 
     @file_system_utils.revise_file_list( all_headers, in_hash[:files_include] )
@@ -458,7 +458,6 @@ class ConfiguratorBuilder
              :collection_test_fixture_extra_link_objects => objects
            }
   end
-
 
   private
 

--- a/lib/ceedling/file_finder.rb
+++ b/lib/ceedling/file_finder.rb
@@ -108,7 +108,7 @@ class FileFinder
         found_file =
           @file_finder_helper.find_file_in_collection(
             source_file,
-            @file_wrapper.directory_listing( File.join(@configurator.cmock_mock_path, '*') ),
+            @file_wrapper.directory_listing( File.join(@configurator.cmock_mock_path, '**/*.*') ),
             complain)
 
       elsif release

--- a/lib/ceedling/file_path_utils.rb
+++ b/lib/ceedling/file_path_utils.rb
@@ -176,6 +176,11 @@ class FilePathUtils
 
   def form_folder_for_mock(mock)
     path = File.dirname(mock).sub(/^#{@configurator.cmock_mock_path}[\\\/]?/, '')
+    
+    # If we dont have a path then File.dirname() returns '.' however, we cannot return this because it would break
+    # dependency handling.
+    return '' if path == '.'
+
     if path != ''
       path = File.join(path, "")
     end

--- a/lib/ceedling/file_path_utils.rb
+++ b/lib/ceedling/file_path_utils.rb
@@ -174,18 +174,27 @@ class FilePathUtils
     return (@file_wrapper.instantiate_file_list(sources)).pathmap("#{@configurator.project_test_build_output_c_path}/%n#{@configurator.extension_object}")
   end
 
+  def form_folder_for_mock(mock)
+    path = File.dirname(mock).sub(/^#{@configurator.cmock_mock_path}[\\\/]?/, '')
+    if path != ''
+      path = File.join(path, "")
+    end
+    return path
+  end
+
   def form_preprocessed_mockable_headers_filelist(mocks)
     list = @file_wrapper.instantiate_file_list(mocks)
     headers = list.map do |file|
+      path_name   = form_folder_for_mock(file)
       module_name = File.basename(file).sub(/^#{@configurator.cmock_mock_prefix}/, '').sub(/\.[a-zA-Z]+$/,'')
-      "#{@configurator.project_test_preprocess_files_path}/#{module_name}#{@configurator.extension_header}"
+      "#{@configurator.project_test_preprocess_files_path}/#{path_name}#{module_name}#{@configurator.extension_header}"
     end
     return headers
   end
 
   def form_mocks_source_filelist(mocks)
     list = (@file_wrapper.instantiate_file_list(mocks))
-    sources = list.map{|file| "#{@configurator.cmock_mock_path}/#{file}#{@configurator.extension_source}"}
+    sources = list.map{|file| "#{@configurator.cmock_mock_path}/#{form_folder_for_mock(file)}#{File.basename(file)}#{@configurator.extension_source}"}
     return sources
   end
 

--- a/lib/ceedling/generator.rb
+++ b/lib/ceedling/generator.rb
@@ -42,12 +42,16 @@ class Generator
     @tool_executor.exec( command[:line], command[:options] )
   end
 
-  def generate_mock(context, header_filepath)
-    arg_hash = {:header_file => header_filepath, :context => context}
+  def generate_mock(context, mock)
+    arg_hash = {:header_file => mock.source, :context => context}
     @plugin_manager.pre_mock_generate( arg_hash )
 
     begin
-      @cmock_builder.cmock.setup_mocks( arg_hash[:header_file] )
+      folder = @file_path_utils.form_folder_for_mock(mock.name)
+      if folder == ''
+        folder = nil
+      end
+      @cmock_builder.cmock.setup_mocks( arg_hash[:header_file], folder )
     rescue
       raise
     ensure

--- a/lib/ceedling/generator_test_runner.rb
+++ b/lib/ceedling/generator_test_runner.rb
@@ -52,7 +52,9 @@ class GeneratorTestRunner
     @test_runner_generator.generate( module_name,
                                      runner_filepath,
                                      test_cases,
-                                     mock_list.map{|f| File.basename(f,'.*')+header_extension},
+                                     mock_list.map{
+                                       |f| @file_path_utils.form_folder_for_mock(f) + File.basename(f,'.*') + header_extension
+                                     },
                                      test_file_includes.map{|f| File.basename(f,'.*')+header_extension})
   end
 end

--- a/lib/ceedling/rules_cmock.rake
+++ b/lib/ceedling/rules_cmock.rake
@@ -5,5 +5,6 @@ rule(/#{CMOCK_MOCK_PREFIX}[^\/\\]+#{'\\'+EXTENSION_SOURCE}$/ => [
       @ceedling[:file_finder].find_header_input_for_mock_file(task_name)
     end  
   ]) do |mock|
-  @ceedling[:generator].generate_mock(TEST_SYM, mock.source)
+
+  @ceedling[:generator].generate_mock(TEST_SYM, mock)
 end

--- a/lib/ceedling/test_includes_extractor.rb
+++ b/lib/ceedling/test_includes_extractor.rb
@@ -102,7 +102,7 @@ class TestIncludesExtractor
 
     includes.each do |include_file|
       # check if include is a mock
-      scan_results = include_file.scan(/(#{mock_prefix}.+)#{'\\'+header_extension}/)
+      scan_results = include_file.scan(/(.*#{mock_prefix}.+)#{'\\'+header_extension}/)
       # add mock to lookup hash
       @mocks[file_key] << scan_results[0][0] if (scan_results.size > 0)
     end


### PR DESCRIPTION
My current project has a very nested folder structure which forces us to use globs in the `:include:` section of our `project.yml` which in turn at some point caused the gcc-compile command to exceed the maximum command-line length. 
In order to fix this i would like to eliminate the need for globs while also allowing us to mock headers located in Subdirectories. 

This pull request allows ceedling to generate mocks for headers located in sub directories. (also requested by #358 )

This allows headers in sub directories to be mocked without using globs in the `:include:` section of the `project.yml`
The following use-cases would now be supported:
```C
#include "Subdir/Mock_Test.h"
#include "Mock_Test2.h"
#include "Subdir1/Subdir2/Mock_Test3.h"
```

### Current Limitations:
- The FFF plugin's `setup_mocks()`-function still needs to be updated to allow sub-directory mocks **(BREAKING CHANGE)**
   Will do that if this is pull-requests is something thats needed/wanted.
- Mocking multiple headers with the same name is currently (probably) not supported because of the way ceedling handles dependencies.
- Unfortunatly a CMock update is required to allow it to generate mocks in Subdirectories.

### Further improvements:
 - Allowing ceedling to mock multiple headers with identical names could maybe achieved by modifying the way dependecy names are generated by [`file_path_utils.rb`](https://github.com/ThrowTheSwitch/Ceedling/blob/master/lib/ceedling/file_path_utils.rb#L116) and modifying the [`preprocessinator.rb`](https://github.com/ThrowTheSwitch/Ceedling/blob/master/lib/ceedling/preprocessinator.rb) to use it.
The [`file_finder.rb`](https://github.com/ThrowTheSwitch/Ceedling/blob/master/lib/ceedling/file_finder.rb) would probably also need to be updated aswell.

Disclaimer: Im no professional ruby developer so im more than happy for any feedback :)
If there are any issues please let me know :)

Related CMock pull request: https://github.com/ThrowTheSwitch/CMock/pull/327
Thanks to @alex116 for is work in #343.