### PR TITLE
Disable running twice gcov when only TEXT report enabled

### DIFF
--- a/plugins/gcov/lib/gcovr_reportinator.rb
+++ b/plugins/gcov/lib/gcovr_reportinator.rb
@@ -29,7 +29,18 @@ class GcovrReportinator
       STDOUT.flush
 
       # Generate the report(s).
-      run(args)
+      # only if one of the previous done checks for:
+      #
+      # - args_builder_cobertura
+      # - args_builder_sonarqube
+      # - args_builder_json
+      # - args_builder_html
+      #
+      # updated the args variable. In other case, no need to run GCOVR
+      # for current setup.
+      if !(args == args_common)
+        run(args)
+      end
     else
       # gcovr version 4.1 and earlier supports HTML and Cobertura XML reports.
       # It does not support SonarQube and JSON reports.


### PR DESCRIPTION
Proposed solution for issue described in #641.
Disable running twice 4.2 gcovr when:
-  calls of  args_builder_cobertura /- args_builder_sonarqube / args_builder_json / args_builder_html functions does not update args.
- when Text Report is not set.