### PR TITLE
Optimization: Preprocess files in parallel

### DIFF
--- a/lib/ceedling/par_map.rb
+++ b/lib/ceedling/par_map.rb
@@ -1,9 +1,15 @@
 
-
 def par_map(n, things, &block)
+  if (things.length <= 1)
+    yield things.pop() if not things.empty?
+    return
+  end
+
   queue = Queue.new
   things.each { |thing| queue << thing }
-  threads = (1..n).collect do
+
+  num_threads = [n, things.length].min()
+  threads = (1..num_threads).collect do
     Thread.new do
       begin
         while true

--- a/lib/ceedling/preprocessinator_helper.rb
+++ b/lib/ceedling/preprocessinator_helper.rb
@@ -1,3 +1,4 @@
+require 'ceedling/par_map'
 
 
 class PreprocessinatorHelper
@@ -43,7 +44,12 @@ class PreprocessinatorHelper
     if (@configurator.project_use_deep_dependencies)
       @task_invoker.invoke_test_preprocessed_files(file_list)
     else
-      file_list.each { |file| preprocess_file_proc.call( yield(file) ) }
+      found_files = Array.new
+      file_list.each { |file| found_files << yield(file) }
+
+      par_map(PROJECT_COMPILE_THREADS, found_files) do |file|
+        preprocess_file_proc.call(file)
+      end
     end
   end
 


### PR DESCRIPTION
For large projects having many header files, I've seen very positive results: When running the preprocessing in parallel on the project I am working on, I saw that our "ceedling test:all" command went from taking 45 seconds (with 1 compile_thread) to 12 seconds (with 8 compile threads).

Bonus: When doing stuff in parallel, don't spawn more threads than necessary. This change isn't strictly necessary, but I thought that it made sense.
