### PR TITLE
[CI] Update bundler gem version to 2.4.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, '3.0']
+        ruby: [2.6, 2.7, 3.0]
     steps:
       # Install Binutils, Multilib, etc
       - name: Install C dev Tools
@@ -45,6 +45,7 @@ jobs:
       # Install Ruby Testing Tools (Bundler version should match the one in Gemfile.lock)
       - name: Install Ruby Testing Tools
         run: |
+          gem update --system 3.2.3
           gem install rspec
           gem install rubocop -v 0.57.2
           gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,11 @@ GEM
   remote: http://rubygems.org/
   specs:
     constructor (2.0.0)
-    deep_merge (1.2.1)
+    deep_merge (1.2.2)
     diff-lcs (1.3)
     diy (1.1.2)
       constructor (>= 1.0.0)
-    rake (12.3.3)
+    rake (13.0.6)
     require_all (1.3.3)
     rr (1.1.2)
     rspec (3.8.0)
@@ -22,7 +22,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    thor (0.19.1)
+    thor (0.20.3)
 
 PLATFORMS
   ruby
@@ -40,4 +40,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   2.0.2
+   2.4.3


### PR DESCRIPTION
Update bundler gem to 2.4.3v to fix warning:
   warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.

Remove single quotation apostrophe in main.yml in definition of ruby 3.0 version