### PR TITLE
Fixed issue with required Version.rb module on Windows

### DIFF
--- a/bin/ceedling
+++ b/bin/ceedling
@@ -164,7 +164,7 @@ unless (project_found)
 
           # Perform the actual clone of the config file, while updating the version
           File.open(dst_yaml,'w') do |dst|
-            require 'ceedling/version.rb'
+            require File.expand_path(File.join(File.dirname(__FILE__),"..","lib","ceedling","version.rb"))
             dst << File.read(src_yaml).gsub(":ceedling_version: '?'",":ceedling_version: #{Ceedling::Version::CEEDLING}")
             puts "      create  #{dst_yaml}"
           end
@@ -217,7 +217,7 @@ unless (project_found)
 
     desc "version", "return the version of the tools installed"
     def version()
-      require 'ceedling/version.rb'
+      require File.expand_path(File.join(File.dirname(__FILE__),"..","lib","ceedling","version.rb"))
       puts "    Ceedling:: #{Ceedling::Version::CEEDLING}"
       puts "       CMock:: #{Ceedling::Version::CMOCK}"
       puts "       Unity:: #{Ceedling::Version::UNITY}"


### PR DESCRIPTION
Running 'ceedling new project' or even 'ceedling version' in windows with version V0.31.0 is raising errors because ceedling was not able to find version.rb module. 

This fix is replacing the current relative path to this file in ceedling module, with the usage of the absolute folder based on the currently running file. With that, it is expected that independently where the user is running the ceedling build, the module will be always able to find the 'version.rb' as required