### PR TITLE
Add option to shuffle test execution order

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -17,6 +17,7 @@ Documentation is available within the repository markdown files and as a local H
 ## 🌟 Added
 
 - Support for the Bullseye commercial code coverage tool has been restored through updates to the temporarily disabled [Bullseye plugin](https://throwtheswitch.github.io/Ceedling/latest/plugins/bullseye/).
+- Optional randomized order for Unity test case runs within a test executable ([PR #1041]https://github.com/ThrowTheSwitch/Ceedling/pull/1041) via `:unity` ↳ `:shuffle_tests` ⇒ `TRUE`.
 
 ### Delta builds
 Delta builds have been restored after a temporary hiatus following a major refactoring for 1.0.0 ([Restore delta test builds to Ceedling 1.0.0+](https://github.com/ThrowTheSwitch/Ceedling/issues/1143)).

--- a/docs/mkdocs/configuration/reference/test-runner.md
+++ b/docs/mkdocs/configuration/reference/test-runner.md
@@ -45,6 +45,19 @@ but Ceedling now automatically sets it for you in the scenarios requiring it.
     The idea of command line arguments passed to an executable is generally 
     only possible with desktop command line terminals.
 
+## `:test_runner` ↳ `:rng_seed`
+
+Seeds the randomization used by [`:unity` ↳ `:shuffle_tests`][unity-shuffle-tests]
+to shuffle the Unity runner test case execution order. `:rng_seed` has no 
+effect unless `:shuffle_tests` is enabled.
+
+Left at its default of `0`, Unity seeds the shuffle from the current time 
+causing a different execution order every time a test runner executes. Set 
+a fixed, nonzero value for a reproducible shuffled order (e.g. to debug 
+an order-dependent failure without test case order moving around run to run).
+
+**Default**: 0
+
 ## Example `:test_runner` YAML
 
 ```yaml
@@ -57,5 +70,6 @@ but Ceedling now automatically sets it for you in the scenarios requiring it.
 
 [ceedling-conventions]: ../../testing-guide/conventions.md
 [unity-runner-options]: https://github.com/ThrowTheSwitch/Unity/blob/master/docs/UnityHelperScriptsGuide.md#options-accepted-by-generate_test_runnerrb
+[unity-shuffle-tests]: unity.md#shuffle_tests
 
 <br/><br/>

--- a/docs/mkdocs/configuration/reference/unity.md
+++ b/docs/mkdocs/configuration/reference/unity.md
@@ -44,6 +44,20 @@ void test_should_handle_divisible_by_5_for_parameterized_test_range(int num) {
 
 See Unity documentation for more on parameterized test cases.
 
-**Default**: false
+**Default**: `false`
+
+## `:shuffle_tests`
+
+Configures the Unity test runner to randomize the order in which test cases 
+run within a test executable. This is useful for surfacing bugs caused by 
+tests that depend on execution order or on state left behind by an earlier 
+test.
+
+The randomization seed can be pinned to a fixed value for reproducible
+ordering — see [`:test_runner` ↳ `:rng_seed`][test-runner-rng-seed].
+
+**Default**: `false`
 
 <br/><br/>
+
+[test-runner-rng-seed]: test-runner.md#test_runner--rng_seed

--- a/lib/ceedling/config/configurator.rb
+++ b/lib/ceedling/config/configurator.rb
@@ -383,6 +383,7 @@ class Configurator
     # Merge Unity options used by test runner generation
     config[:test_runner][:defines] += config[:unity][:defines]
     config[:test_runner][:use_param_tests] = config[:unity][:use_param_tests]
+    config[:test_runner][:shuffle_tests] = config[:unity][:shuffle_tests]
 
     @runner_config = config[:test_runner]
 

--- a/lib/ceedling/configurator.rb
+++ b/lib/ceedling/configurator.rb
@@ -260,6 +260,7 @@ class Configurator
     # Merge Unity options used by test runner generation
     config[:test_runner][:defines] += config[:unity][:defines]
     config[:test_runner][:use_param_tests] = config[:unity][:use_param_tests]
+    config[:test_runner][:shuffle_tests] = config[:unity][:shuffle_tests]
 
     @runner_config = config[:test_runner]
 

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -361,7 +361,8 @@ DEFAULT_CEEDLING_PROJECT_CONFIG = {
 
   :unity => {
     :defines => [],
-    :use_param_tests => false
+    :use_param_tests => false,
+    :shuffle_tests => false
     },
 
   :cmock => {

--- a/spec/system/shuffle_tests_spec.rb
+++ b/spec/system/shuffle_tests_spec.rb
@@ -1,0 +1,118 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+
+##
+## Randomized Test Execution Order (:unity ↳ :shuffle_tests)
+## ==========================================================
+##
+## Unity's runner generator can shuffle the order test cases run in, seeded by
+## :test_runner ↳ :rng_seed. Unity always prints each test's name as it runs
+## (`<file>:<line>:<test name>:PASS`, regardless of verbosity), so the order
+## tests actually ran in is recoverable straight from build console output --
+## no need to inspect the generated runner file itself.
+##
+## Test content is trivial (five independent, empty-bodied passing tests with
+## alphabetically distinct names) so it's inlined here as a heredoc rather
+## than a checked-in assets/fixtures file.
+##
+
+SHUFFLE_TEST_C = <<~C
+  #include "unity.h"
+
+  void setUp(void) {}
+  void tearDown(void) {}
+
+  void test_A(void) { TEST_ASSERT_TRUE(1); }
+  void test_B(void) { TEST_ASSERT_TRUE(1); }
+  void test_C(void) { TEST_ASSERT_TRUE(1); }
+  void test_D(void) { TEST_ASSERT_TRUE(1); }
+  void test_E(void) { TEST_ASSERT_TRUE(1); }
+C
+
+# Source declaration order -- the order a non-shuffled runner always executes
+# these tests in.
+DECLARED_ORDER = %w[test_A test_B test_C test_D test_E]
+
+ceedling_system_tests do
+
+  before :all do
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  before { @proj_name = unique_proj_name("shuffle") }
+
+  # Extracts the sequence of test names in the order Unity printed them
+  # (each PASS line matches `<file>:<line>:<test name>:PASS`).
+  def executed_order(output)
+    output.to_s.scan(/test_shuffle\.c:\d+:(test_\w+):PASS/)
+          .flatten
+          .select { |name| DECLARED_ORDER.include?( name ) }
+  end
+
+  describe "Deployed as a gem" do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new #{@proj_name}")
+      end
+    end
+
+    before do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          File.write('test/test_shuffle.c', SHUFFLE_TEST_C)
+        end
+      end
+    end
+
+    it "runs tests in declared order by default (:shuffle_tests disabled)" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_build_exec
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/TESTED:\s+5/)
+          expect(output).to match(/PASSED:\s+5/)
+          expect(output).to match(/FAILED:\s+0/)
+
+          expect(executed_order(output)).to eq(DECLARED_ORDER)
+        end
+      end
+    end
+
+    it "runs tests in a randomized order when :shuffle_tests is enabled with a fixed :rng_seed" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          settings = {
+            :unity       => { :shuffle_tests => true },
+            :test_runner => { :rng_seed => 42 },
+          }
+          @c.merge_project_yml_for_test(settings)
+
+          output = @c.ceedling_build_exec
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/TESTED:\s+5/)
+          expect(output).to match(/PASSED:\s+5/)
+          expect(output).to match(/FAILED:\s+0/)
+
+          order = executed_order(output)
+          expect(order.sort).to eq(DECLARED_ORDER.sort) # same five tests, all present
+          expect(order).to_not eq(DECLARED_ORDER)        # but not in declared order
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/system/shuffle_tests_spec.rb
+++ b/spec/system/shuffle_tests_spec.rb
@@ -17,9 +17,14 @@ require 'spec_system_helper'
 ## tests actually ran in is recoverable straight from build console output --
 ## no need to inspect the generated runner file itself.
 ##
-## Test content is trivial (five independent, empty-bodied passing tests with
+## Test content is trivial (ten independent, empty-bodied passing tests with
 ## alphabetically distinct names) so it's inlined here as a heredoc rather
-## than a checked-in assets/fixtures file.
+## than a checked-in assets/fixtures file. Ten test cases (10! = 3,628,800
+## possible orderings) keeps the odds of a fixed seed's shuffle coincidentally
+## landing back on declared order effectively negligible -- a C library's
+## rand() sequence for a given seed is implementation-defined and differs
+## across platforms, so a small test count risks exactly that coincidence on
+## some platform even though shuffling is working correctly.
 ##
 
 SHUFFLE_TEST_C = <<~C
@@ -33,11 +38,22 @@ SHUFFLE_TEST_C = <<~C
   void test_C(void) { TEST_ASSERT_TRUE(1); }
   void test_D(void) { TEST_ASSERT_TRUE(1); }
   void test_E(void) { TEST_ASSERT_TRUE(1); }
+  void test_F(void) { TEST_ASSERT_TRUE(1); }
+  void test_G(void) { TEST_ASSERT_TRUE(1); }
+  void test_H(void) { TEST_ASSERT_TRUE(1); }
+  void test_I(void) { TEST_ASSERT_TRUE(1); }
+  void test_J(void) { TEST_ASSERT_TRUE(1); }
 C
 
 # Source declaration order -- the order a non-shuffled runner always executes
 # these tests in.
-DECLARED_ORDER = %w[test_A test_B test_C test_D test_E]
+DECLARED_ORDER = %w[test_A test_B test_C test_D test_E test_F test_G test_H test_I test_J]
+
+# Several successive, fixed seeds rather than one -- asserting that shuffled
+# order varies *somewhere* across these runs (rather than requiring every
+# adjacent pair to differ) confirms seeding actually changes execution order
+# without a single unlucky seed/platform combination failing the whole test.
+SHUFFLE_SEEDS = [42, 43, 44, 45]
 
 ceedling_system_tests do
 
@@ -81,8 +97,8 @@ ceedling_system_tests do
           output = @c.ceedling_build_exec
 
           expect(@c.last_exit_status).to eq(0)
-          expect(output).to match(/TESTED:\s+5/)
-          expect(output).to match(/PASSED:\s+5/)
+          expect(output).to match(/TESTED:\s+10/)
+          expect(output).to match(/PASSED:\s+10/)
           expect(output).to match(/FAILED:\s+0/)
 
           expect(executed_order(output)).to eq(DECLARED_ORDER)
@@ -90,25 +106,30 @@ ceedling_system_tests do
       end
     end
 
-    it "runs tests in a randomized order when :shuffle_tests is enabled with a fixed :rng_seed" do
+    it "runs tests in a randomized order when :shuffle_tests is enabled with fixed :rng_seed values" do
       @c.with_context do
         Dir.chdir @proj_name do
-          settings = {
-            :unity       => { :shuffle_tests => true },
-            :test_runner => { :rng_seed => 42 },
-          }
-          @c.merge_project_yml_for_test(settings)
+          orders = SHUFFLE_SEEDS.map do |seed|
+            settings = {
+              :unity       => { :shuffle_tests => true },
+              :test_runner => { :rng_seed => seed },
+            }
+            @c.merge_project_yml_for_test(settings)
 
-          output = @c.ceedling_build_exec
+            output = @c.ceedling_build_exec
 
-          expect(@c.last_exit_status).to eq(0)
-          expect(output).to match(/TESTED:\s+5/)
-          expect(output).to match(/PASSED:\s+5/)
-          expect(output).to match(/FAILED:\s+0/)
+            expect(@c.last_exit_status).to eq(0)
+            expect(output).to match(/TESTED:\s+10/)
+            expect(output).to match(/PASSED:\s+10/)
+            expect(output).to match(/FAILED:\s+0/)
 
-          order = executed_order(output)
-          expect(order.sort).to eq(DECLARED_ORDER.sort) # same five tests, all present
-          expect(order).to_not eq(DECLARED_ORDER)        # but not in declared order
+            order = executed_order(output)
+            expect(order.sort).to eq(DECLARED_ORDER.sort) # same ten tests, all present
+
+            order
+          end
+
+          expect(orders.uniq.size).to be > 1 # shuffling varied order somewhere across these seeds
         end
       end
     end

--- a/spec/units/configurator_spec.rb
+++ b/spec/units/configurator_spec.rb
@@ -15,6 +15,7 @@ describe Configurator do
 
   before(:each) do
     @ruby_expandinator = RubyExpandinator.new
+    @loginator = double('loginator').as_null_object
 
     @configurator = described_class.new({
       configurator_setup:   double('configurator_setup').as_null_object,
@@ -23,7 +24,7 @@ describe Configurator do
       config_walkinator:    double('config_walkinator').as_null_object,
       yaml_wrapper:         double('yaml_wrapper').as_null_object,
       system_wrapper:       double('system_wrapper').as_null_object,
-      loginator:            double('loginator').as_null_object,
+      loginator:            @loginator,
       reportinator:         double('reportinator').as_null_object,
       ruby_expandinator:    @ruby_expandinator,
     })
@@ -181,6 +182,78 @@ describe Configurator do
       @configurator.prepare_plugins_load_paths( 'plugins/path', config )
 
       expect( config[:plugins][:load_paths] ).to include( '2' )
+    end
+
+  end
+
+  describe "#populate_test_runner_generation_config" do
+
+    def runner_config
+      {
+        project:     { use_backtrace: :none },
+        cmock:       { mock_prefix: 'Mock', mock_suffix: '_x', enforce_strict_ordering: true },
+        unity:       { defines: ['UNITY_DEFINE'], use_param_tests: false, shuffle_tests: false },
+        test_runner: { cmdline_args: false, defines: ['RUNNER_DEFINE'] },
+      }
+    end
+
+    it "copies CMock options used by test runner generation" do
+      config = runner_config
+
+      @configurator.populate_test_runner_generation_config( config )
+
+      expect( config[:test_runner][:mock_prefix] ).to eq( 'Mock' )
+      expect( config[:test_runner][:mock_suffix] ).to eq( '_x' )
+      expect( config[:test_runner][:enforce_strict_ordering] ).to eq( true )
+    end
+
+    it "merges Unity defines and :use_param_tests into test runner config" do
+      config = runner_config
+      config[:unity][:use_param_tests] = true
+
+      @configurator.populate_test_runner_generation_config( config )
+
+      expect( config[:test_runner][:defines] ).to eq( ['RUNNER_DEFINE', 'UNITY_DEFINE'] )
+      expect( config[:test_runner][:use_param_tests] ).to eq( true )
+    end
+
+    it "carries :unity ↳ :shuffle_tests into test runner config when enabled" do
+      config = runner_config
+      config[:unity][:shuffle_tests] = true
+
+      @configurator.populate_test_runner_generation_config( config )
+
+      expect( config[:test_runner][:shuffle_tests] ).to eq( true )
+    end
+
+    it "carries :unity ↳ :shuffle_tests into test runner config when disabled" do
+      config = runner_config
+      config[:unity][:shuffle_tests] = false
+
+      @configurator.populate_test_runner_generation_config( config )
+
+      expect( config[:test_runner][:shuffle_tests] ).to eq( false )
+    end
+
+    it "forces :cmdline_args on and logs a notice when :use_backtrace is enabled" do
+      config = runner_config
+      config[:project][:use_backtrace] = :simple
+      config[:test_runner][:cmdline_args] = false
+
+      expect( @loginator ).to receive(:log).with( /:cmdline_args/, Verbosity::COMPLAIN, LogLabels::NOTICE )
+
+      @configurator.populate_test_runner_generation_config( config )
+
+      expect( config[:test_runner][:cmdline_args] ).to eq( true )
+    end
+
+    it "leaves :cmdline_args untouched when :use_backtrace is :none" do
+      config = runner_config
+      config[:test_runner][:cmdline_args] = false
+
+      @configurator.populate_test_runner_generation_config( config )
+
+      expect( config[:test_runner][:cmdline_args] ).to eq( false )
     end
 
   end


### PR DESCRIPTION
This commit adds the option to pass the `shuffle_tests` Unity option to the test runner configuration.

This depends on ThrowTheSwitch/Unity#714.