### PR TITLE
Account for different ordering of files when traversing fs

### DIFF
--- a/lib/ceedling/file_system_utils.rb
+++ b/lib/ceedling/file_system_utils.rb
@@ -53,7 +53,7 @@ class FileSystemUtils
       FilePathUtils.add_path?(path) ? plus.merge(dirs) : minus.merge(dirs)
     end
 
-    return (plus - minus).to_a.uniq.sort
+    return (plus - minus).to_a.uniq
   end
 
 

--- a/lib/ceedling/file_wrapper.rb
+++ b/lib/ceedling/file_wrapper.rb
@@ -29,7 +29,7 @@ class FileWrapper
   end
 
   def directory_listing(glob)
-    return Dir.glob(glob, File::FNM_PATHNAME)
+    return Dir.glob(glob, File::FNM_PATHNAME).sort
   end
 
   def rm_f(filepath, options={})


### PR DESCRIPTION
But this should be done for each Dir.glob call, to ensure stability of the order of the paths specified by the user.  This is important notably for include directories, where the order of -I options imposes what file is included when there are homonyms in different directories.

cf. commit 558c84939fea8ab1649a6202ac13f781a50d9256