### PR TITLE
Loading ceedling module fails on Linux (not local)

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -2233,7 +2233,7 @@ differs whether you are using the gem version or a local Ceedling version.
 
 Gem Version:
 ```ruby
-require('Ceedling')
+require('ceedling')
 Ceedling.load_project
 ```
 


### PR DESCRIPTION
```
/usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require': cannot load such file -- Ceedling (LoadError)
        from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
        from rakefile.rb:1:in `<top (required)>'
        from /usr/local/bundle/gems/ceedling-0.31.1/bin/ceedling:322:in `load'
        from /usr/local/bundle/gems/ceedling-0.31.1/bin/ceedling:322:in `<top (required)>'
        from /usr/local/bundle/bin/ceedling:23:in `load'
        from /usr/local/bundle/bin/ceedling:23:in `<main>'
```