### PR TITLE
Replace Deprecated File.exists? methods

### DIFF
--- a/bin/ceedling
+++ b/bin/ceedling
@@ -6,10 +6,10 @@ require 'fileutils'
 
 # Check for the main project file (either the one defined in the ENV or the default)
 main_filepath = ENV['CEEDLING_MAIN_PROJECT_FILE']
-project_found = (!main_filepath.nil? && File.exists?(main_filepath))
+project_found = (!main_filepath.nil? && File.exist?(main_filepath))
 if (!project_found)
   main_filepath = "project.yml"
-  project_found = File.exists?(main_filepath)
+  project_found = File.exist?(main_filepath)
 end
 
 def is_windows?
@@ -57,7 +57,7 @@ unless (project_found)
       rescue
         raise "ERROR: Could not find valid project file '#{yaml_path}'"
       end
-      found_docs = File.exists?( File.join(name, "docs", "CeedlingPacket.md") )
+      found_docs = File.exist?( File.join(name, "docs", "CeedlingPacket.md") )
       copy_assets_and_create_structure(name, silent, true, {:upgrade => true, :no_configs => true, :local => as_local, :docs => found_docs})
     end
 
@@ -262,16 +262,16 @@ else
     :add_path => [],
     :path_connector => (platform == :mswin) ? ";" : ":",
     :graceful_fail => false,
-    :which_ceedling => (Dir.exists?("vendor/ceedling") ? "vendor/ceedling" : 'gem'),
+    :which_ceedling => (Dir.exist?("vendor/ceedling") ? "vendor/ceedling" : 'gem'),
     :default_tasks => [ 'test:all' ],
     :list_tasks => false
   }
 
   #guess that we need a special script file first if it exists
   if (platform == :mswin)
-    options[:pretest] = File.exists?("#{ platform.to_s }_setup.bat") ? "#{ platform.to_s }_setup.bat" : nil
+    options[:pretest] = File.exist?("#{ platform.to_s }_setup.bat") ? "#{ platform.to_s }_setup.bat" : nil
   else
-    options[:pretest] = File.exists?("#{ platform.to_s }_setup.sh") ? "source #{ platform.to_s }_setup.sh" : nil
+    options[:pretest] = File.exist?("#{ platform.to_s }_setup.sh") ? "source #{ platform.to_s }_setup.sh" : nil
   end
 
   #merge in project settings if they can be found here
@@ -318,7 +318,7 @@ else
   end
 
   # Load Ceedling (either through the rakefile OR directly)
-  if (File.exists?("rakefile.rb"))
+  if (File.exist?("rakefile.rb"))
     load 'rakefile.rb'
   else
     if (options[:which_ceedling] == 'gem')

--- a/lib/ceedling/configurator_builder.rb
+++ b/lib/ceedling/configurator_builder.rb
@@ -294,7 +294,7 @@ class ConfiguratorBuilder
   def collect_source(in_hash)
     all_source = @file_wrapper.instantiate_file_list
     in_hash[:collection_paths_source].each do |path|
-      if File.exists?(path) and not File.directory?(path)
+      if File.exist?(path) and not File.directory?(path)
         all_source.include( path )
       else
         all_source.include( File.join(path, "*#{in_hash[:extension_source]}") )
@@ -336,7 +336,7 @@ class ConfiguratorBuilder
 
     paths.each do |path|
       release_input.include( File.join(path, "*#{in_hash[:extension_header]}") )
-      if File.exists?(path) and not File.directory?(path)
+      if File.exist?(path) and not File.directory?(path)
         release_input.include( path )
       else
         release_input.include( File.join(path, "*#{in_hash[:extension_source]}") )
@@ -366,7 +366,7 @@ class ConfiguratorBuilder
 
     paths.each do |path|
       all_input.include( File.join(path, "*#{in_hash[:extension_header]}") )
-      if File.exists?(path) and not File.directory?(path)
+      if File.exist?(path) and not File.directory?(path)
         all_input.include( path )
       else
         all_input.include( File.join(path, "*#{in_hash[:extension_source]}") )

--- a/lib/ceedling/dependinator.rb
+++ b/lib/ceedling/dependinator.rb
@@ -12,7 +12,7 @@ class Dependinator
 
   def load_release_object_deep_dependencies(dependencies_list)
     dependencies_list.each do |dependencies_file|
-      if File.exists?(dependencies_file)
+      if File.exist?(dependencies_file)
         @rake_wrapper.load_dependencies( dependencies_file )
       end
     end
@@ -30,7 +30,7 @@ class Dependinator
   def load_test_object_deep_dependencies(files_list)
     dependencies_list = @file_path_utils.form_test_dependencies_filelist(files_list)
     dependencies_list.each do |dependencies_file|
-      if File.exists?(dependencies_file)
+      if File.exist?(dependencies_file)
         @rake_wrapper.load_dependencies(dependencies_file)
       end
     end

--- a/lib/ceedling/target_loader.rb
+++ b/lib/ceedling/target_loader.rb
@@ -27,7 +27,7 @@ module TargetLoader
                target_path.call(targets[:default_target])
              end
 
-    unless File.exists? target
+    unless File.exist? target
       raise NoSuchTarget.new("No such target: #{target}")
     end
 

--- a/lib/ceedling/tasks_filesystem.rake
+++ b/lib/ceedling/tasks_filesystem.rake
@@ -60,7 +60,7 @@ task :directories => PROJECT_BUILD_PATHS
 # when the force file doesn't exist, it probably means we clobbered or are on a fresh
 # install. In either case, stuff was deleted, so assume we want to rebuild it all
 file @ceedling[:configurator].project_test_force_rebuild_filepath do
-  unless File.exists?(@ceedling[:configurator].project_test_force_rebuild_filepath)
+  unless File.exist?(@ceedling[:configurator].project_test_force_rebuild_filepath)
     @ceedling[:dependinator].touch_force_rebuild_files
   end
 end

--- a/lib/ceedling/version.rb
+++ b/lib/ceedling/version.rb
@@ -9,13 +9,13 @@ module Ceedling
       # Check for local or global version of vendor directory in order to look up versions
       path1 = File.expand_path( File.join("..","..","vendor",path) )
       path2 = File.expand_path( File.join(File.dirname(__FILE__),"..","..","vendor",path) )
-      filename = if (File.exists?(path1))
+      filename = if (File.exist?(path1))
         path1
-      elsif (File.exists?(path2))
+      elsif (File.exist?(path2))
         path2
-      elsif File.exists?(CEEDLING_VENDOR)
+      elsif File.exist?(CEEDLING_VENDOR)
         path3 = File.expand_path( File.join(CEEDLING_VENDOR,path) )
-        if (File.exists?(path3))
+        if (File.exist?(path3))
           path3
         else
           basepath = File.join( CEEDLING_VENDOR, path.split(/\\\//)[0], 'release')

--- a/plugins/compile_commands_json/lib/compile_commands_json.rb
+++ b/plugins/compile_commands_json/lib/compile_commands_json.rb
@@ -5,7 +5,7 @@ require 'json'
 class CompileCommandsJson < Plugin
   def setup
     @fullpath = File.join(PROJECT_BUILD_ARTIFACTS_ROOT, "compile_commands.json")
-    @database = if (File.exists?(@fullpath))
+    @database = if (File.exist?(@fullpath))
                   JSON.parse( File.read(@fullpath) )
                 else
                   []

--- a/plugins/dependencies/dependencies.rake
+++ b/plugins/dependencies/dependencies.rake
@@ -24,7 +24,7 @@ DEPENDENCIES_LIBRARIES.each do |deplib|
 
       # We double-check that it doesn't already exist, because this process sometimes
       # produces multiple files, but they may have already been flagged as invoked
-      unless (File.exists?(path))
+      unless (File.exist?(path))
 
         # Set Environment Variables, Fetch, and Build
         @ceedling[DEPENDENCIES_SYM].set_env_if_required(path)

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -98,7 +98,7 @@ class Gcov < Plugin
     ignore_path_list = @ceedling[:file_system_utils].collect_paths(@ceedling[:configurator].project_config_hash[:gcov_uncovered_ignore_list] || [])
     ignore_uncovered_list = @ceedling[:file_wrapper].instantiate_file_list
     ignore_path_list.each do |path|
-      if File.exists?(path) and not File.directory?(path)
+      if File.exist?(path) and not File.directory?(path)
         ignore_uncovered_list.include(path)
       else
         ignore_uncovered_list.include(File.join(path, "*#{EXTENSION_SOURCE}"))

--- a/plugins/module_generator/lib/module_generator.rb
+++ b/plugins/module_generator/lib/module_generator.rb
@@ -54,15 +54,15 @@ class ModuleGenerator < Plugin
 
       bf = MODULE_GENERATOR_BOILERPLATE_FILES
 
-      if !bf[:src].nil? && File.exists?(bf[:src])
+      if !bf[:src].nil? && File.exist?(bf[:src])
         unity_generator_options[:boilerplates][:src] = File.read(bf[:src])
       end
 
-      if !bf[:inc].nil? && File.exists?(bf[:inc])
+      if !bf[:inc].nil? && File.exist?(bf[:inc])
         unity_generator_options[:boilerplates][:inc] = File.read(bf[:inc])
       end
 
-      if !bf[:tst].nil? && File.exists?(bf[:tst])
+      if !bf[:tst].nil? && File.exist?(bf[:tst])
         unity_generator_options[:boilerplates][:tst] = File.read(bf[:tst])
       end
     end

--- a/spec/gcov/gcov_deployment_spec.rb
+++ b/spec/gcov/gcov_deployment_spec.rb
@@ -62,7 +62,7 @@ describe "Ceedling" do
               @output = `bundle exec ruby -S ceedling utils:gcov`
               expect(@output).to match(/For now, creating only an HtmlBasic report\./)
               expect(@output).to match(/Creating (?:a )?gcov (?:results)?(?:HTML)? report(?:\(s\))? in 'build\/artifacts\/gcov'\.\.\. Done/)
-              expect(File.exists?('build/artifacts/gcov/GcovCoverageResults.html')).to eq true
+              expect(File.exist?('build/artifacts/gcov/GcovCoverageResults.html')).to eq true
 
             end
           end

--- a/spec/gcov/gcov_test_cases_spec.rb
+++ b/spec/gcov/gcov_test_cases_spec.rb
@@ -190,7 +190,7 @@ module GcovTestCases
         output = `bundle exec ruby -S ceedling gcov:all`
         output = `bundle exec ruby -S ceedling utils:gcov`
         expect(output).to match(/Creating gcov results report\(s\) in 'build\/artifacts\/gcov'\.\.\. Done/)
-        expect(File.exists?('build/artifacts/gcov/GcovCoverageResults.html')).to eq true
+        expect(File.exist?('build/artifacts/gcov/GcovCoverageResults.html')).to eq true
       end
     end
   end

--- a/spec/generator_test_results_spec.rb
+++ b/spec/generator_test_results_spec.rb
@@ -66,7 +66,7 @@ describe GeneratorTestResults do
   end
 
   after(:each) do
-    if File.exists?(TEST_OUT_FILE)
+    if File.exist?(TEST_OUT_FILE)
       File.delete(TEST_OUT_FILE)
     end
   end

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -147,11 +147,11 @@ module CeedlingTestCases
   def can_create_projects
     @c.with_context do
       Dir.chdir @proj_name do
-        expect(File.exists?("project.yml")).to eq true
-        expect(File.exists?("src")).to eq true
-        expect(File.exists?("test")).to eq true
-        expect(File.exists?("test/support")).to eq true
-        expect(File.exists?("test/support/.gitkeep")).to eq true
+        expect(File.exist?("project.yml")).to eq true
+        expect(File.exist?("src")).to eq true
+        expect(File.exist?("test")).to eq true
+        expect(File.exist?("test/support")).to eq true
+        expect(File.exist?("test/support/.gitkeep")).to eq true
       end
     end
   end
@@ -159,7 +159,7 @@ module CeedlingTestCases
   def has_an_ignore
     @c.with_context do
       Dir.chdir @proj_name do
-        expect(File.exists?(".gitignore")).to eq true
+        expect(File.exist?(".gitignore")).to eq true
       end
     end
   end
@@ -170,9 +170,9 @@ module CeedlingTestCases
       expect($?.exitstatus).to match(0)
       expect(output).to match(/upgraded!/i)
       Dir.chdir @proj_name do
-        expect(File.exists?("project.yml")).to eq true
-        expect(File.exists?("src")).to eq true
-        expect(File.exists?("test")).to eq true
+        expect(File.exist?("project.yml")).to eq true
+        expect(File.exist?("src")).to eq true
+        expect(File.exist?("test")).to eq true
         all_docs = Dir["vendor/ceedling/docs/*.pdf"].length + Dir["vendor/ceedling/docs/*.md"].length
       end
     end
@@ -181,7 +181,7 @@ module CeedlingTestCases
   def contains_a_vendor_directory
     @c.with_context do
       Dir.chdir @proj_name do
-        expect(File.exists?("vendor/ceedling")).to eq true
+        expect(File.exist?("vendor/ceedling")).to eq true
       end
     end
   end
@@ -189,7 +189,7 @@ module CeedlingTestCases
   def does_not_contain_a_vendor_directory
     @c.with_context do
       Dir.chdir @proj_name do
-        expect(File.exists?("vendor/ceedling")).to eq false
+        expect(File.exist?("vendor/ceedling")).to eq false
       end
     end
   end
@@ -206,7 +206,7 @@ module CeedlingTestCases
   def does_not_contain_documentation
     @c.with_context do
       Dir.chdir @proj_name do
-        expect(File.exists?("vendor/ceedling/docs")).to eq false
+        expect(File.exist?("vendor/ceedling/docs")).to eq false
         expect(Dir["vendor/ceedling/**/*.pdf"].length).to eq 0
       end
     end
@@ -458,7 +458,7 @@ module CeedlingTestCases
         expect(output).to match(/PASSED:\s+\d/)
         expect(output).to match(/FAILED:\s+\d/)
         expect(output).to match(/IGNORED:\s+\d/)
-        expect(File.exists?("build/artifacts/test/test_example_file_verbose.log")).to eq true
+        expect(File.exist?("build/artifacts/test/test_example_file_verbose.log")).to eq true
       end
     end
   end
@@ -521,9 +521,9 @@ module CeedlingTestCases
         output = `bundle exec ruby -S ceedling module:create[myPonies:ponies]`
         expect($?.exitstatus).to match(0)
         expect(output).to match(/Generate Complete/i)
-        expect(File.exists?("myPonies/src/ponies.c")).to eq true
-        expect(File.exists?("myPonies/src/ponies.h")).to eq true
-        expect(File.exists?("myPonies/test/test_ponies.c")).to eq true
+        expect(File.exist?("myPonies/src/ponies.c")).to eq true
+        expect(File.exist?("myPonies/src/ponies.h")).to eq true
+        expect(File.exist?("myPonies/test/test_ponies.c")).to eq true
 
         # add module path to project file
         settings = { :paths => { :test => [ "myPonies/test" ],
@@ -541,9 +541,9 @@ module CeedlingTestCases
         output = `bundle exec ruby -S ceedling module:destroy[myPonies:ponies]`
         expect($?.exitstatus).to match(0)
         expect(output).to match(/Destroy Complete/i)
-        expect(File.exists?("myPonies/src/ponies.c")).to eq false
-        expect(File.exists?("myPonies/src/ponies.h")).to eq false
-        expect(File.exists?("myPonies/test/test_ponies.c")).to eq false
+        expect(File.exist?("myPonies/src/ponies.c")).to eq false
+        expect(File.exist?("myPonies/src/ponies.h")).to eq false
+        expect(File.exist?("myPonies/test/test_ponies.c")).to eq false
       end
     end
   end
@@ -565,17 +565,17 @@ module CeedlingTestCases
         output = `bundle exec ruby -S ceedling module:create[myPonies:ponies]`
         expect($?.exitstatus).to match(0)
         expect(output).to match(/Generate Complete/i)
-        expect(File.exists?("myPonies/src/ponies.c")).to eq true
-        expect(File.exists?("myPonies/inc/ponies.h")).to eq true
-        expect(File.exists?("myPonies/test/test_ponies.c")).to eq true
+        expect(File.exist?("myPonies/src/ponies.c")).to eq true
+        expect(File.exist?("myPonies/inc/ponies.h")).to eq true
+        expect(File.exist?("myPonies/test/test_ponies.c")).to eq true
 
         # Module destruction
         output = `bundle exec ruby -S ceedling module:destroy[myPonies:ponies]`
         expect($?.exitstatus).to match(0)
         expect(output).to match(/Destroy Complete/i)
-        expect(File.exists?("myPonies/src/ponies.c")).to eq false
-        expect(File.exists?("myPonies/inc/ponies.h")).to eq false
-        expect(File.exists?("myPonies/test/test_ponies.c")).to eq false
+        expect(File.exist?("myPonies/src/ponies.c")).to eq false
+        expect(File.exist?("myPonies/inc/ponies.h")).to eq false
+        expect(File.exist?("myPonies/test/test_ponies.c")).to eq false
       end
     end
   end
@@ -597,17 +597,17 @@ module CeedlingTestCases
         output = `bundle exec ruby -S ceedling module:create[ponies]`
         expect($?.exitstatus).to match(0)
         expect(output).to match(/Generate Complete/i)
-        expect(File.exists?("foo/ponies.c")).to eq true
-        expect(File.exists?("bar/ponies.h")).to eq true
-        expect(File.exists?("barz/test_ponies.c")).to eq true
+        expect(File.exist?("foo/ponies.c")).to eq true
+        expect(File.exist?("bar/ponies.h")).to eq true
+        expect(File.exist?("barz/test_ponies.c")).to eq true
 
         # Module destruction
         output = `bundle exec ruby -S ceedling module:destroy[ponies]`
         expect($?.exitstatus).to match(0)
         expect(output).to match(/Destroy Complete/i)
-        expect(File.exists?("foo/ponies.c")).to eq false
-        expect(File.exists?("bar/ponies.h")).to eq false
-        expect(File.exists?("barz/test_ponies.c")).to eq false
+        expect(File.exist?("foo/ponies.c")).to eq false
+        expect(File.exist?("bar/ponies.h")).to eq false
+        expect(File.exist?("barz/test_ponies.c")).to eq false
       end
     end
   end


### PR DESCRIPTION
`File.exits?` [has been deprecated since Ruby 2.2](https://stackoverflow.com/questions/14301088/difference-between-fileexist-and-fileexists) and since our target ruby is 2.4 and above it makes the most sense to replace it.


Rubocop detected it and this commit was the result of the auto correct functionality. If interested I'd like to talk more about using rubocop in the repo and crafting a config for it. It looks like it's currently installed in the CI, but not used.