### PR TITLE
Separate build directories for customized tests

### DIFF
--- a/lib/ceedling/cacheinator.rb
+++ b/lib/ceedling/cacheinator.rb
@@ -32,12 +32,6 @@ class Cacheinator
     return @cacheinator_helper.diff_cached_config?( cached_filepath, hash )
   end
 
-  def diff_cached_test_defines?(files)
-    cached_filepath = @file_path_utils.form_test_build_cache_path(DEFINES_DEPENDENCY_CACHE_FILE)
-
-    return @cacheinator_helper.diff_cached_defines?( cached_filepath, files )
-  end
-
   def diff_cached_release_config?(hash)
     cached_filepath = @file_path_utils.form_release_build_cache_path(INPUT_CONFIGURATION_CACHE_FILE)
 

--- a/lib/ceedling/cacheinator_helper.rb
+++ b/lib/ceedling/cacheinator_helper.rb
@@ -9,27 +9,4 @@ class CacheinatorHelper
     return false
   end
 
-  def diff_cached_defines?(cached_filepath, files)
-    changed_defines = false
-    current_defines = COLLECTION_DEFINES_TEST_AND_VENDOR.reject(&:empty?)
-
-    current_dependencies = Hash[files.collect { |source| [source, current_defines.dup] }]
-    if not @file_wrapper.exist?(cached_filepath)
-      @yaml_wrapper.dump(cached_filepath, current_dependencies)
-      return changed_defines
-    end
-
-    dependencies = @yaml_wrapper.load(cached_filepath)
-    common_dependencies = current_dependencies.select { |file, defines| dependencies.has_key?(file) }
-
-    if dependencies.values_at(*common_dependencies.keys) != common_dependencies.values
-      changed_defines = true
-    end
-
-    dependencies.merge!(current_dependencies)
-    @yaml_wrapper.dump(cached_filepath, dependencies)
-
-    return changed_defines
-  end
-
 end

--- a/lib/ceedling/cmock_builder.rb
+++ b/lib/ceedling/cmock_builder.rb
@@ -3,13 +3,20 @@ require 'cmock'
 class CmockBuilder
   
   attr_accessor :cmock
+  attr_reader :cmock_config
   
   def setup 
     @cmock = nil
+    @cmock_config = nil
   end
   
   def manufacture(cmock_config)
     @cmock = CMock.new(cmock_config)
+    @cmock_config = cmock_config.clone
+  end
+
+  def clone_mock_generator(cmock_config)
+    return @cmock.class.new(cmock_config)
   end
 
 end

--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -63,7 +63,6 @@ DEFAULT_CEEDLING_MAIN_PROJECT_FILE = 'project.yml' unless defined?(DEFAULT_CEEDL
 DEFAULT_CEEDLING_USER_PROJECT_FILE = 'user.yml'    unless defined?(DEFAULT_CEEDLING_USER_PROJECT_FILE) # supplemental user config file
 
 INPUT_CONFIGURATION_CACHE_FILE     = 'input.yml'   unless defined?(INPUT_CONFIGURATION_CACHE_FILE)     # input configuration file dump
-DEFINES_DEPENDENCY_CACHE_FILE      = 'defines_dependency.yml' unless defined?(DEFINES_DEPENDENCY_CACHE_FILE) # preprocessor definitions for files
 
 TEST_ROOT_NAME    = 'test'                unless defined?(TEST_ROOT_NAME)
 TEST_TASK_ROOT    = TEST_ROOT_NAME + ':'  unless defined?(TEST_TASK_ROOT)

--- a/lib/ceedling/dependinator.rb
+++ b/lib/ceedling/dependinator.rb
@@ -38,23 +38,20 @@ class Dependinator
 
 
   def enhance_runner_dependencies(runner_filepath)
-    @rake_wrapper[runner_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
-      @project_config_manager.test_defines_changed)
+    @rake_wrapper[runner_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if @project_config_manager.test_config_changed
   end
 
 
   def enhance_shallow_include_lists_dependencies(include_lists)
     include_lists.each do |include_list_filepath|
-      @rake_wrapper[include_list_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
-        @project_config_manager.test_defines_changed)
+      @rake_wrapper[include_list_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if @project_config_manager.test_config_changed
     end
   end
 
 
   def enhance_preprocesed_file_dependencies(files)
     files.each do |filepath|
-      @rake_wrapper[filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
-        @project_config_manager.test_defines_changed)
+      @rake_wrapper[filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if @project_config_manager.test_config_changed
     end
   end
 
@@ -62,8 +59,7 @@ class Dependinator
   def enhance_mock_dependencies(mocks_list)
     # if input configuration or ceedling changes, make sure these guys get rebuilt
     mocks_list.each do |mock_filepath|
-      @rake_wrapper[mock_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
-        @project_config_manager.test_defines_changed)
+      @rake_wrapper[mock_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if @project_config_manager.test_config_changed
       @rake_wrapper[mock_filepath].enhance( @configurator.cmock_unity_helper )                    if (@configurator.cmock_unity_helper)
     end
   end
@@ -71,16 +67,14 @@ class Dependinator
 
   def enhance_dependencies_dependencies(dependencies)
     dependencies.each do |dependencies_filepath|
-      @rake_wrapper[dependencies_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
-        @project_config_manager.test_defines_changed)
+      @rake_wrapper[dependencies_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if @project_config_manager.test_config_changed
     end
   end
 
 
   def enhance_test_build_object_dependencies(objects)
     objects.each do |object_filepath|
-      @rake_wrapper[object_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if (@project_config_manager.test_config_changed ||
-        @project_config_manager.test_defines_changed)
+      @rake_wrapper[object_filepath].enhance( [@configurator.project_test_force_rebuild_filepath] ) if @project_config_manager.test_config_changed
     end
   end
 

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -270,6 +270,7 @@ test_invoker:
   compose:
     - configurator
     - test_invoker_helper
+    - test_config_customizator
     - plugin_manager
     - streaminator
     - preprocessinator
@@ -279,7 +280,6 @@ test_invoker:
     - build_invoker_utils
     - file_path_utils
     - file_wrapper
-    - cmock_builder
 
 test_invoker_helper:
   compose:
@@ -289,6 +289,13 @@ test_invoker_helper:
     - file_finder
     - file_path_utils
     - file_wrapper
+
+test_config_customizator:
+  compose:
+    - configurator
+    - streaminator
+    - file_wrapper
+    - cmock_builder
 
 release_invoker:
   compose:

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -279,6 +279,7 @@ test_invoker:
     - build_invoker_utils
     - file_path_utils
     - file_wrapper
+    - cmock_builder
 
 test_invoker_helper:
   compose:

--- a/lib/ceedling/preprocessinator.rb
+++ b/lib/ceedling/preprocessinator.rb
@@ -21,8 +21,6 @@ class Preprocessinator
 
     mocks_list = @preprocessinator_helper.assemble_mocks_list(test)
 
-    @project_config_manager.process_test_defines_change(mocks_list)
-
     @preprocessinator_helper.preprocess_mockable_headers(mocks_list, @preprocess_mock_file_proc)
 
     @task_invoker.invoke_test_mocks(mocks_list)

--- a/lib/ceedling/project_config_manager.rb
+++ b/lib/ceedling/project_config_manager.rb
@@ -3,7 +3,7 @@ require 'ceedling/constants'
 
 class ProjectConfigManager
 
-  attr_reader   :options_files, :release_config_changed, :test_config_changed, :test_defines_changed
+  attr_reader   :options_files, :release_config_changed, :test_config_changed
   attr_accessor :config_hash
 
   constructor :cacheinator, :configurator, :yaml_wrapper, :file_wrapper
@@ -13,7 +13,6 @@ class ProjectConfigManager
     @options_files = []
     @release_config_changed = false
     @test_config_changed    = false
-    @test_defines_changed   = false
   end
 
 
@@ -41,12 +40,4 @@ class ProjectConfigManager
     @test_config_changed = @cacheinator.diff_cached_test_config?( @config_hash )
   end
 
-  def process_test_defines_change(files)
-    # has definitions changed since last test build
-    @test_defines_changed = @cacheinator.diff_cached_test_defines?( files )
-    if @test_defines_changed
-      # update timestamp for rake task prerequisites
-      @file_wrapper.touch( @configurator.project_test_force_rebuild_filepath, :mtime => Time.now + 10 )
-    end
-  end
 end

--- a/lib/ceedling/task_invoker.rb
+++ b/lib/ceedling/task_invoker.rb
@@ -46,31 +46,21 @@ class TaskInvoker
     return @rake_utils.task_invoked?(regex)
   end
 
-  def reset_rake_task_for_changed_defines(file)
-    if !(file =~ /#{VENDORS_FILES.map{|ignore| '\b' + ignore.ext(File.extname(file)) + '\b'}.join('|')}$/)
-      @rake_wrapper[file].clear_actions if @first_run == false && @project_config_manager.test_defines_changed
-      @rake_wrapper[file].reenable if @first_run == false && @project_config_manager.test_defines_changed
-    end
-  end
-
   def invoke_test_mocks(mocks)
     @dependinator.enhance_mock_dependencies( mocks )
     mocks.each { |mock|
-      reset_rake_task_for_changed_defines( mock )
       @rake_wrapper[mock].invoke
     }
   end
   
   def invoke_test_runner(runner)
     @dependinator.enhance_runner_dependencies( runner )
-    reset_rake_task_for_changed_defines( runner )
     @rake_wrapper[runner].invoke
   end
 
   def invoke_test_shallow_include_lists(files)
     @dependinator.enhance_shallow_include_lists_dependencies( files )
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
-      reset_rake_task_for_changed_defines( file )
       @rake_wrapper[file].invoke
     end
   end
@@ -78,7 +68,6 @@ class TaskInvoker
   def invoke_test_preprocessed_files(files)
     @dependinator.enhance_preprocesed_file_dependencies( files )
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
-      reset_rake_task_for_changed_defines( file )
       @rake_wrapper[file].invoke
     end
   end
@@ -86,14 +75,12 @@ class TaskInvoker
   def invoke_test_dependencies_files(files)
     @dependinator.enhance_dependencies_dependencies( files )
     par_map(PROJECT_COMPILE_THREADS, files) do |file|
-      reset_rake_task_for_changed_defines( file )
       @rake_wrapper[file].invoke
     end
   end
 
   def invoke_test_objects(objects)
     par_map(PROJECT_COMPILE_THREADS, objects) do |object|
-      reset_rake_task_for_changed_defines( object )
       @rake_wrapper[object].invoke
     end
   end

--- a/lib/ceedling/test_config_customizator.rb
+++ b/lib/ceedling/test_config_customizator.rb
@@ -1,0 +1,109 @@
+
+class TestConfigCustomizator
+
+  constructor :configurator,
+              :streaminator,
+              :file_wrapper,
+              :cmock_builder
+
+  def setup
+    @standard_test_defines = {}
+    @standard_test_paths = {}
+    @standard_cmock = {}
+  end
+
+
+  def is_customized_test(test_name)
+    def_test_key = "defines_#{test_name.downcase}".to_sym
+    @configurator.project_config_hash.has_key?(def_test_key) || @configurator.defines_use_test_definition
+  end
+
+  def backup_test_config
+    backup_standard_test_defines()
+    backup_standard_test_paths()
+  end
+
+  def restore_test_config
+    @streaminator.stdout_puts("Restored defines and build path to standard", Verbosity::NORMAL)
+    set_standard_test_defines()
+    set_standard_test_build_path()
+  end
+
+  def prepare_customized_test_config(test_name)
+    @streaminator.stdout_puts("Updating test definitions and build path for #{test_name}", Verbosity::NORMAL)
+    set_custom_test_defines(test_name)
+    set_custom_test_build_path(test_name)
+  end
+
+  private
+
+  def backup_standard_test_defines
+    @standard_test_defines = Array.new(COLLECTION_DEFINES_TEST_AND_VENDOR)
+  end
+
+  def set_standard_test_defines
+    COLLECTION_DEFINES_TEST_AND_VENDOR.replace(@standard_test_defines)
+  end
+
+  def set_custom_test_defines(test_name)
+    def_test_key = "defines_#{test_name.downcase}".to_sym
+    test_defs_cfg = Array.new(COLLECTION_DEFINES_TEST_AND_VENDOR)
+    if @configurator.project_config_hash.has_key?(def_test_key)
+      test_defs_cfg.replace(@configurator.project_config_hash[def_test_key])
+      test_defs_cfg .concat(COLLECTION_DEFINES_VENDOR) if COLLECTION_DEFINES_VENDOR
+    end
+    if @configurator.defines_use_test_definition
+      test_defs_cfg << test_name.strip.upcase.sub(/@.*$/, "")
+    end
+    COLLECTION_DEFINES_TEST_AND_VENDOR.replace(test_defs_cfg)
+  end
+
+  def backup_standard_test_paths
+    @standard_test_paths[:project_test_build_output_path] = @configurator.project_test_build_output_path
+    @standard_test_paths[:project_test_build_output_asm_path] = @configurator.project_test_build_output_asm_path
+    @standard_test_paths[:project_test_build_output_c_path] = @configurator.project_test_build_output_c_path
+    @standard_test_paths[:project_test_build_cache_path] = @configurator.project_test_build_cache_path
+    @standard_test_paths[:project_test_dependencies_path] = @configurator.project_test_dependencies_path
+    if @configurator.project_use_test_preprocessor
+      @standard_test_paths[:project_test_preprocess_includes_path] = @configurator.project_test_preprocess_includes_path
+      @standard_test_paths[:project_test_preprocess_files_path] = @configurator.project_test_preprocess_files_path
+    end
+
+    if @configurator.project_use_mocks
+      @standard_test_paths[:cmock_mock_path] = @configurator.cmock_mock_path
+      @standard_cmock[:cmock] = @cmock_builder.cmock
+      @standard_cmock[:tool_search_paths] = Array.new(COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR)
+    end
+  end
+
+  def set_standard_test_build_path
+    @standard_test_paths.each do |config, path|
+      @configurator.project_config_hash[config] = path
+    end
+
+    if @configurator.project_use_mocks
+      @cmock_builder.cmock = @standard_cmock[:cmock]
+      COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR.replace(@standard_cmock[:tool_search_paths])
+    end
+  end
+
+  def set_custom_test_build_path(test_name)
+    @standard_test_paths.each do |config, path|
+      @configurator.project_config_hash[config] = File.join(path, test_name)
+      @file_wrapper.mkdir(@configurator.project_config_hash[config])
+    end 
+
+    if @configurator.project_use_mocks
+      cmock_config = @cmock_builder.cmock_config.clone
+      cmock_config[:mock_path] = @configurator.project_config_hash[:cmock_mock_path]
+      # fff replace @cmock_bulder.cmock from CMock during setup
+      # we have to create new CMock of fff or other mock generator
+      mock_generator = @cmock_builder.clone_mock_generator(cmock_config)
+      @cmock_builder.cmock = mock_generator
+      COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR.map! do |path|
+        path == @standard_test_paths[:cmock_mock_path] ? @configurator.cmock_mock_path : path
+      end
+    end
+  end
+
+end

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -139,8 +139,6 @@ class TestInvoker
         no_link_objects = @file_path_utils.form_test_build_objects_filelist(@preprocessinator.preprocess_shallow_source_includes( test ))
         objects = objects.uniq - no_link_objects
 
-        @project_config_manager.process_test_defines_change(@project_config_manager.filter_internal_sources(sources))
-
         # clean results files so we have a missing file with which to kick off rake's dependency rules
         @test_invoker_helper.clean_results( {:pass => results_pass, :fail => results_fail}, options )
 


### PR DESCRIPTION
This PR is the extension of PR #591. 

Previous approach with dependency tracking for custom preprocessor defines for test was too complex and looks more like a dirty hack than a clean solution.
The preprocessed headers for mocks, output files, etc. with different defines are actually a different files even if names are the same between tests.
Let use use customized build directories for test with specific configuration and standard paths when only standard defines are used and files can be shared between standard tests .
I think it also useful for running tests in parallel  because we can add separated files to a list of files in one step and next call compiler tool to generate outputs.

I can rebase this PR after merge #591.