### PR TITLE
    Fixed #783 cmock of the wrong file is generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ ceedling-*.gem
 .ruby-version
 /.idea
 /.vscode
+
+*~

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -11,8 +11,8 @@ class Configurator
   attr_accessor :project_logging, :project_debug, :project_verbosity, :sanity_checks
 
   constructor(:configurator_setup, :configurator_builder, :configurator_plugins, :cmock_builder, :yaml_wrapper, :system_wrapper) do
-    @project_logging   = false
-    @project_debug     = false
+    @project_logging   = true
+    @project_debug     = true
     @project_verbosity = Verbosity::NORMAL
     @sanity_checks     = TestResultsSanityChecks::NORMAL
   end

--- a/lib/ceedling/configurator_builder.rb
+++ b/lib/ceedling/configurator_builder.rb
@@ -316,7 +316,8 @@ class ConfiguratorBuilder
       in_hash[:collection_paths_include]
 
     paths.each do |path|
-      all_headers.include( File.join(path, "**/*#{in_hash[:extension_header]}") )
+      # Do not search in subdirectories. If this is wanted, the user will use foo/** in project.yml
+      all_headers.include( File.join(path, "*#{in_hash[:extension_header]}") )
     end
 
     @file_system_utils.revise_file_list( all_headers, in_hash[:files_include] )

--- a/lib/ceedling/file_system_utils.rb
+++ b/lib/ceedling/file_system_utils.rb
@@ -53,7 +53,7 @@ class FileSystemUtils
       FilePathUtils.add_path?(path) ? plus.merge(dirs) : minus.merge(dirs)
     end
 
-    return (plus - minus).to_a.uniq.sort
+    return (plus - minus).to_a.uniq
   end
 
 

--- a/lib/ceedling/file_wrapper.rb
+++ b/lib/ceedling/file_wrapper.rb
@@ -63,6 +63,8 @@ class FileWrapper
   end
 
   def write(filepath, contents, flags='w')
+    directory = File.dirname(filepath)
+    FileUtils.mkdir_p(directory)
     File.open(filepath, flags) do |file|
       file.write(contents)
     end

--- a/lib/ceedling/file_wrapper.rb
+++ b/lib/ceedling/file_wrapper.rb
@@ -29,7 +29,7 @@ class FileWrapper
   end
 
   def directory_listing(glob)
-    return Dir.glob(glob, File::FNM_PATHNAME)
+    return Dir.glob(glob, File::FNM_PATHNAME).sort
   end
 
   def rm_f(filepath, options={})

--- a/lib/ceedling/preprocessinator_file_handler.rb
+++ b/lib/ceedling/preprocessinator_file_handler.rb
@@ -14,7 +14,7 @@ class PreprocessinatorFileHandler
     contents = @preprocessinator_extractor.extract_base_file_from_preprocessed_expansion(preprocessed_filepath)
 
     includes.each{|include| contents.unshift("#include \"#{include}\"")}
-
+    contents.unshift("/* Source File = #{filepath} */")
     @file_wrapper.write(preprocessed_filepath, contents.join("\n"))
   end
 

--- a/lib/ceedling/preprocessinator_file_handler.rb
+++ b/lib/ceedling/preprocessinator_file_handler.rb
@@ -13,7 +13,8 @@ class PreprocessinatorFileHandler
 
     contents = @preprocessinator_extractor.extract_base_file_from_preprocessed_expansion(preprocessed_filepath)
 
-    includes.each{|include| contents.unshift("#include \"#{include}\"")}
+    # we want to keep the order of the included files, it may be important!
+    includes.reverse.each{|include| contents.unshift("#include \"#{include}\"")}
     contents.unshift("/* Source File = #{filepath} */")
     @file_wrapper.write(preprocessed_filepath, contents.join("\n"))
   end
@@ -26,8 +27,8 @@ class PreprocessinatorFileHandler
 
     contents = @preprocessinator_extractor.extract_base_file_from_preprocessed_directives(preprocessed_filepath)
 
-    includes.each{|include| contents.unshift("#include \"#{include}\"")}
-
+    includes.reverse.each{|include| contents.unshift("#include \"#{include}\"")}
+    contents.unshift("/* Source File = #{filepath} */")
     @file_wrapper.write(preprocessed_filepath, contents.join("\n"))
   end
 

--- a/lib/ceedling/rakefile.rb
+++ b/lib/ceedling/rakefile.rb
@@ -51,7 +51,9 @@ project_config =
 @ceedling[:plugin_manager].pre_build
 
 # load rakefile component files (*.rake)
-PROJECT_RAKEFILE_COMPONENT_FILES.each { |component| load(component) }
+PROJECT_RAKEFILE_COMPONENT_FILES.each { |component|
+  $stderr.puts "Loading rakefile component: #{component}..." unless @silent
+  load(component) }
 
 # tell rake to shut up by default (overridden in verbosity / debug tasks as appropriate)
 verbose(false)

--- a/lib/ceedling/yaml_wrapper.rb
+++ b/lib/ceedling/yaml_wrapper.rb
@@ -4,10 +4,19 @@ require 'erb'
 
 class YamlWrapper
 
+  def load_options()
+    yaml_version = YAML::VERSION[0].to_i  # Extract major version number of YAML
+    if yaml_version > 3
+      { aliases: true }
+    else
+      { }
+    end
+  end
+
   def load(filepath)
     source = ERB.new(File.read(filepath)).result
     begin
-      return YAML.load(source, aliases: true)
+      return YAML.load(source, **load_options)
     rescue ArgumentError
       return YAML.load(source)
     end
@@ -15,7 +24,7 @@ class YamlWrapper
 
   def load_string(source)
     begin
-      return YAML.load(source, aliases: true)
+      return YAML.load(source, **load_options)
     rescue ArgumentError
       return YAML.load(source)
     end

--- a/plugins/gcov/lib/gcovr_reportinator.rb
+++ b/plugins/gcov/lib/gcovr_reportinator.rb
@@ -336,7 +336,7 @@ class GcovrReportinator
 
   # Returns true if the given report type is enabled, otherwise returns false.
   def is_report_enabled(opts, report_type)
-    return !(opts.nil?) && !(opts[:gcov_reports].nil?) && (opts[:gcov_reports].map(&:upcase).include? report_type.upcase)
+    return !(opts.nil?) && !(opts[:gcov_reports].nil?) && (opts[:gcov_reports].compact.map(&:upcase).include? report_type.upcase)
   end
 
 end

--- a/plugins/gcov/lib/reportgenerator_reportinator.rb
+++ b/plugins/gcov/lib/reportgenerator_reportinator.rb
@@ -112,7 +112,7 @@ class ReportGeneratorReportinator
   REPORT_GENERATOR_SETTING_PREFIX = "gcov_report_generator"
 
   # Deep clone the gcov tool config, so we can modify it locally if specified via options.
-  GCOV_TOOL_CONFIG = Marshal.load(Marshal.dump(TOOLS_GCOV_GCOV_POST_REPORT))
+  GCOV_TOOL_CONFIG = Marshal.load(Marshal.dump(TOOLS_GCOV_POST_REPORT_CUSTOM))
 
   # Build the ReportGenerator arguments.
   def args_builder(opts)

--- a/plugins/gcov/lib/reportgenerator_reportinator.rb
+++ b/plugins/gcov/lib/reportgenerator_reportinator.rb
@@ -112,7 +112,7 @@ class ReportGeneratorReportinator
   REPORT_GENERATOR_SETTING_PREFIX = "gcov_report_generator"
 
   # Deep clone the gcov tool config, so we can modify it locally if specified via options.
-  GCOV_TOOL_CONFIG = Marshal.load(Marshal.dump(TOOLS_GCOV_POST_REPORT_CUSTOM))
+  GCOV_TOOL_CONFIG = Marshal.load(Marshal.dump(TOOLS_GCOV_GCOV_POST_REPORT))
 
   # Build the ReportGenerator arguments.
   def args_builder(opts)


### PR DESCRIPTION
    
    Do not add subdirectories of configured paths to the list of all headers,
    since the user may use ** himself, and may order the paths to include
    specific files.
    
    Added comment mentioning path of source file to generated files.
