### PR TITLE
Fix filepath expansion in assemble_mixins().

### DIFF
--- a/bin/mixinator.rb
+++ b/bin/mixinator.rb
@@ -83,7 +83,8 @@ class Mixinator
     #  2. Remove duplicates
     assembly.uniq! do |entry|
       # If entry is filepath, expand it, otherwise leave entry untouched (it's a mixin name only)
-      @path_validator.filepath?( entry ) ? File.expand_path( entry.values.first ) : entry
+      mixin = entry.values.first
+      @path_validator.filepath?( mixin ) ? File.expand_path( mixin ) : mixin
     end
 
     # Return the compacted list (in merge order)


### PR DESCRIPTION
On recent pre-release versions of Ceedling, I'm getting the following error when trying to use mixins from command line:

```shell
🧨 EXCEPTION: no implicit conversion of Hash into String
🚧 Loaded project configuration at default location using ./project.yml
Backtrace ==>
/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/path_validator.rb:51:in `extname': no implicit conversion of Hash into String (TypeError)
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/path_validator.rb:51:in `filepath?'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/mixinator.rb:86:in `block in assemble_mixins'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/mixinator.rb:84:in `uniq!'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/mixinator.rb:84:in `assemble_mixins'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/configinator.rb:84:in `loadinate'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/cli_handler.rb:164:in `build'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/cli.rb:312:in `build'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/thor-1.3.0/lib/thor/command.rb:28:in `run'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/thor-1.3.0/lib/thor/invocation.rb:127:in `invoke_command'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/thor-1.3.0/lib/thor.rb:527:in `dispatch'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/cli.rb:92:in `start'
	/home/alejo/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ceedling-0.32.0/bin/ceedling:125:in `<top (required)>'
	/home/alejo/.rbenv/versions/3.3.0/bin/ceedling:25:in `load'
	/home/alejo/.rbenv/versions/3.3.0/bin/ceedling:25:in `<main>'
```

What I found is that in the `assemble_mixins()` function it is attempted to expand a file path but the check is made against `entry` argument which is a Hash, causing the exception above.