### PR TITLE
Feature/gdb backtrace with params

### DIFF
--- a/assets/example_file.c
+++ b/assets/example_file.c
@@ -3,3 +3,7 @@
 int add_numbers(int a, int b) {
   return a + b;
 }
+
+int difference_between_numbers(int a, int b) {
+  return a - b;
+}

--- a/assets/example_file.h
+++ b/assets/example_file.h
@@ -3,4 +3,6 @@
 
 int add_numbers(int a, int b);
 
+int difference_between_numbers(int a, int b);
+
 #endif /* EXAMPLE_FILE_H */

--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -985,6 +985,46 @@ that you execute on target hardware).
 
   **Default**: FALSE
 
+  ---
+
+  **Note:**
+
+    The configuration can be combined together with
+    
+    ```
+    :test_runner:
+        :cmdline_args: true
+    ```
+
+    After setting **cmdline_args** to **true**, the debuger will execute each test
+    case from crashing test file separately. The exclude and include test_case patterns will
+    be applied, to filter execution of test cases.
+
+    The .gcno and .gcda files will be generated and section of the code under test case
+    causing segmetation fault will be omitted from Coverage Report.
+
+    The default debugger (**gdb**)[https://www.sourceware.org/gdb/] can be switch to any other
+    via setting new configuration under tool node in project.yml. At default set to:
+
+    ```yaml
+      :tools:
+        :backtrace_settings:
+          :executable: gdb
+          :arguments:
+            - -q
+            - --eval-command run
+            - --eval-command backtrace
+            - --batch
+            - --args
+    ```
+    
+    Important. The debugger which will collect segmentation fault should run in:
+
+    - background
+    - with option to enable pass to executable binary additional arguments
+
+  ---
+
 * `output`:
 
   The name of your release build binary artifact to be found in <build

--- a/lib/ceedling/debugger_utils.rb
+++ b/lib/ceedling/debugger_utils.rb
@@ -1,0 +1,222 @@
+# The debugger utils class,
+# Store functions and variables helping to parse debugger output and
+# prepare output understandable by report generators
+class DebuggerUtils
+  constructor :configurator,
+              :tool_executor,
+              :unity_utils
+
+  def setup
+    @new_line_tag = '$$$'
+    @colon_tag = '!!!'
+    @command_line = nil
+    @test_result_collector_struct = Struct.new(:passed, :failed, :ignored,
+                                               :output, keyword_init: true)
+  end
+
+  # Copy original command line generated from @tool_executor.build_command_line
+  # to use command line without command line extra args not needed by debugger
+  #
+  # @param [hash, #command] - Command line generated from @tool_executor.build_command_line
+  def configure_debugger(command)
+    # Make a clone of clean command hash
+    # for further calls done for collecting segmentation fault
+    if @configurator.project_config_hash[:project_use_backtrace_gdb_reporter] &&
+       @configurator.project_config_hash[:test_runner_cmdline_args]
+      @command_line = command.clone
+    elsif @configurator.project_config_hash[:project_use_backtrace_gdb_reporter]
+      # If command_lines are not enabled, do not clone but create reference to command
+      # line
+      @command_line = command
+    end
+  end
+
+  # Execute test_runner file under gdb and return:
+  # - output -> stderr and stdout
+  # - time -> execution of single test
+  #
+  # @param [hash, #command] - Command line generated from @tool_executor.build_command_line
+  # @return [String, #output] - output from binary execution
+  # @return [Float, #time] - time execution of the binary file
+  def collect_cmd_output_with_gdb(command, cmd)
+    gdb_file_name = @configurator.project_config_hash[:tools_backtrace_settings][:executable]
+    gdb_extra_args = @configurator.project_config_hash[:tools_backtrace_settings][:arguments]
+    gdb_extra_args = gdb_extra_args.join(' ')
+
+    gdb_exec_cmd = "#{gdb_file_name} #{gdb_extra_args} #{cmd}"
+    crash_result = @tool_executor.exec(gdb_exec_cmd, command[:options])
+    [crash_result[:output], crash_result[:time].to_f]
+  end
+
+  # Collect list of test cases from test_runner
+  # and apply filters basing at passed :
+  # --test_case
+  # --exclude_test_case
+  # input arguments
+  #
+  # @param [hash, #command] - Command line generated from @tool_executor.build_command_line
+  # @return Array - list of the test_cases defined in test_file_runner
+  def collect_list_of_test_cases(command)
+    all_test_names = command[:line] + @unity_utils.additional_test_run_args('', 'list_test_cases')
+    test_list = @tool_executor.exec(all_test_names, command[:options])
+    test_runner_tc = test_list[:output].split("\n").drop(1)
+
+    # Clean collected test case names
+    # Filter tests which contain test_case_name passed by `--test_case` argument
+    if ENV['CEEDLING_INCLUDE_TEST_CASE_NAME']
+      test_runner_tc.delete_if { |i| !(i =~ /#{ENV['CEEDLING_INCLUDE_TEST_CASE_NAME']}/) }
+    end
+
+    # Filter tests which contain test_case_name passed by `--exclude_test_case` argument
+    if ENV['CEEDLING_EXCLUDE_TEST_CASE_NAME']
+      test_runner_tc.delete_if { |i| i =~ /#{ENV['CEEDLING_EXCLUDE_TEST_CASE_NAME']}/ }
+    end
+
+    test_runner_tc
+  end
+
+  # Update stderr output stream to auto, to collect segmentation fault for
+  # test execution with gcov tool
+  #
+  # @param [hash, #command] - Command line generated from @tool_executor.build_command_line
+  def enable_gcov_with_gdb_and_cmdargs(command)
+    if @configurator.project_config_hash[:project_use_backtrace_gdb_reporter] &&
+       @configurator.project_config_hash[:test_runner_cmdline_args]
+       command[:options][:stderr_redirect] = if @configurator.project_config_hash[:tools_backtrace_settings][:stderr_redirect] == StdErrRedirect::NONE
+                                               DEFAULT_BACKTRACE_TOOL[:stderr_redirect]
+                                             else
+                                               @configurator.project_config_hash[:tools_backtrace_settings][:stderr_redirect]
+                                             end
+    end
+  end
+
+  # Support function to collect backtrace from gdb.
+  # If test_runner_cmdline_args is set, function it will try to run each of test separately
+  # and create output String similar to non segmentation fault execution but with notification
+  # test with segmentation fault as failure
+  #
+  # @param [hash, #shell_result] - output shell created by calling @tool_executor.exec
+  # @return hash - updated shell_result passed as argument
+  def gdb_output_collector(shell_result)
+    if @configurator.project_config_hash[:test_runner_cmdline_args]
+      test_case_result_collector = @test_result_collector_struct.new(
+        passed: 0,
+        failed: 0,
+        ignored: 0,
+        output: []
+      )
+
+      # Reset time
+      shell_result[:time] = 0
+
+      test_case_list_to_execute = collect_list_of_test_cases(@command_line)
+      test_case_list_to_execute.each do |test_case_name|
+        test_run_cmd = @command_line.clone
+        test_run_cmd_with_args = test_run_cmd[:line] + @unity_utils.additional_test_run_args(test_case_name, 'test_case')
+        test_output, exec_time = collect_cmd_output_with_gdb(test_run_cmd, test_run_cmd_with_args)
+
+        # Concatenate execution time between tests
+        # running tests serpatatelly might increase total execution time
+        shell_result[:time] += exec_time
+
+        # Concatenate test results from single test runs, which not crash
+        # to create proper output for further parser
+        if test_output =~ /([\S]+):(\d+):([\S]+):(IGNORE|PASS|FAIL:)(.*)/
+          test_output = "#{Regexp.last_match(1)}:#{Regexp.last_match(2)}:#{Regexp.last_match(3)}:#{Regexp.last_match(4)}#{Regexp.last_match(5)}"
+          if test_output =~ /:PASS/
+            test_case_result_collector[:passed] += 1
+          elsif test_output =~ /:IGNORE/
+            test_case_result_collector[:ignored] += 1
+          elsif test_output =~ /:FAIL:/
+            test_case_result_collector[:failed] += 1
+          end
+        else
+          # <-- Parse Segmentatation Fault output section -->
+          
+          # Withdraw test_name from gdb output
+          test_name = if test_output =~ /<(.*)>/
+                        Regexp.last_match(1)
+                      else
+                        ''
+                      end
+
+          # Collect file_name and line in which Segmentation fault have his beginning
+          if test_output =~ /#{test_name}\s\(\)\sat\s(.*):(\d+)\n/
+            # Remove path from file_name
+            file_name = Regexp.last_match(1).to_s.split('/').last.split('\\').last
+            # Save line number
+            line = Regexp.last_match(2)
+
+            # Replace:
+            # - '\n' by @new_line_tag to make gdb output flat
+            # - ':' by @colon_tag to avoid test results problems
+            # to enable parsing output for default generator_test_results regex
+            test_output = test_output.gsub("\n", @new_line_tag).gsub(':', @colon_tag)
+            test_output = "#{file_name}:#{line}:#{test_name}:FAIL: #{test_output}"
+          end
+
+          # Mark test as failure
+          test_case_result_collector[:failed] += 1
+        end
+        test_case_result_collector[:output].append("#{test_output}\r\n")
+      end
+
+      template = "\n-----------------------\n" \
+                 "\n#{(test_case_result_collector[:passed] + \
+                       test_case_result_collector[:failed] + \
+                       test_case_result_collector[:ignored])} " \
+                  "Tests #{test_case_result_collector[:failed]} " \
+                  "Failures #{test_case_result_collector[:ignored]} Ignored\n\n"
+
+      template += if test_case_result_collector[:failed] > 0
+                    "FAIL\n"
+                  else
+                    "OK\n"
+                  end
+      shell_result[:output] = test_case_result_collector[:output].join('') + \
+                              template
+    else
+      shell_result[:output], shell_result[:time] = collect_cmd_output_with_gdb(
+        @command_line,
+        @command_line[:line]
+      )
+    end
+
+    shell_result
+  end
+
+  # Restore new line under flatten log
+  #
+  # @param(String, #text) - string containing flatten output log
+  # @return [String, #output] - output with restored new line character
+  def restore_new_line_character_in_flatten_log(text)
+    if @configurator.project_config_hash[:project_use_backtrace_gdb_reporter] &&
+       @configurator.project_config_hash[:test_runner_cmdline_args]
+      text = text.gsub(@new_line_tag, "\n")
+    end
+    text
+  end
+
+  # Restore colon character under flatten log
+  #
+  # @param(String, #text) - string containing flatten output log
+  # @return [String, #output] - output with restored colon character
+  def restore_colon_character_in_flatten_log(text)
+    if @configurator.project_config_hash[:project_use_backtrace_gdb_reporter] &&
+       @configurator.project_config_hash[:test_runner_cmdline_args]
+      text = text.gsub(@colon_tag, ':')
+    end
+    text
+  end
+
+  # Unflat segmentation fault log
+  #
+  # @param(String, #text) - string containing flatten output log
+  # @return [String, #output] - output with restored colon and new line character
+  def unflat_debugger_log(text)
+    text = restore_new_line_character_in_flatten_log(text)
+    text = restore_colon_character_in_flatten_log(text)
+    text = text.gsub('"',"'") # Replace " character by ' for junit_xml reporter
+    text
+  end
+end

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -237,12 +237,28 @@ DEFAULT_RELEASE_LINKER_TOOL = {
     ].freeze
   }
 
+DEFAULT_BACKTRACE_TOOL = {
+  :executable => FilePathUtils.os_executable_ext('gdb').freeze,
+  :name => 'default_backtrace_settings'.freeze,
+  :stderr_redirect => StdErrRedirect::AUTO.freeze,
+  :background_exec => BackgroundExec::NONE.freeze,
+  :optional => false.freeze,
+  :arguments => [
+    '-q',
+    '--eval-command run',
+    '--eval-command backtrace',
+    '--batch',
+    '--args'
+    ].freeze
+  }
+
 
 DEFAULT_TOOLS_TEST = {
   :tools => {
     :test_compiler => DEFAULT_TEST_COMPILER_TOOL,
     :test_linker   => DEFAULT_TEST_LINKER_TOOL,
     :test_fixture  => DEFAULT_TEST_FIXTURE_TOOL,
+    :backtrace_settings => DEFAULT_BACKTRACE_TOOL,
     }
   }
 
@@ -386,7 +402,8 @@ DEFAULT_CEEDLING_CONFIG = {
     },
 
     # all tools populated while building up config structure
-    :tools => {},
+    :tools => {
+    },
 
     # empty argument lists for default tools
     # (these can be overridden in project file to add arguments to tools without totally redefining tools)

--- a/lib/ceedling/generator_test_results.rb
+++ b/lib/ceedling/generator_test_results.rb
@@ -4,7 +4,7 @@ require 'ceedling/constants'
 
 class GeneratorTestResults
 
-  constructor :configurator, :generator_test_results_sanity_checker, :yaml_wrapper
+  constructor :configurator, :generator_test_results_sanity_checker, :yaml_wrapper, :debugger_utils
 
   def process_and_write_results(unity_shell_result, results_file, test_file)
     output_file = results_file
@@ -43,7 +43,6 @@ class GeneratorTestResults
 
     # remove test statistics lines
     output_string = unity_shell_result[:output].sub(TEST_STDOUT_STATISTICS_PATTERN, '')
-
     output_string.lines do |line|
       # process unity output
       case line.chomp!
@@ -61,6 +60,7 @@ class GeneratorTestResults
         results[:stdout] << elements[1] if (!elements[1].nil?)
       when /(:FAIL)/
         elements = extract_line_elements(line, results[:source][:file])
+        elements[0][:test] = @debugger_utils.restore_new_line_character_in_flatten_log(elements[0][:test])
         results[:failures] << elements[0]
         results[:stdout] << elements[1] if (!elements[1].nil?)
       else # collect up all other
@@ -74,6 +74,9 @@ class GeneratorTestResults
 
     output_file = results_file.ext(@configurator.extension_testfail) if (results[:counts][:failed] > 0)
 
+    results[:failures].each do |failure|
+      failure[:message] = @debugger_utils.unflat_debugger_log(failure[:message])
+    end
     @yaml_wrapper.dump(output_file, results)
 
     return { :result_file => output_file, :result => results }
@@ -101,7 +104,9 @@ class GeneratorTestResults
 
     if (line =~ stdout_regex)
       stdout = $1.clone
-      line.sub!(/#{Regexp.escape(stdout)}/, '')
+      unless @configurator.project_config_hash[:project_use_backtrace_gdb_reporter]
+        line.sub!(/#{Regexp.escape(stdout)}/, '')
+      end
     end
 
     # collect up test results minus and extra output
@@ -112,8 +117,14 @@ class GeneratorTestResults
       unity_test_time = $1.to_f / 1000
       elements[-1].sub!(/ \((\d*(?:\.\d*)?) ms\)/, '')
     end
+    if elements[3..-1]
+      message = (elements[3..-1].join(':')).strip
+      message = @debugger_utils.unflat_debugger_log(message)
+    else
+      message = nil
+    end
 
-    return {:test => elements[1], :line => elements[0].to_i, :message => (elements[3..-1].join(':')).strip, :unity_test_time => unity_test_time}, stdout if elements.size >= 3
+    return {:test => elements[1], :line => elements[0].to_i, :message => message, :unity_test_time => unity_test_time}, stdout if elements.size >= 3
     return {:test => '???', :line => -1, :message => nil, :unity_test_time => unity_test_time} #fallback safe option. TODO better handling
   end
 

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -42,6 +42,12 @@ unity_utils:
   compose:
      - configurator
 
+debugger_utils:
+  compose:
+     - configurator
+     - tool_executor
+     - unity_utils
+
 project_config_manager:
   compose:
     - cacheinator
@@ -201,6 +207,7 @@ generator:
     - plugin_manager
     - file_wrapper
     - unity_utils
+    - debugger_utils
 
 generator_helper:
   compose:
@@ -211,6 +218,7 @@ generator_test_results:
     - configurator
     - generator_test_results_sanity_checker
     - yaml_wrapper
+    - debugger_utils
 
 generator_test_results_sanity_checker:
   compose:

--- a/lib/ceedling/unity_utils.rb
+++ b/lib/ceedling/unity_utils.rb
@@ -3,7 +3,7 @@
 # and additional warning definitions
 class UnityUtils
   attr_reader :test_runner_disabled_replay, :arg_option_map
-  attr_accessor :test_runner_args, :not_supported
+  attr_accessor :test_case_incl, :test_case_excl, :not_supported
 
   constructor :configurator
 
@@ -12,7 +12,8 @@ class UnityUtils
      "The option[s]: %<opt>.s \ncannot be applied." \
      'To enable it, please add `:cmdline_args` under' \
      ' :test_runner option in your project.yml.'
-    @test_runner_args = ''
+    @test_case_incl = ''
+    @test_case_excl = ''
     @not_supported = ''
 
     # Refering to Unity implementation of the parser implemented in the unit.c :
@@ -40,6 +41,9 @@ class UnityUtils
   # @param [String, #option] one of the supported by unity arguments.
   #                          At current moment only "test_case_name" to
   #                          run single test
+  #
+  # @return String - empty if cmdline_args is not set
+  #                  In other way properly formated command line for Unity
   def additional_test_run_args(argument, option)
     # Confirm wherever cmdline_args is set to true
     # and parsing arguments under generated test runner in Unity is enabled
@@ -52,33 +56,35 @@ class UnityUtils
     raise 'Unknown Unity argument option' unless \
       @arg_option_map.key?(option)
 
-    @test_runner_args += " -#{@arg_option_map[option]} #{argument} "
+    " -#{@arg_option_map[option]} #{argument} "
   end
 
   # Return test case arguments
   #
   # @return [String] formatted arguments for test file
   def collect_test_runner_additional_args
-    @test_runner_args
+    "#{@test_case_incl} #{@test_case_excl}"
   end
 
   # Parse passed by user arguments
   def create_test_runner_additional_args
     if ENV['CEEDLING_INCLUDE_TEST_CASE_NAME']
       if @configurator.project_config_hash[:test_runner_cmdline_args]
-        additional_test_run_args(ENV['CEEDLING_INCLUDE_TEST_CASE_NAME'],
-                                 'test_case')
+        @test_case_incl += additional_test_run_args(
+          ENV['CEEDLING_INCLUDE_TEST_CASE_NAME'],
+          'test_case')
       else
-        @not_supported = "\n\t--test_case"
+        @not_supported += "\n\t--test_case"
       end
     end
 
     if ENV['CEEDLING_EXCLUDE_TEST_CASE_NAME']
       if @configurator.project_config_hash[:test_runner_cmdline_args]
-        additional_test_run_args(ENV['CEEDLING_EXCLUDE_TEST_CASE_NAME'],
-                                 'exclude_test_case')
+        @test_case_excl += additional_test_run_args(
+          ENV['CEEDLING_EXCLUDE_TEST_CASE_NAME'],
+          'exclude_test_case')
       else
-        @not_supported = "\n\t--exclude_test_case"
+        @not_supported += "\n\t--exclude_test_case"
       end
     end
     print_warning_about_not_enabled_cmdline_args

--- a/spec/gcov/gcov_deployment_spec.rb
+++ b/spec/gcov/gcov_deployment_spec.rb
@@ -32,6 +32,9 @@ describe "Ceedling" do
       it { can_test_projects_with_gcov_with_compile_error }
       it { can_fetch_project_help_for_gcov }
       it { can_create_html_report }
+      it { can_create_gcov_html_report_from_crashing_test_runner_with_enabled_debug_and_cmd_args_set_to_true_for_test_cases_not_causing_crash }
+      it { can_create_gcov_html_report_from_crashing_test_runner_with_enabled_debug_and_cmd_args_set_to_true_with_zero_coverage }
+      it { can_create_gcov_html_report_from_test_runner_with_enabled_debug_and_cmd_args_set_to_true_with_100_coverage_when_excluding_crashing_test_case }
     end
 
 

--- a/spec/gcov/gcov_test_cases_spec.rb
+++ b/spec/gcov/gcov_test_cases_spec.rb
@@ -194,4 +194,147 @@ module GcovTestCases
       end
     end
   end
+
+  def can_create_gcov_html_report_from_crashing_test_runner_with_enabled_debug_and_cmd_args_set_to_true_for_test_cases_not_causing_crash
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_sigsegv.c"), 'test/'
+        FileUtils.cp test_asset_path("project_with_guts_gcov.yml"), 'project.yml'
+
+        add_line = false
+        updated_prj_yml = []
+        File.read('project.yml').split("\n").each do |line|
+          if line =~ /\:project\:/
+            add_line = true
+            updated_prj_yml.append(line)
+          else
+            if add_line
+              updated_prj_yml.append('  :use_backtrace_gdb_reporter: TRUE')
+              add_line = false
+            end
+            updated_prj_yml.append(line)
+          end
+        end
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+
+        updated_prj_yml.insert(updated_prj_yml.length() -1, enable_unity_extra_args)
+
+        File.write('project.yml', updated_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling gcov:all 2>&1`
+        expect($?.exitstatus).to match(1) # Test should fail as sigsegv is called
+        gcov_html_report = `bundle exec ruby -S ceedling utils:gcov 2>&1`
+        expect($?.exitstatus).to match(0)
+        expect(output).to match(/Program received signal SIGSEGV, Segmentation fault./)
+        expect(output).to match(/Unit test failures./)
+        expect(File.exist?('./build/gcov/results/test_example_file_sigsegv.fail'))
+        output_rd = File.read('./build/gcov/results/test_example_file_sigsegv.fail')
+        expect(output_rd =~ /test_add_numbers_will_fail \(\) at test\/test_example_file_sigsegv.c\:14/ )
+        expect(output).to match(/TESTED:\s+2/)
+        expect(output).to match(/PASSED:\s+1/)
+        expect(output).to match(/FAILED:\s+1/)
+        expect(output).to match(/IGNORED:\s+0/)
+        expect(output).to match(/example_file.c Lines executed:50.00% of 4/)
+
+        expect(gcov_html_report).to match(/Creating gcov results report\(s\) in 'build\/artifacts\/gcov'\.\.\. Done/)
+        expect(File.exist?('build/artifacts/gcov/GcovCoverageResults.html')).to eq true
+      end
+    end
+  end
+
+  def can_create_gcov_html_report_from_crashing_test_runner_with_enabled_debug_and_cmd_args_set_to_true_with_zero_coverage
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_sigsegv.c"), 'test/'
+        FileUtils.cp test_asset_path("project_with_guts_gcov.yml"), 'project.yml'
+
+        add_line = false
+        updated_prj_yml = []
+        File.read('project.yml').split("\n").each do |line|
+          if line =~ /\:project\:/
+            add_line = true
+            updated_prj_yml.append(line)
+          else
+            if add_line
+              updated_prj_yml.append('  :use_backtrace_gdb_reporter: TRUE')
+              add_line = false
+            end
+            updated_prj_yml.append(line)
+          end
+        end
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+
+        updated_prj_yml.insert(updated_prj_yml.length() -1, enable_unity_extra_args)
+
+        File.write('project.yml', updated_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling gcov:all --exclude_test_case=test_add_numbers_adds_numbers 2>&1`
+        expect($?.exitstatus).to match(1) # Test should fail as sigsegv is called
+        gcov_html_report = `bundle exec ruby -S ceedling utils:gcov 2>&1`
+        expect($?.exitstatus).to match(0)
+        expect(output).to match(/Program received signal SIGSEGV, Segmentation fault./)
+        expect(output).to match(/Unit test failures./)
+        expect(File.exist?('./build/gcov/results/test_example_file_sigsegv.fail'))
+        output_rd = File.read('./build/gcov/results/test_example_file_sigsegv.fail')
+        expect(output_rd =~ /test_add_numbers_will_fail \(\) at test\/test_example_file_sigsegv.c\:14/ )
+        expect(output).to match(/TESTED:\s+1/)
+        expect(output).to match(/PASSED:\s+0/)
+        expect(output).to match(/FAILED:\s+1/)
+        expect(output).to match(/IGNORED:\s+0/)
+        expect(output).to match(/example_file.c Lines executed:0.00% of 4/)
+
+        expect(gcov_html_report).to match(/Creating gcov results report\(s\) in 'build\/artifacts\/gcov'\.\.\. Done/)
+        expect(File.exist?('build/artifacts/gcov/GcovCoverageResults.html')).to eq true
+      end
+    end
+  end
+
+  def can_create_gcov_html_report_from_test_runner_with_enabled_debug_and_cmd_args_set_to_true_with_100_coverage_when_excluding_crashing_test_case
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_sigsegv.c"), 'test/'
+        FileUtils.cp test_asset_path("project_with_guts_gcov.yml"), 'project.yml'
+
+        add_line = false
+        updated_prj_yml = File.read('project.yml').split("\n")
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+
+        updated_prj_yml.insert(updated_prj_yml.length() -1, enable_unity_extra_args)
+
+        File.write('project.yml', updated_prj_yml.join("\n"), mode: 'w')
+
+        add_test_case = "\nvoid test_difference_between_two_numbers(void)\n"\
+                        "{\n" \
+                        "  TEST_ASSERT_EQUAL(0, difference_between_numbers(1,1));\n" \
+                        "}\n"
+        
+        updated_test_file = File.read('test/test_example_file_sigsegv.c').split("\n")
+        updated_test_file.insert(updated_test_file.length(), add_test_case)
+        File.write('test/test_example_file_sigsegv.c', updated_test_file.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling gcov:all --exclude_test_case=test_add_numbers_will_fail 2>&1`
+        expect($?.exitstatus).to match(0)
+        gcov_html_report = `bundle exec ruby -S ceedling utils:gcov 2>&1`
+        expect($?.exitstatus).to match(0)
+        expect(File.exist?('./build/gcov/results/test_example_file_sigsegv.pass'))
+        expect(output).to match(/TESTED:\s+2/)
+        expect(output).to match(/PASSED:\s+2/)
+        expect(output).to match(/FAILED:\s+0/)
+        expect(output).to match(/IGNORED:\s+0/)
+        expect(output).to match(/example_file.c Lines executed:100.00% of 4/)
+
+        expect(gcov_html_report).to match(/Creating gcov results report\(s\) in 'build\/artifacts\/gcov'\.\.\. Done/)
+        expect(File.exist?('build/artifacts/gcov/GcovCoverageResults.html')).to eq true
+      end
+    end
+  end
 end

--- a/spec/generator_test_results_spec.rb
+++ b/spec/generator_test_results_spec.rb
@@ -5,6 +5,7 @@ require 'ceedling/yaml_wrapper'
 require 'ceedling/constants'
 require 'ceedling/streaminator'
 require 'ceedling/configurator'
+require 'ceedling/debugger_utils'
 
 NORMAL_OUTPUT =
   "Verbose output one\n" +
@@ -61,8 +62,16 @@ describe GeneratorTestResults do
     # these will always be used as is.
     @yaml_wrapper = YamlWrapper.new
     @sanity_checker = GeneratorTestResultsSanityChecker.new({:configurator => @configurator, :streaminator => @streaminator})
-    
-    @generate_test_results = described_class.new({:configurator => @configurator, :generator_test_results_sanity_checker => @sanity_checker, :yaml_wrapper => @yaml_wrapper})
+    @debugger_utils = DebuggerUtils.new({:configurator => @configurator, :tool_executor => nil, :unity_utils => nil})
+
+    @generate_test_results = described_class.new(
+      {
+        :configurator => @configurator,
+        :generator_test_results_sanity_checker => @sanity_checker,
+        :yaml_wrapper => @yaml_wrapper,
+        :debugger_utils => @debugger_utils
+      }
+    )
   end
 
   after(:each) do

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -843,7 +843,7 @@ module CeedlingTestCases
         expect($?.exitstatus).to match(1) # Test should fail as sigsegv is called
         expect(output).to match(/Segmentation fault \(core dumped\)/)
         expect(output).to match(/No tests executed./)
-        expect(!File.exists?('./build/test/results/test_add.fail'))
+        expect(!File.exist?('./build/test/results/test_add.fail'))
       end
     end
   end
@@ -876,9 +876,138 @@ module CeedlingTestCases
         expect($?.exitstatus).to match(1) # Test should fail as sigsegv is called
         expect(output).to match(/Program received signal SIGSEGV, Segmentation fault./)
         expect(output).to match(/Unit test failures./)
-        expect(File.exists?('./build/test/results/test_example_file_sigsegv.fail'))
+        expect(File.exist?('./build/test/results/test_example_file_sigsegv.fail'))
         output_rd = File.read('./build/test/results/test_example_file_sigsegv.fail')
         expect(output_rd =~ /test_add_numbers_will_fail \(\) at test\/test_example_file_sigsegv.c\:14/ )
+      end
+    end
+  end
+
+  def execute_all_test_cases_from_crashing_test_runner_and_return_test_report_with_failue_when_cmd_args_set_to_true
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_sigsegv.c"), 'test/'
+
+        add_line = false
+        updated_prj_yml = []
+        File.read('project.yml').split("\n").each do |line|
+          if line =~ /\:project\:/
+            add_line = true
+            updated_prj_yml.append(line)
+          else
+            if add_line
+              updated_prj_yml.append('  :use_backtrace_gdb_reporter: TRUE')
+              add_line = false
+            end
+            updated_prj_yml.append(line)
+          end
+        end
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+
+        updated_prj_yml.insert(updated_prj_yml.length() -1, enable_unity_extra_args)
+
+        File.write('project.yml', updated_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling test:all 2>&1`
+        expect($?.exitstatus).to match(1) # Test should fail as sigsegv is called
+        expect(output).to match(/Program received signal SIGSEGV, Segmentation fault./)
+        expect(output).to match(/Unit test failures./)
+        expect(File.exist?('./build/test/results/test_example_file_sigsegv.fail'))
+        output_rd = File.read('./build/test/results/test_example_file_sigsegv.fail')
+        expect(output_rd =~ /test_add_numbers_will_fail \(\) at test\/test_example_file_sigsegv.c\:14/ )
+        expect(output).to match(/TESTED:\s+2/)
+        expect(output).to match(/PASSED:\s+1/)
+        expect(output).to match(/FAILED:\s+1/)
+        expect(output).to match(/IGNORED:\s+0/)
+      end
+    end
+  end
+
+  def execute_and_collect_debug_logs_from_crashing_test_case_defined_by_test_case_argument_with_enabled_debug_and_cmd_args_set_to_true
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_sigsegv.c"), 'test/'
+
+        add_line = false
+        updated_prj_yml = []
+        File.read('project.yml').split("\n").each do |line|
+          if line =~ /\:project\:/
+            add_line = true
+            updated_prj_yml.append(line)
+          else
+            if add_line
+              updated_prj_yml.append('  :use_backtrace_gdb_reporter: TRUE')
+              add_line = false
+            end
+            updated_prj_yml.append(line)
+          end
+        end
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+
+        updated_prj_yml.insert(updated_prj_yml.length() -1, enable_unity_extra_args)
+
+        File.write('project.yml', updated_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling test:all --test_case=test_add_numbers_will_fail 2>&1`
+        expect($?.exitstatus).to match(1) # Test should fail as sigsegv is called
+        expect(output).to match(/Program received signal SIGSEGV, Segmentation fault./)
+        expect(output).to match(/Unit test failures./)
+        expect(File.exist?('./build/test/results/test_example_file_sigsegv.fail'))
+        output_rd = File.read('./build/test/results/test_example_file_sigsegv.fail')
+        expect(output_rd =~ /test_add_numbers_will_fail \(\) at test\/test_example_file_sigsegv.c\:14/ )
+        expect(output).to match(/TESTED:\s+1/)
+        expect(output).to match(/PASSED:\s+0/)
+        expect(output).to match(/FAILED:\s+1/)
+        expect(output).to match(/IGNORED:\s+0/)
+      end
+    end
+  end
+
+  def execute_and_collect_debug_logs_from_crashing_test_case_defined_by_exclude_test_case_argument_with_enabled_debug_and_cmd_args_set_to_true
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_sigsegv.c"), 'test/'
+
+        add_line = false
+        updated_prj_yml = []
+        File.read('project.yml').split("\n").each do |line|
+          if line =~ /\:project\:/
+            add_line = true
+            updated_prj_yml.append(line)
+          else
+            if add_line
+              updated_prj_yml.append('  :use_backtrace_gdb_reporter: TRUE')
+              add_line = false
+            end
+            updated_prj_yml.append(line)
+          end
+        end
+        enable_unity_extra_args = "\n:test_runner:\n"\
+                                  "  :cmdline_args: true\n"
+
+        updated_prj_yml.insert(updated_prj_yml.length() -1, enable_unity_extra_args)
+
+        File.write('project.yml', updated_prj_yml.join("\n"), mode: 'w')
+
+        output = `bundle exec ruby -S ceedling test:all --exclude_test_case=add_numbers_adds_numbers 2>&1`
+        expect($?.exitstatus).to match(1) # Test should fail as sigsegv is called
+        expect(output).to match(/Program received signal SIGSEGV, Segmentation fault./)
+        expect(output).to match(/Unit test failures./)
+        expect(File.exist?('./build/test/results/test_example_file_sigsegv.fail'))
+        output_rd = File.read('./build/test/results/test_example_file_sigsegv.fail')
+        expect(output_rd =~ /test_add_numbers_will_fail \(\) at test\/test_example_file_sigsegv.c\:14/ )
+        expect(output).to match(/TESTED:\s+1/)
+        expect(output).to match(/PASSED:\s+0/)
+        expect(output).to match(/FAILED:\s+1/)
+        expect(output).to match(/IGNORED:\s+0/)
       end
     end
   end

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -49,6 +49,9 @@ describe "Ceedling" do
     it { handles_destroying_a_module_that_does_not_exist_using_the_module_plugin_path_extension }
     it { test_run_of_projects_fail_because_of_sigsegv_without_report }
     it { test_run_of_projects_fail_because_of_sigsegv_with_report }
+    it { execute_all_test_cases_from_crashing_test_runner_and_return_test_report_with_failue_when_cmd_args_set_to_true }
+    it { execute_and_collect_debug_logs_from_crashing_test_case_defined_by_test_case_argument_with_enabled_debug_and_cmd_args_set_to_true }
+    it { execute_and_collect_debug_logs_from_crashing_test_case_defined_by_exclude_test_case_argument_with_enabled_debug_and_cmd_args_set_to_true }
     it { can_run_single_test_with_full_test_case_name_from_test_file_with_success_cmdline_args_are_enabled }
     it { can_run_single_test_with_partiall_test_case_name_from_test_file_with_enabled_cmdline_args_success }
     it { exlcude_test_case_name_filter_works_and_only_one_test_case_is_executed }


### PR DESCRIPTION
---
**FEATURE**
Extend collecting backtrace data from crashing test_runner executable file.
After setting up project.yml:

```
:project:
  :use_backtrace_gdb_reporter: TRUE

...

:test_runner:
  :cmdline_args: true
```

Ceedling engine is executing test separatelly in the test file, which is crashing.

What that means?

1. If file is crashing on one test case, rest of test cases will be executed. The test results will be collected. The test which cause segmentation fault is executed and marked as failure. The backtrace is added as failure reason.
2. The *.gcno and *.gcda files are created and the code coverage is computing collected data from rest of test cases. The blank side is touching only test code execution, which is causing segmentation fault 
3. Running on only test case which cause segmentation fault, decrease amount of time execution and create fail file together with backtrace as help for further investigation. 
---

**PR includes**

Updated code :
 -  Added new class debugging_utils.rb. (no code style issues - tested via rubocop)
 - Updated implementation of generator.rb
 - Updated implementation or generator_test_results.rb
 - Updated unity_utils.rb 

Updated CeedlingPacket.md with new ceedling functionality.

Added 5 UT to cover new functionality. ( rubocop describe problems with to long name description)

---
**Short description**

This PR contains extension for backtrace collector which enable possibility to collect test results from crashing test_runner file and creating test report files.

As well enable running separate test cases form crashing test runner. This logic enables creation of *.gcda and *.gcno files required by GCOV to generate coverage data

```
ceedling test:<test_file_name> --test_case=<test_case_name>
ceedling gcov:all
cedling utils:gcov
```

and updating project.yml after adding:
```
:project:
  :use_backtrace_gdb_reporter: TRUE

...

:test_runner:
  :cmdline_args: true
```

**Limitations and problems**:

- If test_runner file contains a lot of test cases, the time execution on it can be increased, as each of test case will be executed separately and the possible new problems, such as test case dependency might appears.

---
** How it works in real life **

If test file contains three test cases:
test_gpio.c

```
#include "unity.h"
#include "gpio_def.h"
#include <signal.h>

void setUp(void) {}
void tearDown(void) {}

void test_gpio_start(void) {
  TEST_ASSERT_EQUAL(GPIO_OK, gpio_start(gpio13) ).
}

void test_gpio_configure_proper(void) {
  raise(SIGSEGV);
  TEST_ASSERT_EQUAL(GPIO_OK, gpio_configure(gpio_13, NULL));
}


void test_gpio_configure_fail_pin_not_allowed(void) {
  TEST_ASSERT_EQUAL(GPIO_ERR, gpio_configure(gpio_max, NULL));
}

```

if we run ceedling on it with enabled in project.yml:
project.yml after adding:

```
:project:
  :use_backtrace_gdb_reporter: TRUE

...

:test_runner:
  :cmdline_args: true
```

after discovering segmentation fault, thanks to enabled by cmdline_args Unity functionality, all test names will be collected from crashing test_runner file.

Each test will be executed separately in gdb (which will produce backtrace on segmentation fault) and test results (and log - keep in mind xunit has possibility of failure description) will be save and computed in one test report as Ceedling is producing during normal test execution flow. This will extend the execution time for test files with many test_cases only in case of segmentation faulted test case, but it will end up producing a valuable report about the failure.

As well the end developer receive possibility to run and get backtrace data from failing test case running:

```sh
ceedling test:all --test_case=test_gpio_configure_proper
```

which will produce backtrace to help engineer to investigate segmentation fault reason.

---

@mvandervoord : Can I ask you for a looking at this in your free time? I have hope that this feature will help other people as helped me in my day work.
