### PR TITLE
Use local gem and multiple ruby versions in Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,9 @@ jobs:
   unit-tests:
     name: "Unit Tests"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [2.5, 2.6, 2.7]
     steps:
       # Install Binutils, Multilib, etc
       - name: Install C dev Tools
@@ -34,12 +37,17 @@ jobs:
         with: 
           submodules: recursive
 
-      # Install Ruby Testing Tools (Bundler version should match the one in Gemfile.lock)
+      # Setup Ruby Testing Tools to do tests on multiple ruby version
       - name: Setup Ruby Testing Tools
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      # Install Ruby Testing Tools (Bundler version should match the one in Gemfile.lock)
+      - name: Install Ruby Testing Tools
         run: |
-          sudo gem install rspec
-          sudo gem install rubocop -v 0.57.2
-          sudo gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)" 
+          gem install rspec
+          gem install rubocop -v 0.57.2
+          gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
           bundle install
 
       # Run Tests
@@ -51,7 +59,7 @@ jobs:
       - name: Build and Install Gem
         run: |
           gem build ceedling.gemspec
-          sudo gem install --local ceedling-*.gem
+          gem install --local ceedling-*.gem
 
       # Run Blinky
       # Disabled because it's set up for avr-gcc


### PR DESCRIPTION
Hi!

- I noticed the Github Actions starts failing on the current master branch. I think it is caused by some conflicts with system gems.

https://github.com/CezaryGapinski/Ceedling/runs/2007065955?check_suite_focus=true
```
/var/lib/gems/2.5.0/gems/did_you_mean-1.5.0/lib/did_you_mean/version.rb:2: warning: previous definition of VERSION was here
/usr/lib/ruby/vendor_ruby/did_you_mean/jaro_winkler.rb:63: warning: already initialized constant DidYouMean::JaroWinkler::WEIGHT
/var/lib/gems/2.5.0/gems/did_you_mean-1.5.0/lib/did_you_mean/jaro_winkler.rb:63: warning: previous definition of WEIGHT was here
/usr/lib/ruby/vendor_ruby/did_you_mean/jaro_winkler.rb:64: warning: already initialized constant DidYouMean::JaroWinkler::THRESHOLD
/var/lib/gems/2.5.0/gems/did_you_mean-1.5.0/lib/did_you_mean/jaro_winkler.rb:64: warning: previous definition of THRESHOLD was here
```
I managed to resolve it by install gems locally without sudo.

- Thanks to ruby/setup-ruby we can set matrix of ruby versions for tests, and I think it would be nice to have feature to test ceedling on the few selected ruby versions.