### PR TITLE
Feature - add functionality to run single or multiple tests from one or multiple test files 

### DIFF
--- a/bin/ceedling
+++ b/bin/ceedling
@@ -303,6 +303,10 @@ else
         options[:list_tasks] = true
       when /^project:(\w+)/
         ENV['CEEDLING_USER_PROJECT_FILE'] = "#{$1}.yml"
+      when /^--test_case=(\w+)/
+        ENV['CEEDLING_INCLUDE_TEST_CASE_NAME'] = $1
+      when /^--exclude_test_case=(\w+)/
+        ENV['CEEDLING_EXCLUDE_TEST_CASE_NAME'] = $1
       else
         options[:args].push(v)
     end

--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -326,6 +326,59 @@ Ceedling (more on this later).
   whose path contains foo/bar. Note: both directory separator characters
   / and \ are valid.
 
+* `ceedling test:* --test_case=<test_case_name> `
+  Execute test case which match **test_case_name**. Option available only after 
+  setting up **cmdline_args** to true under **test_runner** in project.yml:
+    
+    ```
+    :test_runner:
+      :cmdline_args: true
+    ```
+
+  For instance, if you have file test_gpio.c with defined 3 tests:
+
+    - test_gpio_start
+    - test_gpio_configure_proper
+    - test_gpio_configure_fail_pin_not_allowed
+
+  and you want to run only configure tests, you can call:
+
+    ```ceedling test:gpio --test_case=configure```
+
+    ---
+  **Limitation**
+
+    The Unity implementation use test case name as substring which will be search in your test case names. If you pass only **gpio** and your file under test contains **gpio** in the name, it will run all tests from it. This is connected with the logic, how Unity generates test_<file_name_runner.c> files. In such case, it is suggested to use full name of test case.
+
+  ---
+
+* `ceedling test:* --exclude_test_case=<test_case_name> `
+  Execute test case which does not match **test_case_name**. Option available only after 
+  setting up **cmdline_args** to true under **test_runner** in project.yml:
+    
+    ```
+    :test_runner:
+      :cmdline_args: true
+    ```
+
+  For instance, if you have file test_gpio.c with defined 3 tests:
+
+    - test_gpio_start
+    - test_gpio_configure_proper
+    - test_gpio_configure_fail_pin_not_allowed
+
+  and you want to run only start tests, you can call:
+
+    ```ceedling test:gpio --exclude_test_case=configure```
+
+  ---
+  **Limitation**
+
+    The Unity implementation use test case name as substring which will be search in your test case names. If you pass only **gpio** and your file under test contains **gpio** in the name, it will run all tests from it. This is connected with the logic, how Unity generates test_<file_name_runner.c> files. In such case, it is suggested to use full name of test case.
+
+  ---
+
+
 * `ceedling release`:
 
   Build all source into a release artifact (if the release build option

--- a/lib/ceedling/configurator_builder.rb
+++ b/lib/ceedling/configurator_builder.rb
@@ -400,8 +400,13 @@ class ConfiguratorBuilder
 
   def collect_test_and_vendor_defines(in_hash)
     defines = in_hash[:defines_test].clone
+
+    require_relative 'unity_utils.rb'
+    cmd_line_define = UnityUtils.update_defines_if_args_enables(in_hash)
+
     vendor_defines = get_vendor_defines(in_hash)
     defines.concat(vendor_defines) if vendor_defines
+    defines.concat(cmd_line_define) if cmd_line_define
 
     return {:collection_defines_test_and_vendor => defines}
   end

--- a/lib/ceedling/generator.rb
+++ b/lib/ceedling/generator.rb
@@ -16,7 +16,8 @@ class Generator
               :file_path_utils,
               :streaminator,
               :plugin_manager,
-              :file_wrapper
+              :file_wrapper,
+              :unity_utils
 
 
   def generate_shallow_includes_list(context, file)
@@ -169,6 +170,7 @@ class Generator
     # Unity's exit code is equivalent to the number of failed tests, so we tell @tool_executor not to fail out if there are failures
     # so that we can run all tests and collect all results
     command = @tool_executor.build_command_line(arg_hash[:tool], [], arg_hash[:executable])
+    command[:line] += @unity_utils.collect_test_runner_additional_args
     @streaminator.stdout_puts("Command: #{command}", Verbosity::DEBUG)
     command[:options][:boom] = false
     shell_result = @tool_executor.exec( command[:line], command[:options] )

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -38,6 +38,10 @@ project_file_loader:
     - system_wrapper
     - file_wrapper
 
+unity_utils:
+  compose:
+     - configurator
+
 project_config_manager:
   compose:
     - cacheinator
@@ -196,6 +200,7 @@ generator:
     - streaminator
     - plugin_manager
     - file_wrapper
+    - unity_utils
 
 generator_helper:
   compose:

--- a/lib/ceedling/rules_tests.rake
+++ b/lib/ceedling/rules_tests.rake
@@ -58,7 +58,7 @@ end
 
 namespace TEST_SYM do
   # use rules to increase efficiency for large projects (instead of iterating through all sources and creating defined tasks)
-
+  @ceedling[:unity_utils].create_test_runner_additional_args
   rule(/^#{TEST_TASK_ROOT}\S+$/ => [ # test task names by regex
       proc do |task_name|
         test = task_name.sub(/#{TEST_TASK_ROOT}/, '')

--- a/lib/ceedling/unity_utils.rb
+++ b/lib/ceedling/unity_utils.rb
@@ -1,0 +1,101 @@
+# The Unity utils class,
+# Store functions to enable test execution of single test case under test file
+# and additional warning definitions
+class UnityUtils
+  attr_reader :test_runner_disabled_replay, :arg_option_map
+  attr_accessor :test_runner_args, :not_supported
+
+  constructor :configurator
+
+  def setup
+    @test_runner_disabled_replay = "NOTICE: \n" \
+     "The option[s]: %<opt>.s \ncannot be applied." \
+     'To enable it, please add `:cmdline_args` under' \
+     ' :test_runner option in your project.yml.'
+    @test_runner_args = ''
+    @not_supported = ''
+
+    # Refering to Unity implementation of the parser implemented in the unit.c :
+    #
+    # case 'l': /* list tests */
+    # case 'n': /* include tests with name including this string */
+    # case 'f': /* an alias for -n */
+    # case 'q': /* quiet */
+    # case 'v': /* verbose */
+    # case 'x': /* exclude tests with name including this string */
+    @arg_option_map =
+      {
+        'test_case' => 'n',
+        'list_test_cases' => 'l',
+        'run_tests_verbose' => 'v',
+        'exclude_test_case' => 'x'
+      }
+  end
+
+  # Create test runner args which can be passed to executable test file as
+  # filter to execute one test case from test file
+  #
+  # @param [String, #argument] argument passed after test file name
+  #                            e.g.: ceedling test:<test_file>:<argument>
+  # @param [String, #option] one of the supported by unity arguments.
+  #                          At current moment only "test_case_name" to
+  #                          run single test
+  def additional_test_run_args(argument, option)
+    # Confirm wherever cmdline_args is set to true
+    # and parsing arguments under generated test runner in Unity is enabled
+    # and passed argument is not nil
+
+    return nil if argument.nil?
+
+    raise TypeError, 'option expects an arg_option_map key' unless \
+      option.is_a?(String)
+    raise 'Unknown Unity argument option' unless \
+      @arg_option_map.key?(option)
+
+    @test_runner_args += " -#{@arg_option_map[option]} #{argument} "
+  end
+
+  # Return test case arguments
+  #
+  # @return [String] formatted arguments for test file
+  def collect_test_runner_additional_args
+    @test_runner_args
+  end
+
+  # Parse passed by user arguments
+  def create_test_runner_additional_args
+    if ENV['CEEDLING_INCLUDE_TEST_CASE_NAME']
+      if @configurator.project_config_hash[:test_runner_cmdline_args]
+        additional_test_run_args(ENV['CEEDLING_INCLUDE_TEST_CASE_NAME'],
+                                 'test_case')
+      else
+        @not_supported = "\n\t--test_case"
+      end
+    end
+
+    if ENV['CEEDLING_EXCLUDE_TEST_CASE_NAME']
+      if @configurator.project_config_hash[:test_runner_cmdline_args]
+        additional_test_run_args(ENV['CEEDLING_EXCLUDE_TEST_CASE_NAME'],
+                                 'exclude_test_case')
+      else
+        @not_supported = "\n\t--exclude_test_case"
+      end
+    end
+    print_warning_about_not_enabled_cmdline_args
+  end
+
+  # Return UNITY_USE_COMMAND_LINE_ARGS define required by Unity to
+  # compile unity with enabled cmd line arguments
+  #
+  # @return [Array] - empty if cmdline_args is not set
+  def self.update_defines_if_args_enables(in_hash)
+    in_hash[:test_runner_cmdline_args] ? ['UNITY_USE_COMMAND_LINE_ARGS'] : []
+  end
+
+  # Print on output console warning about lack of support for single test run
+  # if cmdline_args is not set to true in project.yml file, that
+  def print_warning_about_not_enabled_cmdline_args
+    puts(format(@test_runner_disabled_replay, opt: @not_supported)) unless \
+      @configurator.project_config_hash[:test_runner_cmdline_args]
+  end
+end

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -558,6 +558,134 @@ module CeedlingTestCases
     end
   end
 
+  def can_run_single_test_with_full_test_case_name_from_test_file_with_success_cmdline_args_are_enabled
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+        fake_prj_yml= File.read('project.yml').split("\n")
+        fake_prj_yml.insert(fake_prj_yml.length() -1, enable_unity_extra_args)
+        File.write('project.yml', fake_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling test:test_example_file_success --test_case=test_add_numbers_adds_numbers 2>&1`
+
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+1/)
+        expect(output).to match(/PASSED:\s+1/)
+        expect(output).to match(/FAILED:\s+0/)
+        expect(output).to match(/IGNORED:\s+0/)
+      end
+    end
+  end
+
+  def can_run_single_test_with_partiall_test_case_name_from_test_file_with_enabled_cmdline_args_success
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+        fake_prj_yml= File.read('project.yml').split("\n")
+        fake_prj_yml.insert(fake_prj_yml.length() -1, enable_unity_extra_args)
+        File.write('project.yml', fake_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling test:test_example_file_success --test_case=_adds_numbers 2>&1`
+
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+1/)
+        expect(output).to match(/PASSED:\s+1/)
+        expect(output).to match(/FAILED:\s+0/)
+        expect(output).to match(/IGNORED:\s+0/)
+      end
+    end
+  end
+
+  def none_of_test_is_executed_if_test_case_name_passed_does_not_fit_defined_in_test_file_and_cmdline_args_are_enabled
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+        fake_prj_yml= File.read('project.yml').split("\n")
+        fake_prj_yml.insert(fake_prj_yml.length() -1, enable_unity_extra_args)
+        File.write('project.yml', fake_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling test:test_example_file_success --test_case=zumzum 2>&1`
+
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/No tests executed./)
+      end
+    end
+  end
+
+  def none_of_test_is_executed_if_test_case_name_and_exclude_test_case_name_is_the_same
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+        fake_prj_yml= File.read('project.yml').split("\n")
+        fake_prj_yml.insert(fake_prj_yml.length() -1, enable_unity_extra_args)
+        File.write('project.yml', fake_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling test:test_example_file_success --test_case=_adds_numbers --exclude_test_case=_adds_numbers 2>&1`
+
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/No tests executed./)
+      end
+    end
+  end
+
+  def exlcude_test_case_name_filter_works_and_only_one_test_case_is_executed
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+        fake_prj_yml= File.read('project.yml').split("\n")
+        fake_prj_yml.insert(fake_prj_yml.length() -1, enable_unity_extra_args)
+        File.write('project.yml', fake_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling test:all --exclude_test_case=test_add_numbers_adds_numbers 2>&1`
+
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+1/)
+        expect(output).to match(/PASSED:\s+0/)
+        expect(output).to match(/FAILED:\s+0/)
+        expect(output).to match(/IGNORED:\s+1/)
+      end
+    end
+  end
+
+  def run_all_test_when_test_case_name_is_passed_but_cmdline_args_are_disabled_with_success
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling test:test_example_file_success --test_case=_adds_numbers 2>&1`
+
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+2/)
+        expect(output).to match(/PASSED:\s+1/)
+        expect(output).to match(/FAILED:\s+0/)
+        expect(output).to match(/IGNORED:\s+1/)
+        expect(output).to match(/please add `:cmdline_args` under :test_runner option/)
+      end
+    end
+  end
+
   def can_use_the_module_plugin_with_include_path
     @c.with_context do
       Dir.chdir @proj_name do

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -46,6 +46,13 @@ describe "Ceedling" do
     it { handles_creating_the_same_module_twice_using_the_module_plugin }
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin }
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
+
+    it { can_run_single_test_with_full_test_case_name_from_test_file_with_success_cmdline_args_are_enabled }
+    it { can_run_single_test_with_partiall_test_case_name_from_test_file_with_enabled_cmdline_args_success }
+    it { exlcude_test_case_name_filter_works_and_only_one_test_case_is_executed }
+    it { none_of_test_is_executed_if_test_case_name_passed_does_not_fit_defined_in_test_file_and_cmdline_args_are_enabled }
+    it { none_of_test_is_executed_if_test_case_name_and_exclude_test_case_name_is_the_same }
+    it { run_all_test_when_test_case_name_is_passed_but_cmdline_args_are_disabled_with_success }
   end
 
   describe "deployed in a project's `vendor` directory with gitignore." do


### PR DESCRIPTION
---
**FEATURE**
Add possibility to execute single or multiple tests cases from one test file, or exclude some of test cases from test execution.

Base on request: #330 , #243

---

**PR includes**

Updated code :
 -  Added new class UnityUtils.rb. (no code style issues - tested via rubocop)
 - Updated implementation of configurator_builder.rb
 - Updated implementation of generatior.rb
 - Updated implementation or rules_tests.rb

Updated CeedlingPacket.md with new ceedling functionality.

Added 5 UT to cover new functionality. ( rubocop describe problems with to long name description)

---
**Short description**

This PR contains extension which enable execution of:
- one 
- or multiple tests
- or non if the passed test case name is not fitting passed by end user parameter after colon

Referring to #330 , #243, the new functionality can be enabled by calling:

```
ceedling test:<test_file_name> --test_case=<test_case_name>
```

and updating project.yml after adding:
```
:test_runner:
  :cmdline_args: true
```

The *UNITY_USE_COMMAND_LINE_ARGS* will be set automatically by Ceedling as part of setup, so end user does not need to care about more setup.

Mentioned above functionality is an wrapper for functionality already delivered in Unity component( (UnityParseOptions)[https://github.com/ThrowTheSwitch/Unity/blob/master/src/unity.c#L2266]), and have his own limitations and problems.

**Limitations and problems**:

- Can be at current moment executed for single test file
- it passed test case name is a part of test_file_name.c, all tests will be executed from mentioned file.( The problem is connected with test runner generator which add test file name as part of test_case). 

Information about such of issues are added to documentation.

---
** How it works in real life **

If test file contains three test cases:
test_gpio.c

```
#include "unity.h"
#include "gpio_def.h"

void setUp(void) {}
void tearDown(void) {}

void test_gpio_start(void) {
  TEST_ASSERT_EQUAL(GPIO_OK, gpio_start(gpio13) ).
}

void test_gpio_configure_proper(void) {
  TEST_ASSERT_EQUAL(GPIO_OK, gpio_configure(gpio_13, NULL));
}


void test_gpio_configure_fail_pin_not_allowed(void) {
  TEST_ASSERT_EQUAL(GPIO_ERR, gpio_configure(gpio_max, NULL));
}

```

and you want to run only:
- configure tests, you can call  ```ceedling test:gpio --test_case=configure```
- single test(require to be unique) call ```ceedling test:all --test_case=test_gpio_configure_fail_pin_not_allowed```
- all test cases from file ```ceedling test:gpio``` or ```ceedling test:all --test_case=gpio```
- to exclude test cases from test run with "configure" string, ```ceedling test:all --exclude_test_case

In case if test case name is not in the file name no test case will be executed.

---

@mvandervoord : Can I ask you for a looking at this in your free time? I have hope that this feature will help other people as helped me in my work.
