### PR TITLE
fix(invoker): Add the artifacts inside the context folders

### DIFF
--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -50,6 +50,8 @@ class TestInvoker
 
     @project_config_manager.process_test_config_change
 
+    options[:symbol] = context
+
     # Create Storage For Works In Progress
     testables = {}
     mock_list = []


### PR DESCRIPTION
When running `ceedling test:AdcConductor` the context was nil and the generated xml_tests_report file `report.xml` was created in the `build/artifacts` directory while it should be created in the `build/artifacts/test` directory. The `ceedling test:all` was not impacted by the bug.

fix numaru/vscode-ceedling-test-adapter#114

---

I'm not sure about the implementation. But what I found is that the context is in the separated `context` variable but it is expected to also be in `options[:symbol]` when calling `@test_invoker_helper.run_fixture_now()` latter in the `setup_and_invoke()` function.