### PR TITLE
Changed "Include" section in module_generator readme

### DIFF
--- a/plugins/module_generator/README.md
+++ b/plugins/module_generator/README.md
@@ -72,8 +72,11 @@ by adding to the `:includes` array. For example:
 ```
 :module_generator:
   :includes:
-    - defs.h
-    - board.h
+    :tst:
+      - defs.h
+      - board.h
+    :src:
+      - board.h
 ```
 
 ### Boilerplates


### PR DESCRIPTION
The actual example in the readme isn't working, because of missing subsection array.
Added subsection array like ":src" or ":tst" in the example.