### PR TITLE
Fix Bullseye plugin: configure project_test_build_output_c_path

### DIFF
--- a/plugins/bullseye/lib/bullseye.rb
+++ b/plugins/bullseye/lib/bullseye.rb
@@ -26,6 +26,7 @@ class Bullseye < Plugin
   def config
     {
       :project_test_build_output_path     => BULLSEYE_BUILD_OUTPUT_PATH,
+      :project_test_build_output_c_path   => BULLSEYE_BUILD_OUTPUT_PATH,
       :project_test_results_path          => BULLSEYE_RESULTS_PATH,
       :project_test_dependencies_path     => BULLSEYE_DEPENDENCIES_PATH,
       :defines_test                       => DEFINES_TEST + ['CODE_COVERAGE'],


### PR DESCRIPTION
Hi,

I've detected the Bullseye plugin was not working because the changes introduced by #265. I fixed it just doing the same change it was done for the gcov plugin.

BR,
Carlos Carrizosa