### PR TITLE
Fix issue with undeclared yaml_path variable when calling ceedling upgrade on none existing project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1']#, '3.2']
+        ruby: ['2.7', '3.0', '3.1']
     steps:
       # Install Binutils, Multilib, etc
       - name: Install C dev Tools

--- a/bin/ceedling
+++ b/bin/ceedling
@@ -18,7 +18,7 @@ def is_windows?
 end
 
 def here
-  File.join(File.dirname(__FILE__),"/..")
+  File.join(File.expand_path(File.dirname(__FILE__)),"/..")
 end
 
 unless (project_found)
@@ -51,9 +51,10 @@ unless (project_found)
     desc "upgrade PROJECT_NAME", "upgrade ceedling for a project (not req'd if gem used)"
     def upgrade(name, silent = false)
       as_local = true
+      yaml_path = File.join(name, "project.yml")
       begin
         require File.join(here,"lib","ceedling","yaml_wrapper.rb")
-        as_local = (YamlWrapper.new.load(File.join(name, "project.yml"))[:project][:which_ceedling] != 'gem')
+        as_local = (YamlWrapper.new.load(yaml_path)[:project][:which_ceedling] != 'gem')
       rescue
         raise "ERROR: Could not find valid project file '#{yaml_path}'"
       end

--- a/lib/ceedling/erb_wrapper.rb
+++ b/lib/ceedling/erb_wrapper.rb
@@ -3,7 +3,7 @@ require 'erb'
 class ErbWrapper
   def generate_file(template, data, output_file)
     File.open(output_file, "w") do |f|
-      f << ERB.new(template, 0, "<>").result(binding)
+      f << ERB.new(template, trim_mode: "<>").result(binding)
     end
   end
 end

--- a/lib/ceedling/plugin_reportinator_helper.rb
+++ b/lib/ceedling/plugin_reportinator_helper.rb
@@ -44,7 +44,7 @@ class PluginReportinatorHelper
 
 
   def run_report(stream, template, hash, verbosity)
-    output = ERB.new(template, 0, "%<>")
+    output = ERB.new(template, trim_mode: "%<>")
     @streaminator.stream_puts(stream, output.result(binding()), verbosity)
   end
   

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -180,6 +180,14 @@ module CeedlingTestCases
     end
   end
 
+  def cannot_upgrade_non_existing_project
+    @c.with_context do
+      output = `bundle exec ruby -S ceedling upgrade #{@proj_name} 2>&1`
+      expect($?.exitstatus).to match(1)
+      expect(output).to match(/rescue in upgrade/i)
+    end
+  end
+
   def contains_a_vendor_directory
     @c.with_context do
       Dir.chdir @proj_name do

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -147,6 +147,10 @@ describe "Ceedling" do
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
   end
 
+  describe "Cannot ugrade a non existing project" do
+    it { cannot_upgrade_non_existing_project }
+  end
+
   describe "deployed as a gem" do
     before do
       @c.with_context do


### PR DESCRIPTION
PR'st changes:

- [main.yml] Remove commented test run for ruby 3.2
- [ceedling] Fix issue with undeclared yaml_path variable
   Fix undeclared yaml_path variable when user call:
   ceedling upgrade <non_existing_project>
- Add trim_mode to ERB.new function as parameter specifier


Add test to cover check of upgrade function for non existing project