### PR TITLE
Fix encode problem in preprocessinator_extractor

### DIFF
--- a/lib/ceedling/preprocessinator_extractor.rb
+++ b/lib/ceedling/preprocessinator_extractor.rb
@@ -16,6 +16,7 @@ class PreprocessinatorExtractor
 
     lines = []
     File.readlines(filepath).each do |line|
+      line.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
       if found_file and not line =~ not_pragma
         lines << line
       else
@@ -41,6 +42,7 @@ class PreprocessinatorExtractor
 
     lines = []
     File.readlines(filepath).each do |line|
+      line.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
       lines << line
 
       if line =~ pattern


### PR DESCRIPTION
Suggested proposition to fix problem with encoding �(replacement character U+FFFD) which is causing 
`ArgumentError: invalid byte sequence in UTF-8 /var/lib/gems/2.5.0/gems/ceedling-0.31.0/lib/ceedling/preprocessinator_extractor.rb:46:in =~'``

 https://github.com/ThrowTheSwitch/Ceedling/issues/577