### PR TITLE
Report test file name with subfolders

### DIFF
--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -422,7 +422,7 @@ DEFAULT_TESTS_RESULTS_REPORT_TEMPLATE = %q{
 <%=@ceedling[:plugin_reportinator].generate_banner(header_prepend + 'TEST OUTPUT')%>
 %   hash[:results][:stdout].each do |string|
 %     string[:collection].each do |item|
-<%=string[:source][:path]%><%=File::SEPARATOR%><%=string[:source][:file]%>: "<%=item%>"
+<%=string[:source][:file]%>: "<%=item%>"
 %     end
 %   end
 
@@ -431,7 +431,7 @@ DEFAULT_TESTS_RESULTS_REPORT_TEMPLATE = %q{
 <%=@ceedling[:plugin_reportinator].generate_banner(header_prepend + 'IGNORED TEST SUMMARY')%>
 %   hash[:results][:ignores].each do |ignore|
 %     ignore[:collection].each do |item|
-<%=ignore[:source][:path]%><%=File::SEPARATOR%><%=ignore[:source][:file]%>:<%=item[:line]%>:<%=item[:test]%>
+<%=ignore[:source][:file]%>:<%=item[:line]%>:<%=item[:test]%>
 % if (item[:message].length > 0)
 : "<%=item[:message]%>"
 % else
@@ -445,7 +445,7 @@ DEFAULT_TESTS_RESULTS_REPORT_TEMPLATE = %q{
 <%=@ceedling[:plugin_reportinator].generate_banner(header_prepend + 'FAILED TEST SUMMARY')%>
 %   hash[:results][:failures].each do |failure|
 %     failure[:collection].each do |item|
-<%=failure[:source][:path]%><%=File::SEPARATOR%><%=failure[:source][:file]%>:<%=item[:line]%>:<%=item[:test]%>
+<%=failure[:source][:file]%>:<%=item[:line]%>:<%=item[:test]%>
 % if (item[:message].length > 0)
 : "<%=item[:message]%>"
 % else

--- a/lib/ceedling/generator_test_results.rb
+++ b/lib/ceedling/generator_test_results.rb
@@ -11,8 +11,9 @@ class GeneratorTestResults
 
     results = get_results_structure
 
-    results[:source][:path] = File.dirname(test_file)
-    results[:source][:file] = File.basename(test_file)
+    results[:source][:dirname] = File.dirname(test_file)
+    results[:source][:basename] = File.basename(test_file)
+    results[:source][:file] = test_file
     results[:time] = unity_shell_result[:time] unless unity_shell_result[:time].nil?
 
     # process test statistics
@@ -63,7 +64,7 @@ class GeneratorTestResults
 
   def get_results_structure
     return {
-      :source    => {:path => '', :file => ''},
+      :source    => {:file => '', :dirname => '', :basename => '' },
       :successes => [],
       :failures  => [],
       :ignores   => [],

--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -50,7 +50,7 @@ class TestInvoker
 
     @tests.each do |test|
       # announce beginning of test run
-      header = "Test '#{File.basename(test)}'"
+      header = "Test '#{test}'"
       @streaminator.stdout_puts("\n\n#{header}\n#{'-' * header.length}")
 
       begin

--- a/plugins/json_tests_report/lib/json_tests_report.rb
+++ b/plugins/json_tests_report/lib/json_tests_report.rb
@@ -47,7 +47,7 @@ class JsonTestsReport < Plugin
       result[:collection].each do |item|
         @test_counter += 1
         retval << {
-          "file" => File.join(result[:source][:path], result[:source][:file]),
+          "file" => result[:source][:file],
           "test" => item[:test],
           "line" => item[:line],
           "message" => item[:message]
@@ -63,7 +63,7 @@ class JsonTestsReport < Plugin
       result[:collection].each do |item|
         @test_counter += 1
         retval << { 
-          "file" => File.join(result[:source][:path], result[:source][:file]),
+          "file" => result[:source][:file],
           "test" => item[:test]
         }
       end

--- a/plugins/teamcity_tests_report/lib/teamcity_tests_report.rb
+++ b/plugins/teamcity_tests_report/lib/teamcity_tests_report.rb
@@ -36,7 +36,7 @@ class TeamcityTestsReport < Plugin
     results[:failures].each do |failure|
       failure[:collection].each do |test|
         teamcity_message "testStarted name='#{test[:test]}'"
-        teamcity_message "testFailed name='#{test[:test]}' message='#{escape(test[:message])}' details='File: #{failure[:source][:path]}/#{failure[:source][:file]} Line: #{test[:line]}'"
+        teamcity_message "testFailed name='#{test[:test]}' message='#{escape(test[:message])}' details='File: #{failure[:source][:file]} Line: #{test[:line]}'"
         teamcity_message "testFinished name='#{test[:test]}' duration='#{avg_duration}'"
       end
     end

--- a/plugins/xml_tests_report/lib/xml_tests_report.rb
+++ b/plugins/xml_tests_report/lib/xml_tests_report.rb
@@ -56,7 +56,7 @@ class XmlTestsReport < Plugin
 
     results.each do |result|
       result[:collection].each do |item|
-        filename = File.join(result[:source][:path], result[:source][:file])
+        filename = result[:source][:file]
 
         stream.puts "\t\t<Test id=\"#{@test_counter}\">"
         stream.puts "\t\t\t<Name>#{filename}::#{item[:test]}</Name>"


### PR DESCRIPTION
This change affects how test file names are reported. The test file name is prepended with its path up to the project root, i.e. the location of project.yml

For example ``test_something.c`` becomes ``test/subfolder1/test_something.c``

**Motivation**
 - Source trees are often organized into multiple subfolders, therefore using the same structure for the test files helps to keep sources and tests better connected. Adding the path to the report helps to quickly identify the test file in question.

- IDEs need the entire path to unambiguously identify a test file so it can be opened it in case of a failed test. The Eclipse Unit Testing Framework has been observed picking the wrong file when clicking on a failure report, opening the prepocessed file with the same name but located in the cache folder.

The change affects
- Pretty printed console output
- GoogleTest like output
- JSON output
- XML output
- Teamcity output
