### PR TITLE
Add vendor defines for tests with specific defines

### DIFF
--- a/assets/test_example_file_unity_printf.c
+++ b/assets/test_example_file_unity_printf.c
@@ -1,0 +1,12 @@
+#include "unity.h"
+#include "example_file.h"
+#include <stdio.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_add_numbers_adds_numbers(void) {
+  TEST_PRINTF("1 + 1 =%d", 1 + 1);
+  TEST_ASSERT_EQUAL(2, add_numbers(1,1));
+}
+

--- a/assets/tests_with_defines/src/adc_hardware.c
+++ b/assets/tests_with_defines/src/adc_hardware.c
@@ -1,0 +1,11 @@
+#include "adc_hardware.h"
+#include "adc_hardware_configurator.h"
+
+void AdcHardware_Init(void)
+{
+  #ifdef SPECIFIC_CONFIG
+  Adc_ResetSpec();
+  #elif STANDARD_CONFIG
+  Adc_Reset();
+  #endif
+}

--- a/assets/tests_with_defines/src/adc_hardware.h
+++ b/assets/tests_with_defines/src/adc_hardware.h
@@ -1,0 +1,6 @@
+#ifndef _ADCHARDWARE_H
+#define _ADCHARDWARE_H
+
+void AdcHardware_Init(void);
+
+#endif // _ADCHARDWARE_H

--- a/assets/tests_with_defines/src/adc_hardware_configurator.c
+++ b/assets/tests_with_defines/src/adc_hardware_configurator.c
@@ -1,0 +1,11 @@
+#include "adc_hardware_configurator.h"
+
+#ifdef SPECIFIC_CONFIG
+void Adc_ResetSpec(void)
+{
+}
+#elif STANDARD_CONFIG
+void Adc_Reset(void)
+{
+}
+#endif

--- a/assets/tests_with_defines/src/adc_hardware_configurator.h
+++ b/assets/tests_with_defines/src/adc_hardware_configurator.h
@@ -1,0 +1,10 @@
+#ifndef _ADCHARDWARECONFIGURATOR_H
+#define _ADCHARDWARECONFIGURATOR_H
+
+#ifdef SPECIFIC_CONFIG
+void Adc_ResetSpec(void);
+#elif STANDARD_CONFIG
+void Adc_Reset(void);
+#endif
+
+#endif // _ADCHARDWARECONFIGURATOR_H

--- a/assets/tests_with_defines/test/test_adc_hardware.c
+++ b/assets/tests_with_defines/test/test_adc_hardware.c
@@ -1,0 +1,21 @@
+#include "unity.h"
+#include "adc_hardware.h"
+#include "mock_adc_hardware_configurator.h"
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_init_should_call_adc_reset(void)
+{
+  Adc_Reset_Expect();
+
+  // to check if also test file is compiled with this define
+  #ifdef STANDARD_CONFIG
+  AdcHardware_Init();
+  #endif
+}

--- a/assets/tests_with_defines/test/test_adc_hardware_special.c
+++ b/assets/tests_with_defines/test/test_adc_hardware_special.c
@@ -1,0 +1,21 @@
+#include "unity.h"
+#include "adc_hardware.h"
+#include "mock_adc_hardware_configurator.h"
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_init_should_call_special_adc_reset(void)
+{
+  Adc_ResetSpec_Expect();
+
+  // to check if also test file is compiled with this define
+  #ifdef SPECIFIC_CONFIG
+  AdcHardware_Init();
+  #endif
+}

--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -1315,13 +1315,16 @@ Example [:extension] YAML blurb
 
 * `<test_name>`:
 
-  Add preprocessor definitions for specified `<test_name>`. For example:
+  Replace standard `test` definitions for specified `<test_name>`definitions. For example:
 ```yaml
   :defines:
+    :test:
+      - FOO_STANDARD_CONFIG
     :test_foo_config:
-      - FOO_SPECIFIC_FEATURE
+      - FOO_SPECIFIC_CONFIG
 ```
-  `ceedling test:foo_config` will now have `FOO_SPECIFIC_FEATURE` defined, none of the other tests will.
+  `ceedling test:foo_config` will now have `FOO_SPECIFIC_CONFIG` defined instead of
+  `FOO_STANDARD_CONFIG`. None of the other tests will have `FOO_SPECIFIC_SPECIFIC`.
 
   **Default**: `[]` (empty)
 

--- a/lib/ceedling/configurator_builder.rb
+++ b/lib/ceedling/configurator_builder.rb
@@ -384,14 +384,26 @@ class ConfiguratorBuilder
   end
 
 
+  def get_vendor_defines(in_hash)
+    defines = in_hash[:unity_defines].clone
+    defines.concat(in_hash[:cmock_defines])      if (in_hash[:project_use_mocks])
+    defines.concat(in_hash[:cexception_defines]) if (in_hash[:project_use_exceptions])
+
+    return defines
+  end
+
+
+  def collect_vendor_defines(in_hash)
+    return {:collection_defines_vendor => get_vendor_defines(in_hash)}
+  end
+
+
   def collect_test_and_vendor_defines(in_hash)
-    test_defines = in_hash[:defines_test].clone
+    defines = in_hash[:defines_test].clone
+    vendor_defines = get_vendor_defines(in_hash)
+    defines.concat(vendor_defines) if vendor_defines
 
-    test_defines.concat(in_hash[:unity_defines])
-    test_defines.concat(in_hash[:cmock_defines])      if (in_hash[:project_use_mocks])
-    test_defines.concat(in_hash[:cexception_defines]) if (in_hash[:project_use_exceptions])
-
-    return {:collection_defines_test_and_vendor => test_defines}
+    return {:collection_defines_test_and_vendor => defines}
   end
 
 

--- a/lib/ceedling/configurator_setup.rb
+++ b/lib/ceedling/configurator_setup.rb
@@ -39,6 +39,7 @@ class ConfiguratorSetup
     flattened_config.merge!(@configurator_builder.collect_headers(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_release_existing_compilation_input(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_all_existing_compilation_input(flattened_config))
+    flattened_config.merge!(@configurator_builder.collect_vendor_defines(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_test_and_vendor_defines(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_release_and_vendor_defines(flattened_config))
     flattened_config.merge!(@configurator_builder.collect_release_artifact_extra_link_objects(flattened_config))

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -63,6 +63,7 @@ class TestInvoker
           tst_defs_cfg = Array.new(defs_bkp)
           if @configurator.project_config_hash.has_key?(def_test_key.to_sym)
             tst_defs_cfg.replace(@configurator.project_config_hash[def_test_key.to_sym])
+            tst_defs_cfg .concat(COLLECTION_DEFINES_VENDOR) if COLLECTION_DEFINES_VENDOR
           end
           if @configurator.defines_use_test_definition
             tst_defs_cfg << File.basename(test, ".*").strip.upcase.sub(/@.*$/, "")

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -198,7 +198,7 @@ class SystemContext
 
     Dir.chdir @dir do
       with_constrained_env do
-        `bundle config set path '#{@gem.install_dir}'`
+        `bundle config set --local path '#{@gem.install_dir}'`
         `bundle install`
         checks = ["bundle exec ruby -S ceedling 2>&1"]
         checks.each do |c|

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -274,6 +274,27 @@ module CeedlingTestCases
     end
   end
 
+  def can_test_projects_with_test_and_vendor_defines_with_success
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_unity_printf.c"), 'test/'
+        settings = { :unity => { :defines => [ "UNITY_INCLUDE_PRINT_FORMATTED" ] },
+                     :defines => { :test_example_file_unity_printf => [ "TEST" ] }
+                   }
+        add_project_settings("project.yml", settings)
+
+        output = `bundle exec ruby -S ceedling 2>&1`
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
   def can_test_projects_with_enabled_auto_link_deep_deependency_with_success
     @c.with_context do
       Dir.chdir @proj_name do
@@ -480,7 +501,7 @@ module CeedlingTestCases
         # add module path to project file
         settings = { :paths => { :test => [ "myPonies/test" ],
                                  :source => [ "myPonies/src" ]
-                              }
+                               }
                    }
         add_project_settings("project.yml", settings)
 
@@ -542,7 +563,7 @@ module CeedlingTestCases
                                             :inc_root => mod_gen.inc_root,
                                             :test_root => mod_gen.test_root
                                           }
-        }
+                   }
         add_project_settings("project.yml", settings)
 
         # module creation

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'tmpdir'
-require 'yaml'
+require 'ceedling/yaml_wrapper'
+require 'spec_helper'
 
 Modulegenerator = Struct.new(:project_root, :source_root, :inc_root, :test_root) do
   def initialize(project_root: "./", source_root: "src/", inc_root: "src/", test_root: "test/")
@@ -20,140 +21,11 @@ def convert_slashes(path)
   end
 end
 
-def _add_path_in_section(project_file_path, path, section)
-  project_file_contents = File.readlines(project_file_path)
-  paths_index = project_file_contents.index(":paths:\n")
-
-  if paths_index.nil?
-    # Something wrong with project.yml file, no paths?
-    return
-  end
-
-  section_index =  paths_index + project_file_contents[paths_index..-1].index("  :#{section}:\n")
-
-  project_file_contents.insert(section_index + 1, "    - #{path}\n")
-
-  File.open(project_file_path, "w+") do |f|
-    f.puts(project_file_contents)
-  end
-end
-
-def _create_subsection_in_defines_section(project_file_path, subsection)
-  project_file_contents = File.readlines(project_file_path)
-  section_index = project_file_contents.index(":defines:\n")
-
-  if section_index.nil?
-    # Something wrong with project.yml file, no defines?
-    return
-  end
-
-  project_file_contents.insert(section_index + 1, "  :#{subsection}:\n")
-
-  File.open(project_file_path, "w+") do |f|
-    f.puts(project_file_contents)
-  end
-end
-
-def _add_define_in_section(project_file_path, define, section)
-  project_file_contents = File.readlines(project_file_path)
-  defines_index = project_file_contents.index(":defines:\n")
-
-  if defines_index.nil?
-    # Something wrong with project.yml file, no defines?
-    return
-  end
-
-  section_index =  defines_index + project_file_contents[defines_index..-1].index("  :#{section}:\n")
-
-  project_file_contents.insert(section_index + 1, "    - #{define}\n")
-
-  File.open(project_file_path, "w+") do |f|
-    f.puts(project_file_contents)
-  end
-end
-
-def _add_option_in_project(project_file_path, option, value)
-  project_file_contents = File.readlines(project_file_path)
-  option_index = project_file_contents.index(":project:\n")
-
-  if option_index.nil?
-    # Something wrong with project.yml file, no project section?
-    return
-  end
-
-  project_file_contents.insert(option_index + 1, "  :#{option}: #{value}\n")
-
-  File.open(project_file_path, "w+") do |f|
-    f.puts(project_file_contents)
-  end
-end
-
-def _add_option_in_unity(project_file_path, option, value)
-  project_file_contents = File.readlines(project_file_path)
-  option_index = project_file_contents.index(":unity:\n")
-
-  if option_index.nil?
-    # Silently add before last '...' element
-    project_file_contents.insert(-2, ":unity:\n")
-    option_index = project_file_contents.index(":unity:\n")
-  end
-
-  project_file_contents.insert(option_index + 1, "  :#{option}: #{value}\n")
-
-  File.open(project_file_path, "w+") do |f|
-    f.puts(project_file_contents)
-  end
-end
-
-def add_source_path(path)
-  _add_path_in_section("project.yml", path, "source")
-end
-
-def add_test_path(path)
-  _add_path_in_section("project.yml", path, "test")
-end
-
-def add_test_define(define)
-  _add_define_in_section("project.yml", define, "test")
-end
-
-def create_test_name_defines_section(test_name)
-  _create_subsection_in_defines_section("project.yml", test_name)
-end
-
-def add_test_name_define(test_name, define)
-  _add_define_in_section("project.yml", define, test_name)
-end
-
-def add_project_option(option, value)
-  _add_option_in_project("project.yml", option, value)
-end
-
-def add_unity_option(option, value)
-  _add_option_in_unity("project.yml", option, value)
-end
-
-def add_module_generator_section(project_file_path, mod_gen)
-  project_file_contents = File.readlines(project_file_path)
-  module_gen_index = project_file_contents.index(":module_generator:\n")
-
-  unless module_gen_index.nil?
-    # already a module_generator in project file, delete it
-    module_gen_end_index = project_file_contents[module_gen_index..-1].index("\n")
-    project_file_contents.slice[module_gen_index..module_gen_end_index]
-  end
-
-  project_file_contents.insert(-2, "\n")
-  project_file_contents.insert(-2, ":module_generator:\n")
-  project_file_contents.insert(-2, "  :project_root: #{mod_gen.project_root}\n")
-  project_file_contents.insert(-2, "  :source_root: #{mod_gen.source_root}\n")
-  project_file_contents.insert(-2, "  :inc_root: #{mod_gen.inc_root}\n")
-  project_file_contents.insert(-2, "  :test_root: #{mod_gen.test_root}\n")
-  project_file_contents.insert(-2, "\n")
-
-  File.open(project_file_path, "w+") do |f|
-    f.puts(project_file_contents)
-  end
+def add_project_settings(project_file_path, settings)
+  yaml_wrapper = YamlWrapper.new
+  project_hash = yaml_wrapper.load(project_file_path)
+  project_hash.deep_merge(settings)
+  yaml_wrapper.dump(project_file_path, project_hash)
 end
 
 class GemDirLayout
@@ -389,7 +261,8 @@ module CeedlingTestCases
         FileUtils.cp test_asset_path("example_file.h"), 'src/'
         FileUtils.cp test_asset_path("example_file.c"), 'src/'
         FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
-        add_test_define("UNITY_INCLUDE_EXEC_TIME")
+        settings = { :unity => { :defines => [ "UNITY_INCLUDE_EXEC_TIME" ] } }
+        add_project_settings("project.yml", settings)
 
         output = `bundle exec ruby -S ceedling 2>&1`
         expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
@@ -406,7 +279,8 @@ module CeedlingTestCases
       Dir.chdir @proj_name do
         FileUtils.copy_entry test_asset_path("auto_link_deep_dependencies/src/"), 'src/'
         FileUtils.cp_r test_asset_path("auto_link_deep_dependencies/test/."), 'test/'
-        add_project_option("auto_link_deep_dependencies", "TRUE")
+        settings = { :project => { :auto_link_deep_dependencies => true } }
+        add_project_settings("project.yml", settings)
 
         output = `bundle exec ruby -S ceedling 2>&1`
         expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
@@ -422,8 +296,10 @@ module CeedlingTestCases
     @c.with_context do
       Dir.chdir @proj_name do
         FileUtils.cp test_asset_path("test_example_with_parameterized_tests.c"), 'test/'
-        add_project_option("use_preprocessor_directives", "TRUE")
-        add_unity_option("use_param_tests", "TRUE")
+        settings = { :project => { :use_preprocessor_directives => true },
+                     :unity => { :use_param_tests => true }
+                   }
+        add_project_settings("project.yml", settings)
 
         output = `bundle exec ruby -S ceedling 2>&1`
         expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
@@ -440,9 +316,11 @@ module CeedlingTestCases
       Dir.chdir @proj_name do
         FileUtils.copy_entry test_asset_path("tests_with_defines/src/"), 'src/'
         FileUtils.cp_r test_asset_path("tests_with_defines/test/."), 'test/'
-        add_test_define("STANDARD_CONFIG")
-        create_test_name_defines_section("test_adc_hardware_special")
-        add_test_name_define("test_adc_hardware_special", "SPECIFIC_CONFIG")
+        settings = { :defines => { :test => [ "STANDARD_CONFIG" ],
+                                   :test_adc_hardware_special => [ "TEST", "SPECIFIC_CONFIG" ]
+                                 }
+                   }
+        add_project_settings("project.yml", settings)
 
         output = `bundle exec ruby -S ceedling 2>&1`
         expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
@@ -600,8 +478,11 @@ module CeedlingTestCases
         expect(File.exists?("myPonies/test/test_ponies.c")).to eq true
 
         # add module path to project file
-        add_test_path("myPonies/test")
-        add_source_path("myPonies/src")
+        settings = { :paths => { :test => [ "myPonies/test" ],
+                                 :source => [ "myPonies/src" ]
+                              }
+                   }
+        add_project_settings("project.yml", settings)
 
         # See if ceedling finds the test in the subdir
         output = `bundle exec ruby -S ceedling test:all`
@@ -624,7 +505,13 @@ module CeedlingTestCases
       Dir.chdir @proj_name do
         # add include path to module generator
         mod_gen = Modulegenerator.new(inc_root: "inc/")
-        add_module_generator_section("project.yml", mod_gen)
+        settings = { :module_generator => { :project_root => mod_gen.project_root,
+                                            :source_root => mod_gen.source_root,
+                                            :inc_root => mod_gen.inc_root,
+                                            :test_root => mod_gen.test_root
+                                          }
+                   }
+        add_project_settings("project.yml", settings)
 
         # module creation
         output = `bundle exec ruby -S ceedling module:create[myPonies:ponies]`
@@ -650,7 +537,13 @@ module CeedlingTestCases
       Dir.chdir @proj_name do
         # add paths to module generator
         mod_gen = Modulegenerator.new({source_root: "foo/", inc_root: "bar/", test_root: "barz/"})
-        add_module_generator_section("project.yml", mod_gen)
+        settings = { :module_generator => { :project_root => mod_gen.project_root,
+                                            :source_root => mod_gen.source_root,
+                                            :inc_root => mod_gen.inc_root,
+                                            :test_root => mod_gen.test_root
+                                          }
+        }
+        add_project_settings("project.yml", settings)
 
         # module creation
         output = `bundle exec ruby -S ceedling module:create[ponies]`

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -32,6 +32,7 @@ describe "Ceedling" do
     it { can_test_projects_with_test_name_replaced_defines_with_success }
     it { can_test_projects_with_success_default }
     it { can_test_projects_with_unity_exec_time }
+    it { can_test_projects_with_test_and_vendor_defines_with_success }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_fail_alias }
     it { can_test_projects_with_fail_default }
@@ -80,6 +81,7 @@ describe "Ceedling" do
     it { can_test_projects_with_test_name_replaced_defines_with_success }
     it { can_test_projects_with_success_default }
     it { can_test_projects_with_unity_exec_time }
+    it { can_test_projects_with_test_and_vendor_defines_with_success }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_fail_alias }
     it { can_test_projects_with_fail_default }
@@ -108,6 +110,7 @@ describe "Ceedling" do
     it { can_test_projects_with_success_test_alias }
     it { can_test_projects_with_success_default }
     it { can_test_projects_with_unity_exec_time }
+    it { can_test_projects_with_test_and_vendor_defines_with_success }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_fail_alias }
     it { can_test_projects_with_fail_default }
@@ -129,6 +132,7 @@ describe "Ceedling" do
     it { can_test_projects_with_success_test_alias }
     it { can_test_projects_with_success_default }
     it { can_test_projects_with_unity_exec_time }
+    it { can_test_projects_with_test_and_vendor_defines_with_success }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_fail_alias }
     it { can_test_projects_with_fail_default }
@@ -158,6 +162,7 @@ describe "Ceedling" do
     it { can_test_projects_with_test_name_replaced_defines_with_success }
     it { can_test_projects_with_success_default }
     it { can_test_projects_with_unity_exec_time }
+    it { can_test_projects_with_test_and_vendor_defines_with_success }
     it { can_test_projects_with_fail }
     it { can_test_projects_with_compile_error }
     it { can_use_the_module_plugin }

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -29,6 +29,7 @@ describe "Ceedling" do
     it { can_fetch_project_help }
     it { can_test_projects_with_success }
     it { can_test_projects_with_success_test_alias }
+    it { can_test_projects_with_test_name_replaced_defines_with_success }
     it { can_test_projects_with_success_default }
     it { can_test_projects_with_unity_exec_time }
     it { can_test_projects_with_fail }
@@ -76,6 +77,7 @@ describe "Ceedling" do
     it { can_fetch_project_help }
     it { can_test_projects_with_success }
     it { can_test_projects_with_success_test_alias }
+    it { can_test_projects_with_test_name_replaced_defines_with_success }
     it { can_test_projects_with_success_default }
     it { can_test_projects_with_unity_exec_time }
     it { can_test_projects_with_fail }
@@ -153,6 +155,7 @@ describe "Ceedling" do
     it { can_fetch_project_help }
     it { can_test_projects_with_success }
     it { can_test_projects_with_success_test_alias }
+    it { can_test_projects_with_test_name_replaced_defines_with_success }
     it { can_test_projects_with_success_default }
     it { can_test_projects_with_unity_exec_time }
     it { can_test_projects_with_fail }


### PR DESCRIPTION
- Vendor defines shouldn't be removed for test with specified "test_name" defines.
- Test for PR #430
- Add `--local` flag for `bundle config set` command. Without this flag `BUNDLE_PATH` variable from user config file, for ex. the `~/.bundle/config` was overwritten after run `bundle exec rake `.