### PR TITLE
Fix the junit_test_reporter to fit Ant and Surfire test schema

### DIFF
--- a/plugins/junit_tests_report/lib/junit_tests_report.rb
+++ b/plugins/junit_tests_report/lib/junit_tests_report.rb
@@ -44,7 +44,7 @@ class JunitTestsReport < Plugin
   def write_header( results, stream )
     results[:counts][:time] = @time_result.reduce(0, :+)
     stream.puts '<?xml version="1.0" encoding="utf-8" ?>'
-    stream.puts('<testsuites tests="%<total>d" failures="%<failed>d" skipped="%<ignored>d" time="%<time>f">' % results[:counts])
+    stream.puts('<testsuites tests="%<total>d" failures="%<failed>d" time="%<time>.3f">' % results[:counts])
   end
 
   def write_footer( stream )
@@ -53,7 +53,7 @@ class JunitTestsReport < Plugin
 
   def reorganise_results( results )
     # Reorganise the output by test suite instead of by result
-    suites = Hash.new{ |h,k| h[k] = {collection: [], total: 0, success: 0, failed: 0, ignored: 0, stdout: []} }
+    suites = Hash.new{ |h,k| h[k] = {collection: [], total: 0, success: 0, failed: 0, ignored: 0, errors: 0, stdout: []} }
     results[:successes].each do |result|
       source = result[:source]
       name = source[:file].sub(/\..{1,4}$/, "")
@@ -85,7 +85,7 @@ class JunitTestsReport < Plugin
 
   def write_suite( suite, stream )
     suite[:time] = @time_result.shift
-    stream.puts('  <testsuite name="%<name>s" tests="%<total>d" failures="%<failed>d" skipped="%<ignored>d" time="%<time>f">' % suite)
+    stream.puts('  <testsuite name="%<name>s" tests="%<total>d" failures="%<failed>d" skipped="%<ignored>d" errors="%<errors>d" time="%<time>.3f">' % suite)
 
     suite[:collection].each do |test|
       write_test( test, stream )
@@ -116,9 +116,9 @@ class JunitTestsReport < Plugin
 
     case test[:result]
     when :success
-      stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>f"/>' % test)
+      stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>.3f"/>' % test)
     when :failed
-      stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>f">' % test)
+      stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>.3f">' % test)
       if test[:message].empty?
         stream.puts('      <failure />')
       else
@@ -126,7 +126,7 @@ class JunitTestsReport < Plugin
       end
       stream.puts('    </testcase>')
     when :ignored
-      stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>f">' % test)
+      stream.puts('    <testcase name="%<test>s" time="%<unity_test_time>.3f">' % test)
       stream.puts('      <skipped />')
       stream.puts('    </testcase>')
     end


### PR DESCRIPTION
Hi

I would like to propose small fix to junit xml format which is generated for *:junit_tests_report:*

1. Surfire test
Current format is not compatible with schema as:
http://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd

The time generated by reporter and added to report file in time argument is failing as is not fitting to  pattern '(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})
`
report_junit.xml:cvc-pattern-valid: Value '0.003235' is not facet-valid with respect to pattern '(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?' for type 'SUREFIRE_TIME'
`

2. Ant
    - Add missing errors attribute under test suite node `report_junit.xml:cvc-complex-type.4: Attribute 'errors' must appear on element 'testsuite'.`
    - Remove skipped attribute from test suites node as invalid argument `report_junit.xml:cvc-complex-type.3.2.2: Attribute 'skipped' is not allowed to appear in element 'testsuites`

This unblocks creating test reports under build system such as Jenkins.