### PR TITLE
Add possibility to collect backtrace using GDB for 'Segmenation fault' errors in n tests

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -924,6 +924,13 @@ are easily capable of building a final release binary artifact
 (i.e. non test code; the thing that is your final working software
 that you execute on target hardware).
 
+* `use_backtrace_gdb_reporter`:
+  Set this value to true if you project use gcc compiler and you want to collect
+  backtrace from test runners which fail with **Segmentation fault** error.
+  The .fail files will contain testsuite with information, which test failed.
+  Backtrace is fully integrated with **junit_tests_report** plugin.
+
+  **Default**: FALSE
 
 * `output`:
 

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -298,6 +298,7 @@ DEFAULT_CEEDLING_CONFIG = {
       :test_file_prefix => 'test_',
       :options_paths => [],
       :release_build => false,
+      :use_backtrace_gdb_reporter => false,
     },
 
     :release_build => {

--- a/lib/ceedling/generator_test_results.rb
+++ b/lib/ceedling/generator_test_results.rb
@@ -22,6 +22,23 @@ class GeneratorTestResults
       results[:counts][:failed] = $2.to_i
       results[:counts][:ignored] = $3.to_i
       results[:counts][:passed] = (results[:counts][:total] - results[:counts][:failed] - results[:counts][:ignored])
+    else
+      if @configurator.project_config_hash[:project_use_backtrace_gdb_reporter]
+        # Accessing this code block we expect failure during test execution
+        # which should be connected with SIGSEGV
+        results[:counts][:total] = 1   # Set to one as the amount of test is unknown in segfault, and one of the test is failing
+        results[:counts][:failed] = 1  # Set to one as the one of tests is failing with segfault
+        results[:counts][:ignored] = 0
+        results[:counts][:passed] = 0
+
+        #Collect function name which cause issue and line number
+        if unity_shell_result[:output] =~ /\s"(.*)",\sline_num=(\d*)/
+          results[:failures] << { :test => $1, :line =>$2, :message => unity_shell_result[:output], :unity_test_time => unity_shell_result[:time]}
+        else
+          #In case if regex fail write default values
+          results[:failures] << { :test => '??', :line =>-1, :message => unity_shell_result[:output], :unity_test_time => unity_shell_result[:time]}
+        end
+      end
     end
 
     # remove test statistics lines
@@ -47,7 +64,9 @@ class GeneratorTestResults
         results[:failures] << elements[0]
         results[:stdout] << elements[1] if (!elements[1].nil?)
       else # collect up all other
-        results[:stdout] << line
+        if !@configurator.project_config_hash[:project_use_backtrace_gdb_reporter]
+          results[:stdout] << line.chomp
+        end
       end
     end
 


### PR DESCRIPTION
---
**FEATURE**
Add GDB support to collect SIGSEGV logs from tests which fails on x86 machines.

---

**PR includes**
Updated code
Updated README.md with new project configuration option.

---
**Short description**

During development of the unit tests for my previous project, I observed sometimes  the issues connected with Segmentation fault( SEGFAULT/ SIGSEGV ).
The Ceedling does not deliver us possibility to easily check, why, and which test is failing, and is not creating as we expect report.xml file. It is only failing with description:

```
ERROR: Test executable "test_add.out" failed.
> Produced no final test result counts in $stdout:
Segmentation fault (core dumped)
> And exited with status: [0] (count of failed tests).
> This is often a symptom of a bad memory access in source or test code.

rake aborted!

/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/generator_helper.rb:36:in `test_results_error_handler'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/generator.rb:186:in `generate_test_results'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/rules_tests.rake:55:in `block in <top (required)>'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/task_invoker.rb:107:in `invoke_test_results'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/test_invoker.rb:125:in `block in setup_and_invoke'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/test_invoker.rb:51:in `setup_and_invoke'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/tasks_tests.rake:13:in `block (2 levels) in <top (required)>'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/bin/ceedling:345:in `block in <top (required)>'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/bin/ceedling:332:in `<top (required)>'
/usr/local/bin/ceedling:25:in `load'
/usr/local/bin/ceedling:25:in `<main>'
```

---
**Proposed Solution**

Mentioned PR'st enable support of GDB debugger on local machine on which test are executed and collect Segfault section.

Lets assume that sample source file looks this way:

```
#include <stdint.h>
#include <stdio.h>
#include <signal.h>

int
minus(int a, int b)
{
    raise(SIGSEGV);
    return a - b;
}
```

and test file looks:

```
#include "../src/add.h"
#include "unity.h"

void
setUp(void)
{
}

void
tearDown(void)
{
}

void
test_minus_success(void)
{
    TEST_ASSERT_EQUAL_UINT8(1, minus(2, 1));
}

```

Instead of typical output from ceedling:

```
Test 'test_add.c'
-----------------
Running test_add.out...

ERROR: Test executable "test_add.out" failed.
> Produced no final test result counts in $stdout:
Segmentation fault (core dumped)
> And exited with status: [0] (count of failed tests).
> This is often a symptom of a bad memory access in source or test code.

rake aborted!

/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/generator_helper.rb:36:in `test_results_error_handler'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/generator.rb:186:in `generate_test_results'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/rules_tests.rake:55:in `block in <top (required)>'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/task_invoker.rb:107:in `invoke_test_results'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/test_invoker.rb:125:in `block in setup_and_invoke'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/test_invoker.rb:51:in `setup_and_invoke'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/lib/ceedling/tasks_tests.rake:13:in `block (2 levels) in <top (required)>'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/bin/ceedling:345:in `block in <top (required)>'
/var/lib/gems/3.0.0/gems/ceedling-0.31.1/bin/ceedling:332:in `<top (required)>'
/usr/local/bin/ceedling:25:in `load'
/usr/local/bin/ceedling:25:in `<main>'
Tasks: TOP => build/test/results/test_add.pass
(See full trace by running task with --trace)

--------------------
OVERALL TEST SUMMARY
--------------------

No tests executed.

```

after adding to project.yml file:

```
:project:
   :use_test_backtrace_gdb_reporter: TRUE,
```

the output of test exection will look:

```
Test 'test_add.c'
-----------------
Running test_add.out...

-------------------
FAILED TEST SUMMARY
-------------------
[test_add.c]
  Test: test_minus_success
  At line (21): "[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault.
__pthread_kill_implementation (no_tid=0, signo=11, threadid=140737351477056) at ./nptl/pthread_kill.c:44
44	./nptl/pthread_kill.c: No such file or directory.
#0  __pthread_kill_implementation (no_tid=0, signo=11, threadid=140737351477056) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=11, threadid=140737351477056) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140737351477056, signo=signo@entry=11) at ./nptl/pthread_kill.c:89
#3  0x00007ffff7dbb476 in __GI_raise (sig=11) at ../sysdeps/posix/raise.c:26
#4  0x0000555555555390 in minus (a=2, b=1) at src/add.c:8
#5  0x0000555555555351 in test_minus_success () at test/test_add.c:23
#6  0x00005555555552ba in run_test (func=0x55555555533a <test_minus_success>, name=0x55555555900f "test_minus_success", line_num=21) at build/test/runners/test_add_runner.c:62
#7  0x000055555555531d in main () at build/test/runners/test_add_runner.c:78
"

--------------------
OVERALL TEST SUMMARY
--------------------
TESTED:  1
PASSED:  0
FAILED:  1
IGNORED: 0

---------------------
BUILD FAILURE SUMMARY
---------------------
Unit test failures.
```

The output from **sigsegv** is as well added to junit report (report.xml):

```
<?xml version="1.0" encoding="utf-8" ?>
<testsuites tests="1" failures="1" time="0.093">
  <testsuite name="test_add" tests="1" failures="1" skipped="0" errors="0" time="0.093">
    <testcase name="test_minus_success" time="0.093">
      <failure message="[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault.
__pthread_kill_implementation (no_tid=0, signo=11, threadid=140737351477056) at ./nptl/pthread_kill.c:44
44	./nptl/pthread_kill.c: No such file or directory.
#0  __pthread_kill_implementation (no_tid=0, signo=11, threadid=140737351477056) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=11, threadid=140737351477056) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140737351477056, signo=signo@entry=11) at ./nptl/pthread_kill.c:89
#3  0x00007ffff7dbb476 in __GI_raise (sig=11) at ../sysdeps/posix/raise.c:26
#4  0x0000555555555390 in minus (a=2, b=1) at src/add.c:8
#5  0x0000555555555351 in test_minus_success () at test/test_add.c:23
#6  0x00005555555552ba in run_test (func=0x55555555533a <test_minus_success>, name=0x55555555900f "test_minus_success", line_num=21) at build/test/runners/test_add_runner.c:62
#7  0x000055555555531d in main () at build/test/runners/test_add_runner.c:78
" />
    </testcase>
  </testsuite>
</testsuites>
```

---

@mvandervoord : Can I ask you for a looking at this in your free time? I have hope that this feature will help other people as helped me in my work.
