### PR TITLE
Default make the backtrace tool as optional

### DIFF
--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -242,7 +242,7 @@ DEFAULT_BACKTRACE_TOOL = {
   :name => 'default_backtrace_settings'.freeze,
   :stderr_redirect => StdErrRedirect::AUTO.freeze,
   :background_exec => BackgroundExec::NONE.freeze,
-  :optional => false.freeze,
+  :optional => true.freeze,
   :arguments => [
     '-q',
     '--eval-command run',


### PR DESCRIPTION
When not having GDB installed and even if i put the `use_backtrace_gdb_reporter: FALSE` the path for GDB is checked. Since I do not want to define `tools: backtrace...` in my project yml, since I do not use it at the moment, it would be fair to make it optional (and hence removing the path check by default). Optional helps by not having to have gdb installed in CI, but workaround I assume is to define `tools: backtrace_settings: optional: TRUE` in `project.yml` 

Found in https://github.com/ThrowTheSwitch/Ceedling/pull/739#issuecomment-1545319491