### PR TITLE
Ceedling docker container should not use root as default user

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ To use a _MadScienceLab_ image from your local terminal:
 1. Run the container with:
    1. The Docker `run` command and `-it --rm` command line options
    1. A Docker volume mapping from the root of your project to the default project path inside the container (_/home/dev/project_)
+   1. Use your OS user and group id in Linux to not have artifacts produced by Ceedling owned by root with `--user $(id -u):$(id -g)`
 
 See the command line examples in the following two sections.
 
@@ -442,7 +443,7 @@ Note that all of these somewhat lengthy command lines lend themselves well to be
 When the container launches as shown below, it will drop you into a Z-shell command line that has access to all the tools and utilities available within the container. In this usage, the Docker container becomes just another terminal, including ending its execution with `exit`.
 
 ```shell
- > docker run -it --rm -v /my/local/project/path:/home/dev/project throwtheswitch/madsciencelab-plugins:1.0.0
+ > docker run -it --rm --user $(id -u):$(id -g) -v /my/local/project/path:/home/dev/project throwtheswitch/madsciencelab-plugins:1.0.0
 ```
 
 Once the _MadScienceLab_ container’s command line is available, to run Ceedling, execute it just as you would after installing Ceedling locally:
@@ -464,13 +465,13 @@ Once the _MadScienceLab_ container’s command line is available, to run Ceedlin
 Alternatively, you can run Ceedling through the _MadScienceLab_ Docker container directly from the command line as a command line utility. The general pattern is immediately below.
 
 ```shell
- > docker run -it --rm -v /my/local/project/path:/home/dev/project throwtheswitch/madsciencelab-plugins:1.0.0 <Ceedling command line>
+ > docker run -it --rm --user $(id -u):$(id -g) -v /my/local/project/path:/home/dev/project throwtheswitch/madsciencelab-plugins:1.0.0 <Ceedling command line>
 ```
 
 As a specific example, to run all tests in a suite, the command line would be this:
 
 ```shell
- > docker run -it --rm -v /my/local/project/path:/home/dev/project throwtheswitch/madsciencelab-plugins:1.0.0 ceedling test:all
+ > docker run -it --rm --user $(id -u):$(id -g) -v /my/local/project/path:/home/dev/project throwtheswitch/madsciencelab-plugins:1.0.0 ceedling test:all
 ```
 
 In this usage, the container starts, executes Ceedling, and then ends.


### PR DESCRIPTION
There was some discussion in another issue about how to run Ceedling using docker containers and it was advised to use the root user. I am not certain how container was done as there's no `Dockerfile` in this repo, but we should not promote usage of root user inside the docker container, especially since artifacts created by docker container are used by host user (uploaded, debugging,etc).

Solution is to create a user inside the docker container (lets say developer - command is USER) and use that (I think installation of gem will also need to be done as that user. Then the build directory will not be owned by root (uid 1) but by that user (uid:1000) which in most cases is also an initial user of host system. That way files created within docker container have uid and gid 1000 and not 1 as they do with root and user can delete them without using docker container cleanup (`ceedling clobber` or `ceedling clean`).

The usage of `--user` command is a bit of a bypass. It uses root user inside the docker container, but that is mapped as current user and group on host. I have added that part to the README (as I could contribute), to at least a bit educate the people. The command is only tested on Linux, but I also amended the line for Z-shell, which I did not test.