### PR TITLE
gcov plugin - Additional Report Generator Configuration Options

### DIFF
--- a/plugins/gcov/README.md
+++ b/plugins/gcov/README.md
@@ -392,6 +392,24 @@ All generated reports may be found in `build/artifacts/gcov/ReportGenerator`.
 
     # Optional tag or build version.
     :tag: <tag>
+
+    # Optional list of one or more regular expressions to exclude gcov notes files that match these filters.
+    :gcov_exclude:
+      - <exclude_regex1>
+      - <exclude_regex2>
+
+    # Optionally use a particular gcov executable. Defaults to gcov.
+    :gcov_executable: <gcov_cmd>
+
+    # Optionally set the number of threads to use in parallel. Defaults to 1.
+    :num_parallel_threads: <num_threads>
+
+    # Optional list of one or more command line arguments to pass to Report Generator.
+    # Useful for configuring Risk Hotspots and Other Settings.
+    # https://github.com/danielpalme/ReportGenerator/wiki/Settings
+    :custom_args:
+      - <custom_arg1>
+      - <custom_arg2>
 ```
 
 ## Example Usage

--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -37,6 +37,10 @@
     :executable: gcov
     :optional: TRUE
     :arguments:
+      - -b
+      - -c
+      - -r
+      - -x
       - ${1}
   :gcov_gcovr_post_report:
     :executable: gcovr

--- a/plugins/gcov/lib/gcovr_reportinator.rb
+++ b/plugins/gcov/lib/gcovr_reportinator.rb
@@ -21,8 +21,6 @@ class GcovrReportinator
       args = args_common
       args += args_builder_cobertura(opts, false)
       args += args_builder_sonarqube(opts, false)
-      # Note: In gcovr 4.2, the JSON report is output only when the --output option is specified.
-      # Hopefully we can remove --output after a future gcovr release.
       args += args_builder_json(opts, true)
       # As of gcovr version 4.2, the --html argument must appear last.
       args += args_builder_html(opts, false)
@@ -207,6 +205,8 @@ class GcovrReportinator
       end
 
       args += "--json-pretty " if gcovr_opts[:json_pretty]
+      # Note: In gcovr 4.2, the JSON report is output only when the --output option is specified.
+      # Hopefully we can remove --output after a future gcovr release.
       args += "--json #{use_output_option ? "--output " : ""} \"#{artifacts_file_json}\" "
     end
 

--- a/plugins/gcov/lib/reportgenerator_reportinator.rb
+++ b/plugins/gcov/lib/reportgenerator_reportinator.rb
@@ -24,7 +24,7 @@ class ReportGeneratorReportinator
       end
 
       # Use a custom gcov executable, if specified.
-      TOOLS_GCOV_GCOV_POST_REPORT[:executable] = rg_opts[:gcov_executable] unless rg_opts[:gcov_executable].nil?
+      GCOV_TOOL_CONFIG[:executable] = "\"#{rg_opts[:gcov_executable]}\"" unless rg_opts[:gcov_executable].nil?
 
       # Avoid running gcov on the mock, test, unity, and cexception gcov notes files to save time.
       gcno_exclude_str = "#{opts[:cmock_mock_prefix]}.*"
@@ -111,6 +111,9 @@ class ReportGeneratorReportinator
 
   REPORT_GENERATOR_SETTING_PREFIX = "gcov_report_generator"
 
+  # Deep clone the gcov tool config, so we can modify it locally if specified via options.
+  GCOV_TOOL_CONFIG = Marshal.load(Marshal.dump(TOOLS_GCOV_GCOV_POST_REPORT))
+
   # Build the ReportGenerator arguments.
   def args_builder(opts)
     rg_opts = get_opts(opts)
@@ -185,7 +188,7 @@ class ReportGeneratorReportinator
 
   # Run gcov with the given arguments.
   def run_gcov(args)
-    command = @ceedling[:tool_executor].build_command_line(TOOLS_GCOV_GCOV_POST_REPORT, [], args)
+    command = @ceedling[:tool_executor].build_command_line(GCOV_TOOL_CONFIG, [], args)
     return @ceedling[:tool_executor].exec(command[:line], command[:options])
   end
 

--- a/plugins/gcov/lib/reportgenerator_reportinator.rb
+++ b/plugins/gcov/lib/reportgenerator_reportinator.rb
@@ -24,7 +24,7 @@ class ReportGeneratorReportinator
       end
 
       # Use a custom gcov executable, if specified.
-      GCOV_TOOL_CONFIG[:executable] = "\"#{rg_opts[:gcov_executable]}\"" unless rg_opts[:gcov_executable].nil?
+      GCOV_TOOL_CONFIG[:executable] = rg_opts[:gcov_executable] unless rg_opts[:gcov_executable].nil?
 
       # Avoid running gcov on the mock, test, unity, and cexception gcov notes files to save time.
       gcno_exclude_str = "#{opts[:cmock_mock_prefix]}.*"


### PR DESCRIPTION
1. Moved the gcov command line arguments to defaults.yml so they may be overridden in project.yml.
2. Pass "settings:createSubdirectoryForAllReportTypes=true" to Report Generator when multiple reports are specified in project.yml.
3. Skip running gcov on .gcno files that do not have a matching .gcda file.
4. Added gcov:report_generator:gcov_exclude as an optional list of regular expressions to avoid running gcov on files that match these exclude filters.
5. Added gcov:report_generator:num_parallel_threads to tell Report Generator to use the specified number of threads.
6. Added gcov:report_generator:gcov_executable to specify a particular gcov to call when generating .gcov files.
7. Added gcov:report_generator:custom_args as an optional list of command line arguments to pass to Report Generator. Useful for supporting future Report Generator options without updating this plugin and for specifying custom Settings.