### PR TITLE
Use Ruby 3.0 for Github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.5, 2.6, 2.7, '3.0']
     steps:
       # Install Binutils, Multilib, etc
       - name: Install C dev Tools


### PR DESCRIPTION
It seems as if the floating point number 3.0 gets automatically converted to 3, which results in the latest version of Ruby 3 getting selected (which is 3.1 at the moment).

The fix here is to put the number in single quotes, avoiding the conversion.