### PR TITLE
Improve segfault handling, fix unit tests on Windows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw-ucrt
   x64-mingw32
 
 DEPENDENCIES

--- a/assets/test_example_file_sigsegv.c
+++ b/assets/test_example_file_sigsegv.c
@@ -11,6 +11,7 @@ void test_add_numbers_adds_numbers(void) {
 }
 
 void test_add_numbers_will_fail(void) {
-  raise(SIGSEGV);
-  TEST_ASSERT_EQUAL_INT(2, add_numbers(2,2));
+  uint32_t* nullptr = (void*) 0;
+  uint32_t i = *nullptr;
+  TEST_ASSERT_EQUAL_INT(2, add_numbers(i,2));
 }

--- a/bin/backtrace.gdb
+++ b/bin/backtrace.gdb
@@ -1,0 +1,5 @@
+if $_isvoid ($_exitcode)
+  call ((void(*)(int))fflush)(0)
+  backtrace
+  kill
+end

--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -1927,15 +1927,15 @@ migrated to the `:test_build` and `:release_build` sections.
     By default, this tool is set as follows:
 
     ```yaml
-   :tools:
-     :backtrace_reporter:
-       :executable: gdb
-       :arguments:
-         - -q
-         - --eval-command run
-         - --eval-command backtrace
-         - --batch
-         - --args
+    :tools:
+      :backtrace_reporter:
+        :executable: gdb
+        :arguments:
+          - -q
+          - --batch
+          - --eval-command="run [args] > [output]"
+          - --eval-command backtrace
+      - [test.exe]
     ```
     
     It is important that the debugging tool should be run as a background task, and with the
@@ -3462,6 +3462,18 @@ specifying / overriding tools.
    - `${3}`: optional output map
    - `${4}`: optional library list
    - `${5}`: optional library path list
+
+  **Default**: `gcc`
+
+* `:backtrace_reporter`:
+
+  Debugger for getting backtraces when a test segfaults
+
+   - `${1}`: test executable
+   - `${2}`: arguments to test executable
+   - `${3}`: file to write test executable output to
+             (backtrace should be on the debugger's stdout/stderr)
+   - `${4}`: test name
 
   **Default**: `gcc`
 

--- a/lib/ceedling/generator.rb
+++ b/lib/ceedling/generator.rb
@@ -28,7 +28,7 @@ class Generator
       :test => test,
       :context => context,
       :output_path => output_path }
-    
+
     @plugin_manager.pre_mock_generate( arg_hash )
 
     begin
@@ -42,7 +42,7 @@ class Generator
 
       # Get default config created by Ceedling and customize it
       config = @generator_mocks.build_configuration( output_path )
-  
+
       # Generate mock
       msg = @reportinator.generate_module_progress(
         operation: "Generating mock for",
@@ -203,7 +203,7 @@ class Generator
     @streaminator.stdout_puts(msg, Verbosity::NORMAL)
 
     command =
-      @tool_executor.build_command_line( 
+      @tool_executor.build_command_line(
         arg_hash[:tool],
         arg_hash[:flags],
         arg_hash[:source],
@@ -289,7 +289,7 @@ class Generator
     # Configure debugger
     @debugger_utils.configure_debugger(command)
 
-    # Apply additional test case filters 
+    # Apply additional test case filters
     command[:line] += @unity_utils.collect_test_runner_additional_args
 
     # Enable collecting GCOV results even when segmenatation fault is appearing
@@ -302,14 +302,14 @@ class Generator
     shell_result = @tool_executor.exec( command )
 
     # Handle SegFaults
-    if shell_result[:output] =~ /\s*Segmentation\sfault.*/i
+    if (shell_result[:output] =~ /\s*Segmentation\sfault.*/i) or (shell_result[:status].exitstatus == 3) or (shell_result[:status].termsig == 11)
       if @configurator.project_config_hash[:project_use_backtrace] && @configurator.project_config_hash[:test_runner_cmdline_args]
         # If we have the options and tools to learn more, dig into the details
         shell_result = @debugger_utils.gdb_output_collector(shell_result)
       else
         # Otherwise, call a segfault a single failure so it shows up in the report
         source = File.basename(executable).ext(@configurator.extension_source)
-        shell_result[:output] = "#{source}:1:test_Unknown:FAIL:Segmentation Fault" 
+        shell_result[:output] = "#{source}:1:test_Unknown:FAIL:Segmentation Fault"
         shell_result[:output] += "\n-----------------------\n1 Tests 1 Failures 0 Ignored\nFAIL\n"
         shell_result[:exit_code] = 1
       end

--- a/lib/ceedling/generator_test_results.rb
+++ b/lib/ceedling/generator_test_results.rb
@@ -22,23 +22,6 @@ class GeneratorTestResults
       results[:counts][:failed] = $2.to_i
       results[:counts][:ignored] = $3.to_i
       results[:counts][:passed] = (results[:counts][:total] - results[:counts][:failed] - results[:counts][:ignored])
-    else
-      if @configurator.project_config_hash[:project_use_backtrace]
-        # Accessing this code block we expect failure during test execution
-        # which should be connected with SIGSEGV
-        results[:counts][:total] = 1   # Set to one as the amount of test is unknown in segfault, and one of the test is failing
-        results[:counts][:failed] = 1  # Set to one as the one of tests is failing with segfault
-        results[:counts][:ignored] = 0
-        results[:counts][:passed] = 0
-
-        #Collect function name which cause issue and line number
-        if unity_shell_result[:output] =~ /\s"(.*)",\sline_num=(\d*)/
-          results[:failures] << { :test => $1, :line =>$2, :message => unity_shell_result[:output], :unity_test_time => unity_shell_result[:time]}
-        else
-          #In case if regex fail write default values
-          results[:failures] << { :test => '??', :line =>-1, :message => unity_shell_result[:output], :unity_test_time => unity_shell_result[:time]}
-        end
-      end
     end
 
     # remove test statistics lines
@@ -48,15 +31,15 @@ class GeneratorTestResults
       case line.chomp
       when /(:IGNORE)/
         elements = extract_line_elements(line, results[:source][:file])
-        results[:ignores] << elements[0] 
+        results[:ignores] << elements[0]
         results[:stdout] << elements[1] if (!elements[1].nil?)
       when /(:PASS$)/
         elements = extract_line_elements(line, results[:source][:file])
-        results[:successes] << elements[0] 
+        results[:successes] << elements[0]
         results[:stdout] << elements[1] if (!elements[1].nil?)
       when /(:PASS \(.* ms\)$)/
         elements = extract_line_elements(line, results[:source][:file])
-        results[:successes] << elements[0] 
+        results[:successes] << elements[0]
         results[:stdout] << elements[1] if (!elements[1].nil?)
       when /(:FAIL)/
         elements = extract_line_elements(line, results[:source][:file])
@@ -64,9 +47,7 @@ class GeneratorTestResults
         results[:failures] << elements[0]
         results[:stdout] << elements[1] if (!elements[1].nil?)
       else # collect up all other
-        if !@configurator.project_config_hash[:project_use_backtrace]
-          results[:stdout] << line.chomp
-        end
+        results[:stdout] << line.chomp
       end
     end
 
@@ -100,7 +81,7 @@ class GeneratorTestResults
     # handle anything preceding filename in line as extra output to be collected
     stdout = nil
     stdout_regex = /(.+)#{Regexp.escape(filename)}.+/i
-    unity_test_time = 0 
+    unity_test_time = 0
 
     if (line =~ stdout_regex)
       stdout = $1.clone

--- a/lib/ceedling/system_wrapper.rb
+++ b/lib/ceedling/system_wrapper.rb
@@ -1,4 +1,4 @@
-require 'rbconfig'    
+require 'rbconfig'
 require 'open3'
 
 class SystemWrapper
@@ -52,7 +52,7 @@ class SystemWrapper
     return Time.now.asctime
   end
 
-  def shell_capture3(command:, boom:false) 
+  def shell_capture3(command:, boom:false)
     # Beginning with later versions of Ruby2, simple exit codes were replaced
     # by the more capable and robust Process::Status.
     # Parts of Process::Status's behavior is similar to an integer exit code in
@@ -80,7 +80,7 @@ class SystemWrapper
 
       # Relay full Process::Status
       :status    => status.freeze,
-      
+
       # Provide simple exit code accessor
       :exit_code => exit_code.freeze
     }
@@ -114,7 +114,7 @@ class SystemWrapper
   end
 
   def add_load_path(path)
-    $LOAD_PATH.unshift(path)
+    $LOAD_PATH.unshift(path.dup)
   end
 
   def require_file(path)

--- a/lib/ceedling/system_wrapper.rb
+++ b/lib/ceedling/system_wrapper.rb
@@ -62,13 +62,14 @@ class SystemWrapper
       # Run the command but absorb any exceptions and capture error info instead
       stdout, stderr, status = Open3.capture3( command )
     rescue => err
-      stderr = err
+      stdout = ""
+      stderr = err.to_s
       exit_code = -1
     end
 
     # If boom, then capture the actual exit code, otherwise leave it as zero
     # as though execution succeeded
-    exit_code = status.exitstatus.freeze if boom
+    exit_code = status.exitstatus.freeze if boom and not status.nil?
 
     # (Re)set the system exit code
     $exit_code = exit_code
@@ -76,7 +77,7 @@ class SystemWrapper
     return {
       # Combine stdout & stderr streams for complete output
       :output    => (stdout + stderr).freeze,
-      
+
       # Relay full Process::Status
       :status    => status.freeze,
       


### PR DESCRIPTION
The Ceedling `rspec` tests were not passing on Windows (MinGW-W64), primarily because segfaults were not detected correctly. I have improved the segfault detection logic and test suite output as well as fixing a few other small issues I encountered along the way.