### PR TITLE
Bugfix/unity cmdline args fix

### DIFF
--- a/lib/ceedling/unity_utils.rb
+++ b/lib/ceedling/unity_utils.rb
@@ -81,7 +81,9 @@ class UnityUtils
         @not_supported = "\n\t--exclude_test_case"
       end
     end
-    print_warning_about_not_enabled_cmdline_args
+    if ENV['CEEDLING_EXCLUDE_TEST_CASE_NAME'] || ENV['CEEDLING_INCLUDE_TEST_CASE_NAME']
+      print_warning_about_not_enabled_cmdline_args
+    end
   end
 
   # Return UNITY_USE_COMMAND_LINE_ARGS define required by Unity to

--- a/spec/spec_system_helper.rb
+++ b/spec/spec_system_helper.rb
@@ -666,6 +666,25 @@ module CeedlingTestCases
     end
   end
 
+  def confirm_if_notification_for_cmdline_args_not_enabled_is_disabled
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling test:test_example_file_success 2>&1`
+
+        expect($?.exitstatus).to match(0) # Since a test either pass or are ignored, we return success here
+        expect(output).to match(/TESTED:\s+2/)
+        expect(output).to match(/PASSED:\s+1/)
+        expect(output).to match(/FAILED:\s+0/)
+        expect(output).to match(/IGNORED:\s+1/)
+        expect(output).not_to match(/please add `:cmdline_args` under :test_runner option/)
+      end
+    end
+  end
+
   def exlcude_test_case_name_filter_works_and_only_one_test_case_is_executed
     @c.with_context do
       Dir.chdir @proj_name do

--- a/spec/system/deployment_spec.rb
+++ b/spec/system/deployment_spec.rb
@@ -52,6 +52,7 @@ describe "Ceedling" do
     it { can_run_single_test_with_full_test_case_name_from_test_file_with_success_cmdline_args_are_enabled }
     it { can_run_single_test_with_partiall_test_case_name_from_test_file_with_enabled_cmdline_args_success }
     it { exlcude_test_case_name_filter_works_and_only_one_test_case_is_executed }
+    it { confirm_if_notification_for_cmdline_args_not_enabled_is_disabled }
     it { none_of_test_is_executed_if_test_case_name_passed_does_not_fit_defined_in_test_file_and_cmdline_args_are_enabled }
     it { none_of_test_is_executed_if_test_case_name_and_exclude_test_case_name_is_the_same }
     it { run_all_test_when_test_case_name_is_passed_but_cmdline_args_are_disabled_with_success }


### PR DESCRIPTION
Hi @mvandervoord ,

Can I ask you for looking at this, and maybe adding it to RC0.32?

It is fix for showing notification, that user didn't enabled cmdline_args even if he does not pass in cmd line:
--test_case
--exclude_test_case
arguments.

In advance, thank you.