### PR TITLE
Fixed issue 588 with space between # and include preprocessor directive

### DIFF
--- a/lib/ceedling/test_includes_extractor.rb
+++ b/lib/ceedling/test_includes_extractor.rb
@@ -57,7 +57,7 @@ class TestIncludesExtractor
 
     contents.split("\n").each do |line|
       # look for include statement
-      scan_results = line.scan(/#include\s+\"\s*(.+#{'\\'+header_extension})\s*\"/)
+      scan_results = line.scan(/#\s*include\s+\"\s*(.+#{'\\'+header_extension})\s*\"/)
 
       includes << scan_results[0][0] if (scan_results.size > 0)
 


### PR DESCRIPTION
Fix the regex in extract_from_file function to proper parse
'# include' preprocessor directive.

The problem was mentioned under:
https://github.com/ThrowTheSwitch/Ceedling/issues/588