### PR TITLE
Test define customizable in via project.yml

### DIFF
--- a/plugins/module_generator/README.md
+++ b/plugins/module_generator/README.md
@@ -93,6 +93,16 @@ put that corporate copyright notice (or maybe a copyleft notice, if that's your 
     ***************************/
 ```
 
+### Test Defines
+
+You can specify the "#ifdef TEST" at the top of the test files with a custom define.
+This example will put a "#ifdef CEEDLING_TEST" at the top of the test files.  
+
+```
+:module_generator:
+  :test_define: CEEDLING_TEST
+```
+
 ### Naming Convention
 
 Finally, you can force a particular naming convention. Even if someone calls the generator
@@ -105,4 +115,5 @@ Your options are as follows:
   - `:camel` - camelFilesAreSimilarButStartLow
   - `:snake` - snake_case_is_all_lower_and_uses_underscores
   - `:caps`  - CAPS_FEELS_LIKE_YOU_ARE_SCREAMING
+
 

--- a/plugins/module_generator/lib/module_generator.rb
+++ b/plugins/module_generator/lib/module_generator.rb
@@ -46,6 +46,7 @@ class ModuleGenerator < Plugin
       :naming       => ((defined? MODULE_GENERATOR_NAMING      ) ? MODULE_GENERATOR_NAMING : nil ),
       :update_svn   => ((defined? MODULE_GENERATOR_UPDATE_SVN  ) ? MODULE_GENERATOR_UPDATE_SVN : false ),
       :skeleton_path=> ((defined? MODULE_GENERATOR_SOURCE_ROOT ) ? MODULE_GENERATOR_SOURCE_ROOT.gsub('\\', '/').sub(/^\//, '').sub(/\/$/, '') : "src" ),
+      :test_define  => ((defined? MODULE_GENERATOR_TEST_DEFINE ) ? MODULE_GENERATOR_TEST_DEFINE : "TEST" ),
     }
 
     # Read Boilerplate template file.


### PR DESCRIPTION
Hello,
I had the problem, that the recently added "#ifdef TEST" in the testfile didn't work, because I used the define "TEST" for other purposes. This is why I made the define customizable via the project.yml in ceedling. With this, you can use your own define (in my case "CEEDLING_TEST").

I hope its useful :)

Related to Unity pull request: [ThrowTheSwitch/Unity#545](https://github.com/ThrowTheSwitch/Unity/pull/545)