### PR TITLE
Use unsafe yaml loads to be able to run on Ruby 3.x

### DIFF
--- a/bin/ceedling
+++ b/bin/ceedling
@@ -53,7 +53,7 @@ unless (project_found)
       as_local = true
       begin
         require "yaml"
-        as_local = (YAML.load_file(File.join(name, "project.yml"))[:project][:which_ceedling] != 'gem')
+        as_local = (YAML.unsafe_load_file(File.join(name, "project.yml"))[:project][:which_ceedling] != 'gem')
       rescue
         raise "ERROR: Could not find valid project file '#{yaml_path}'"
       end
@@ -275,7 +275,7 @@ else
   end
 
   #merge in project settings if they can be found here
-  yaml_options = YAML.load_file(main_filepath)
+  yaml_options = YAML.unsafe_load_file(main_filepath)
   if (yaml_options[:paths])
     options[:add_path] = yaml_options[:paths][:tools] || []
   else

--- a/lib/ceedling/yaml_wrapper.rb
+++ b/lib/ceedling/yaml_wrapper.rb
@@ -5,7 +5,7 @@ require 'erb'
 class YamlWrapper
 
   def load(filepath)
-    return YAML.load(ERB.new(File.read(filepath)).result)
+    return YAML.unsafe_load(ERB.new(File.read(filepath)).result)
   end
 
   def dump(filepath, structure)


### PR DESCRIPTION
Fixes #657
I think this is a reasonable change, as this used to be the default in ruby 2.x anyway. Forbidding the use of aliases in yaml altogether would require larger changes.