### PR TITLE
Restructure the setup config load order

### DIFF
--- a/lib/ceedling.rb
+++ b/lib/ceedling.rb
@@ -93,8 +93,8 @@ module Ceedling
 
     # Register the plugin with Ceedling
     require 'ceedling/defaults'
-    DEFAULT_CEEDLING_CONFIG[:plugins][:enabled]    << name
-    DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths] << gem_dir
+    CEEDLING_CONFIG_INTERNAL[:plugins][:enabled]    << name
+    CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths] << gem_dir
   end
 end
 

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -363,12 +363,6 @@ DEFAULT_CEEDLING_CONFIG = {
       :include => [],
     },
 
-    # unlike other top-level entries, environment's value is an array to preserve order
-    :environment => [
-      # when evaluated, this provides wider text field for rake task comments
-      {:rake_columns => '120'},
-    ],
-
     :defines => {
       :use_test_definition => false,
       :test => [], # A hash/sub-hashes in config file can include operations and test executable matchers as keys
@@ -405,18 +399,15 @@ DEFAULT_CEEDLING_CONFIG = {
     },
 
     :unity => {
-      :vendor_path => CEEDLING_VENDOR,
       :defines => []
     },
 
     :cmock => {
-      :vendor_path => CEEDLING_VENDOR,
       :includes => [],
       :defines => []
     },
 
     :cexception => {
-      :vendor_path => CEEDLING_VENDOR,
       :defines => []
     },
 
@@ -445,6 +436,28 @@ DEFAULT_CEEDLING_CONFIG = {
     :release_linker    => { :arguments => [] },
     :release_assembler => { :arguments => [] },
     :release_dependencies_generator => { :arguments => [] },
+
+  }.freeze
+
+CEEDLING_CONFIG_INTERNAL = {
+
+    # unlike other top-level entries, environment's value is an array to preserve order
+    :environment => [
+      # when evaluated, this provides wider text field for rake task comments
+      {:rake_columns => '120'},
+    ],
+
+    :unity => {
+      :vendor_path => CEEDLING_VENDOR
+    },
+
+    :cmock => {
+      :vendor_path => CEEDLING_VENDOR
+    },
+
+    :cexception => {
+      :vendor_path => CEEDLING_VENDOR
+    },
 
     :plugins => {
       :load_paths => [],

--- a/spec/ceedling_spec.rb
+++ b/spec/ceedling_spec.rb
@@ -82,8 +82,8 @@ describe 'Ceedling' do
 
     it 'should load the project with the specified plugins enabled' do
       # create test state/variables
-      DEFAULT_CEEDLING_CONFIG[:plugins][:enabled].clear()
-      DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:enabled].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths].clear()
       spec_double = double('spec-double')
       rakefile_path = File.expand_path( File.join( File.dirname(__FILE__), '..' ).gsub( 'spec','lib' ) )
       rakefile_path = File.join( rakefile_path, 'lib', 'ceedling', 'rakefile.rb' )
@@ -102,8 +102,8 @@ describe 'Ceedling' do
     it 'should set the project root if the root key is provided' do
       # create test state/variables
       Object.send(:remove_const, :PROJECT_ROOT)
-      DEFAULT_CEEDLING_CONFIG[:plugins][:enabled].clear()
-      DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:enabled].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths].clear()
       rakefile_path = File.expand_path( File.join( File.dirname(__FILE__), '..' ).gsub( 'spec','lib' ) )
       rakefile_path = File.join( rakefile_path, 'lib', 'ceedling', 'rakefile.rb' )
       # mocks/stubs/expected calls
@@ -120,8 +120,8 @@ describe 'Ceedling' do
   context 'register_plugin' do
     it 'should register a plugin' do
       # create test state/variables
-      DEFAULT_CEEDLING_CONFIG[:plugins][:enabled].clear()
-      DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:enabled].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths].clear()
       spec_double = double('spec-double')
       # mocks/stubs/expected calls
       expect(Gem::Specification).to receive(:find_by_name).with('ceedling-foo').and_return(spec_double)
@@ -130,14 +130,14 @@ describe 'Ceedling' do
       # execute method
       Ceedling.register_plugin('foo')
       # validate results
-      expect(DEFAULT_CEEDLING_CONFIG[:plugins][:enabled]).to eq ["foo"]
-      expect(DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths]).to eq(["dummy/path"])
+      expect(CEEDLING_CONFIG_INTERNAL[:plugins][:enabled]).to eq ["foo"]
+      expect(CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths]).to eq(["dummy/path"])
     end
 
     it 'should register a plugin with an alternative prefix' do
       # create test state/variables
-      DEFAULT_CEEDLING_CONFIG[:plugins][:enabled].clear()
-      DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:enabled].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths].clear()
       spec_double = double('spec-double')
       # mocks/stubs/expected calls
       expect(Gem::Specification).to receive(:find_by_name).with('prefix-foo').and_return(spec_double)
@@ -146,9 +146,8 @@ describe 'Ceedling' do
       # execute method
       Ceedling.register_plugin('foo','prefix-')
       # validate results
-      expect(DEFAULT_CEEDLING_CONFIG[:plugins][:enabled]).to eq(["foo"])
-      expect(DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths]).to eq(["dummy/path"])
+      expect(CEEDLING_CONFIG_INTERNAL[:plugins][:enabled]).to eq(["foo"])
+      expect(CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths]).to eq(["dummy/path"])
     end
   end
 end
-


### PR DESCRIPTION
## Refactor Configuration Load Order

### Description
Improve the order in which the default configs and user-defined configs are loaded and merged in `setupinator`.

Fixes #536, with thanks to my colleague @chuyingy

### Previous structure

Previously, the config load order and result priority were as follows:

*Previous config load procedure:*
1. Merge `project.yml` with `DEFAULT_CEEDLING_CONFIG`
2. Populate with `DEFAULT_TOOLS_*`, `CMock`, and `Unity` settings.
3. Merge with `plugin` settings.
4. Merge with plugin `defaults`.

*Resulting priority order (highest first):*
- `project.yml`
- `DEFAULT_CEEDLING_CONFIG`
- `DEFAULT_TOOLS_*`, `CMock`, and `Unity`
- `plugin` settings
- plugin `defaults`

This would result in some default settings having a higher priority than plugin settings. It also made the differences in behaviour between plugin settings and plugin defaults confusing as they were almost but not quite the same.

### Proposed changes
The proposed change will first merge the user-defined configs and default configs separately, and then combine them. This approach ensures all user-defined configurations take precedence over any default settings.

CMock and Ceedling settings are divided into internal configuration, and defaults. The internal config section contains the cmock plugin and include settings, the vendor and plugin paths, etc. as we felt it was unlikely that the user would intend to replace these in `project.yml` but rather add to them.

*New config loading procedure:*
1. Populate `project.yml` with Ceedling and CMock internal settings, then merge with `plugins` --> **`config`**
2. Merge `DEFAULT_CEEDLING_CONFIG` with `DEFAULT_TOOLS_*`, CMock and Unity defaults, and plugin `defaults` --> **`defaults`**
3. Populate **`config`** with **`defaults`**

*New priority:*

**`config`**:
- `project.yml`
- CMock and Ceedling internal configuration
- `plugin` settings

**`defaults`**:
- plugin `defaults`
- `DEFAULT_CEEDLING_CONFIG`, `DEFAULT_TOOLS_*`,
- CMock and Unity defaults

All **`config`** parameters take precedence over and replace all **`defaults`**, i.e. are not deep_merged with them. This allows plugin to have the choice to add to the **`config`** as if specified by the user in `project.yml`, or add to the **`defaults`** but still have those values be able to be replaced by the user or another plugin.

## Impact

- Settings provided in `project.yml` or `plugin` config will **replace** those in `DEFAULT_CEEDLING_CONFIG`, `DEFAULT_TOOLS_*` etc instead of being merged with them.
  - Most of the defaults are either atoms that can't be merged, or empty lists anyway. Those that were not have been moved to 'internal configuration' which is merged.
- Settings provided in plugin `defaults` will be merged with (if mergeable) or replace (if not) Ceedling **and other plugin** defaults instead of being ignored in favour of the Ceedling or other plugin defaults