### PR TITLE
Fix Valgrind plugin and add tests

### DIFF
--- a/assets/project_as_gem.yml
+++ b/assets/project_as_gem.yml
@@ -63,6 +63,7 @@
     #- dependencies                   # automatically fetch 3rd party libraries, etc.
     #- subprojects                    # managing builds and test for static libraries
     #- fake_function_framework        # use FFF instead of CMock
+    #- valgrind                       # detect memory management and threading bugs using valgrind. Requires valgrind for your platform
 
     # Report options (You'll want to choose one stdout option, but may choose multiple stored options if desired)
     #- report_build_warnings_log

--- a/examples/temp_sensor/mixin/add_valgrind.yml
+++ b/examples/temp_sensor/mixin/add_valgrind.yml
@@ -1,0 +1,13 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+---
+
+# Enable valgrind plugin
+:plugins:
+  :enabled:
+    - valgrind

--- a/examples/temp_sensor/project.yml
+++ b/examples/temp_sensor/project.yml
@@ -65,6 +65,7 @@
     #- dependencies                   # automatically fetch 3rd party libraries, etc.
     #- subprojects                    # managing builds and test for static libraries
     #- fake_function_framework        # use FFF instead of CMock
+    #- valgrind                       # detect memory management and threading bugs using valgrind. Requires valgrind for your platform
 
     # Report options (You'll want to choose one stdout option, but may choose multiple stored options if desired)
     #- report_build_warnings_log

--- a/plugins/valgrind/config/defaults_valgrind.rb
+++ b/plugins/valgrind/config/defaults_valgrind.rb
@@ -3,7 +3,6 @@ DEFAULT_VALGRIND = {
     :executable => ENV['VALGRIND'].nil? ? FilePathUtils.os_executable_ext('valgrind').freeze : ENV['VALGRIND'].split[0],
     :name => 'default_valgrind'.freeze,
     :stderr_redirect => StdErrRedirect::NONE.freeze,
-    :background_exec => BackgroundExec::NONE.freeze,
     :optional => false.freeze,
     :arguments => [
       "--leak-check=full".freeze,

--- a/spec/valgrind/valgrind_deployment_spec.rb
+++ b/spec/valgrind/valgrind_deployment_spec.rb
@@ -1,0 +1,108 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+require 'valgrind/valgrind_test_cases_spec'
+
+describe "Ceedling" do
+  describe "Valgrind" do
+    include CeedlingTestCases
+    include ValgrindTestCases
+    before :all do
+      determine_reports_to_test
+      @c = SystemContext.new
+      @c.deploy_gem
+    end
+
+    after :all do
+      @c.done!
+    end
+
+    before { @proj_name = "fake_project" }
+    after { @c.with_context { FileUtils.rm_rf @proj_name } }
+
+    describe "basic operations" do
+      before do
+        @c.with_context do
+          `bundle exec ruby -S ceedling new --local #{@proj_name} 2>&1`
+        end
+      end
+
+      it { can_test_projects_with_valgrind_with_success }
+      it { can_test_projects_with_valgrind_with_fail }
+      it { can_test_projects_with_valgrind_with_compile_error }
+      it { can_fetch_project_help_for_valgrind }
+    end
+
+    describe "command: `ceedling example temp_sensor`" do
+      describe "temp_sensor" do
+        before do
+          @c.with_context do
+            output = `bundle exec ruby -S ceedling example temp_sensor 2>&1`
+            expect(output).to match(/created/)
+
+            Dir.chdir "temp_sensor" do
+              @output = `bundle exec ruby -S ceedling --mixin=add_valgrind test:all 2>&1`
+              expect(@output).to match(/TESTED:\s+51/)
+              expect(@output).to match(/PASSED:\s+51/)
+            end
+          end
+        end
+
+        it "should be testable" do
+          @c.with_context do
+            Dir.chdir "temp_sensor" do
+              @output = `bundle exec ruby -S ceedling --mixin=add_valgrind valgrind:all 2>&1`
+              expect(@output).to match(/==\d+== All heap blocks were freed -- no leaks are possible/)
+              expect(@output).to match(/==\d+== ERROR SUMMARY: 0 errors from 0 contexts/)
+            end
+          end
+        end
+
+        it "should be able to test a single module (it should INHERIT file-specific flags)" do
+          @c.with_context do
+            Dir.chdir "temp_sensor" do
+              @output = `bundle exec ruby -S ceedling --mixin=add_valgrind valgrind:TemperatureCalculator 2>&1`
+              expect(@output).to match(/==\d+== All heap blocks were freed -- no leaks are possible/)
+              expect(@output).to match(/==\d+== ERROR SUMMARY: 0 errors from 0 contexts/)
+            end
+          end
+        end
+
+        it "should be able to test multiple files matching a pattern" do
+          @c.with_context do
+            Dir.chdir "temp_sensor" do
+              @output = `bundle exec ruby -S ceedling --mixin=add_valgrind valgrind:pattern[Temp] 2>&1`
+              expect(@output).to match(/==\d+== All heap blocks were freed -- no leaks are possible/)
+              expect(@output).to match(/==\d+== ERROR SUMMARY: 0 errors from 0 contexts/)
+            end
+          end
+        end
+
+        it "should be able to test all files matching in a path" do
+          @c.with_context do
+            Dir.chdir "temp_sensor" do
+              @output = `bundle exec ruby -S ceedling --mixin=add_valgrind valgrind:path[adc] 2>&1`
+              expect(@output).to match(/==\d+== All heap blocks were freed -- no leaks are possible/)
+              expect(@output).to match(/==\d+== ERROR SUMMARY: 0 errors from 0 contexts/)
+            end
+          end
+        end
+
+        it "should be able to test specific test cases in a file" do
+          @c.with_context do
+            Dir.chdir "temp_sensor" do
+              @output = `bundle exec ruby -S ceedling --mixin=add_valgrind valgrind:path[adc] --test-case="RunShouldNot" 2>&1`
+              expect(@output).to match(/==\d+== All heap blocks were freed -- no leaks are possible/)
+              expect(@output).to match(/==\d+== ERROR SUMMARY: 0 errors from 0 contexts/)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/valgrind/valgrind_test_cases_spec.rb
+++ b/spec/valgrind/valgrind_test_cases_spec.rb
@@ -1,0 +1,98 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'fileutils'
+require 'tmpdir'
+require 'yaml'
+require 'spec_system_helper'
+require 'pp'
+
+module ValgrindTestCases
+  def determine_reports_to_test
+    @valgrind_reports = []
+
+    begin
+      `valgrind --version 2>&1`
+      @valgrind_reports << :valgrind if $?.exitstatus == 0
+    rescue
+      puts "No Valgrind exec to test against"
+    end
+  end
+
+  def prep_project_yml_for_valgrind
+    FileUtils.cp test_asset_path("project_as_gem.yml"), "project.yml"
+    @c.uncomment_project_yml_option_for_test("- valgrind")
+  end
+
+  def can_test_projects_with_valgrind_with_success
+    @c.with_context do
+      Dir.chdir @proj_name do
+        prep_project_yml_for_valgrind
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling test:all 2>&1`
+        expect($?.exitstatus).to match(0)
+
+        output = `bundle exec ruby -S ceedling valgrind:all 2>&1`
+        expect($?.exitstatus).to match(0)
+        expect(output).to match(/==\d+== All heap blocks were freed -- no leaks are possible/)
+        expect(output).to match(/==\d+== ERROR SUMMARY: 0 errors from 0 contexts/)
+      end
+    end
+  end
+
+  def can_test_projects_with_valgrind_with_fail
+    @c.with_context do
+      Dir.chdir @proj_name do
+        prep_project_yml_for_valgrind
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling test:all 2>&1`
+        expect($?.exitstatus).to match(1)
+
+        output = `bundle exec ruby -S ceedling valgrind:all 2>&1`
+        expect($?.exitstatus).to match(1)
+        expect(output).to match(/==\d+== All heap blocks were freed -- no leaks are possible/)
+        expect(output).to match(/==\d+== ERROR SUMMARY: 0 errors from 0 contexts/)
+      end
+    end
+  end
+
+  def can_test_projects_with_valgrind_with_compile_error
+    @c.with_context do
+      Dir.chdir @proj_name do
+        prep_project_yml_for_valgrind
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_boom.c"), 'test/'
+
+        output = `bundle exec ruby -S ceedling test:all 2>&1`
+        expect($?.exitstatus).to match(1)
+
+        output = `bundle exec ruby -S ceedling valgrind:all 2>&1`
+        expect($?.exitstatus).to match(1)
+        expect(output).to match(/(?:ERROR: Ceedling Failed)|(?:Ceedling could not complete operations because of errors)/)
+      end
+    end
+  end
+
+  def can_fetch_project_help_for_valgrind
+    @c.with_context do
+      Dir.chdir @proj_name do
+        prep_project_yml_for_valgrind
+        output = `bundle exec ruby -S ceedling help 2>&1`
+        expect($?.exitstatus).to match(0)
+        expect(output).to match(/ceedling valgrind:\*/i)
+        expect(output).to match(/ceedling valgrind:all/i)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit fixes the Valgrind plugin by removing some deprecated functions and updating some function signatures. This commit also adds tests to serve as regression testing to prevent the Valgrind plugin from being broken by future refactoring changes.