### PR TITLE
Adding Error behavior in folder not found condition

### DIFF
--- a/assets/project_as_gem.yml
+++ b/assets/project_as_gem.yml
@@ -29,6 +29,20 @@
 :extension:
   :executable: .out
 
+# Configuration for errors behaviors
+#   - :not_found: is associated to the behavior when a folder is not found.
+#     This configuration shall have the same indices from :paths: and is configured as follow:
+#       - ERROR: Error is logged and the build is stopped
+#       - WARNING: Warning is logged but build continues
+#       - HIDDEN: Nothing is logged
+#   note: Default value for categories not specified, is "ERROR"
+:errors:
+  :not_found:
+    :paths:
+      :test: ERROR
+      :source: ERROR
+      :support: ERROR
+
 :paths:
   :test:
     - +:test/**

--- a/assets/project_with_guts.yml
+++ b/assets/project_with_guts.yml
@@ -29,6 +29,20 @@
 :extension:
   :executable: .out
 
+# Configuration for errors behaviors
+#   - :not_found: is associated to the behavior when a folder is not found.
+#     This configuration shall have the same indices from :paths: and is configured as follow:
+#       - ERROR: Error is logged and the build is stopped
+#       - WARNING: Warning is logged but build continues
+#       - HIDDEN: Nothing is logged
+#   note: Default value for categories not specified, is "ERROR"
+:errors:
+  :not_found:
+    :paths:
+      :test: ERROR
+      :source: ERROR
+      :support: ERROR
+
 :paths:
   :test:
     - +:test/**

--- a/assets/project_with_guts_gcov.yml
+++ b/assets/project_with_guts_gcov.yml
@@ -28,6 +28,20 @@
 
 :extension:
   :executable: .out
+  
+# Configuration for errors behaviors
+#   - :not_found: is associated to the behavior when a folder is not found.
+#     This configuration shall have the same indices from :paths: and is configured as follow:
+#       - ERROR: Error is logged and the build is stopped
+#       - WARNING: Warning is logged but build continues
+#       - HIDDEN: Nothing is logged
+#   note: Default value for categories not specified, is "ERROR"
+:errors:
+  :not_found:
+    :paths:
+      :test: ERROR
+      :source: ERROR
+      :support: ERROR
 
 :paths:
   :test:


### PR DESCRIPTION
This solution can help project.yml configurations to be shared across different projects with different folder structure. With that, even when a path that doesn't exist is specified under 'source' configuration for example, the user will be able to chose what is the expected behavior:

- ERROR: Error is logged and the build is stopped
- WARNING: Warning is logged but build continues
- HIDDEN: Nothing is logged

In the future, this feature can also implement other behaviors, not only the 'not_found' as created in this pull request.