### PR TITLE
Account for different ordering of files when traversing filesystem

### DIFF
--- a/lib/ceedling/file_system_utils.rb
+++ b/lib/ceedling/file_system_utils.rb
@@ -53,7 +53,7 @@ class FileSystemUtils
       FilePathUtils.add_path?(path) ? plus.merge(dirs) : minus.merge(dirs)
     end
 
-    return (plus - minus).to_a.uniq
+    return (plus - minus).to_a.uniq.sort
   end
 
 


### PR DESCRIPTION
When using this tool to build release binaries, I found it was important to force a consistent order of files fed to the linker across machines.