### PR TITLE
Update eval_path_list method to recognize entries with semicolon.

### DIFF
--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -368,13 +368,14 @@ class Configurator
   end
 
   def eval_path_list( paths )
-    if paths.kind_of?(Array)
-      paths = Array.new(paths)
-    end
+    temp = []
 
     paths.flatten.each do |path|
       path.replace( @system_wrapper.module_eval( path ) ) if (path =~ RUBY_STRING_REPLACEMENT_PATTERN)
+      temp.append(path.split(";"))
     end
+
+    paths.replace(temp)
   end
 
 

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -372,7 +372,7 @@ class Configurator
 
     paths.flatten.each do |path|
       path.replace( @system_wrapper.module_eval( path ) ) if (path =~ RUBY_STRING_REPLACEMENT_PATTERN)
-      temp.append(path.split(";"))
+      temp.append(path.split(File::PATH_SEPARATOR))
     end
 
     paths.replace(temp)


### PR DESCRIPTION
Updated eval_path_list method to recognize path entries separated by semicolon. It allows different formats and moreover, the usage of environment variables within the :paths: key.

Below an example using an environment variable being used on the :source: folders. The user can define this variable with all the necessary folders separated by a semicolon (e.g):
"../folderA;../folderB/"

:paths:
  :test:
    - test/**
    - -:test/support/**
  :source:
    - "#{ENV['INCLUDE_DIR']}"