### PR TITLE
1.1.0 Helpful resources / support links in command line help footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ _Note:_ Check the [Release Notes][release-notes] for a “cheat sheet” illustr
 
 ## Online tutorial
 
-Matt Chernosky’s **[detailed tutorial][tutorial]** demonstrates using Ceedling to build a C project with test suite. As the tutorial is a number of years old, the content is a bit out of date. That said, it provides an excellent overview of a real project. Matt is the author of [FFF] and the [FFF plugin][FFF-plugin] for Ceedling.
+Matt Chernosky’s **[detailed tutorial][tutorial]** demonstrates using Ceedling to build a C project with test suite. As the tutorial is a number of years old, the content is a bit out of date. That said, it provides an excellent overview of a real project. Matt is the author of [FFF].
 
 [ceedling-packet]: docs/CeedlingPacket.md
 [release-notes]: docs/ReleaseNotes.md

--- a/bin/ceedling
+++ b/bin/ceedling
@@ -88,7 +88,6 @@ begin
   require 'cli'
   
   # Remove all load paths we've relied on (main application will set up load paths again)
-  $LOAD_PATH.delete( ceedling_bin_path )
   $LOAD_PATH.delete( CEEDLING_APPCFG[:ceedling_lib_path] )
   $LOAD_PATH.delete( diy_vendor_path )
 

--- a/bin/cli_handler.rb
+++ b/bin/cli_handler.rb
@@ -64,6 +64,10 @@ class CliHandler
       # Silent Ceedling loading unless debug verbosity
       silent: !(verbosity == Verbosity::DEBUG)
     )
+
+    version = @helper.manufacture_app_version( app_cfg )
+
+    @helper.help_footer( version.ceedling_tag )
   end
 
 
@@ -395,10 +399,7 @@ class CliHandler
     @helper.which_ceedling?( env:env, app_cfg:app_cfg )
 
     # Ceedling application
-    application = Versionator.new(
-      app_cfg[:ceedling_root_path],
-      app_cfg[:ceedling_vendor_path]
-    )
+    application = @helper.manufacture_app_version( app_cfg )
 
     # Blank Ceedling version block to be built out conditionally below
     ceedling = nil

--- a/bin/rake_patches.rb
+++ b/bin/rake_patches.rb
@@ -1,0 +1,24 @@
+require 'rake'
+require 'stringio'
+
+module CaptureHelpOutput
+  def capture_display_tasks
+    original_stdout = $stdout
+    output_string = StringIO.new
+    $stdout = output_string
+    
+    begin
+      # Call the original method that writes directly to $stdout with printf()
+      display_tasks_and_comments
+    ensure
+      # This block will always execute, even if an exception occurs
+      $stdout = original_stdout
+    end
+
+    # Restore original stdout
+    $stdout = original_stdout
+    
+    # Return the captured output
+    output_string.string
+  end
+end

--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -26,18 +26,21 @@ VERBOSITY_OPTIONS = {
 
 # Label + decorator options for logging
 class LogLabels
-  NONE       =  0  # Override logic and settings with no label and no decoration
-  AUTO       =  1  # Default labeling and decorators
-  NOTICE     =  2  # decorator + 'NOTICE:'
-  WARNING    =  3  # decorator + 'WARNING:'
-  ERROR      =  4  # decorator + 'ERROR:'
-  EXCEPTION  =  5  # decorator + 'EXCEPTION:'
-  CONSTRUCT  =  6  # decorator only
-  RUN        =  7  # decorator only
-  CRASH      =  8  # decorator only
-  PASS       =  9  # decorator only
-  FAIL       = 10  # decorator only
-  TITLE      = 11  # decorator only
+  NONE          =  0  # Override logic and settings with no label and no decoration
+  AUTO          =  1  # Default labeling and decorators
+  NOTICE        =  2  # decorator + 'NOTICE:'
+  WARNING       =  3  # decorator + 'WARNING:'
+  ERROR         =  4  # decorator + 'ERROR:'
+  EXCEPTION     =  5  # decorator + 'EXCEPTION:'
+  CONSTRUCT     =  6  # decorator only
+  RUN           =  7  # decorator only
+  CRASH         =  8  # decorator only
+  PASS          =  9  # decorator only
+  FAIL          = 10  # decorator only
+  TITLE         = 11  # decorator only
+  DOCUMENTATION = 12  # decorator only
+  COMMERCIAL    = 13  # decorator only
+  REQUEST       = 14  # decorator only
 
   # Verbosity levels ERRORS – DEBUG default to certain labels or lack thereof
   # The above label constants are available to override Loginator's default AUTO level as needed

--- a/lib/ceedling/loginator.rb
+++ b/lib/ceedling/loginator.rb
@@ -38,8 +38,9 @@ class Loginator
 
     @replace = {
       # Problematic characters pattern => Simple characters
-      /↳/ => '>>', # Config sub-entry notation
-      /•/ => '*',  # Bulleted lists
+      /↳/ => '>>',   # Config sub-entry notation
+      /•/ => '*',    # Bulleted lists
+      /➡️/ => '>>',  # Right arrow
     }
 
     @project_logging = false
@@ -170,7 +171,7 @@ class Loginator
       # Send backtrace to debug logging, formatted almost identically to how Ruby does it.
       # Don't log the exception message itself in the first `log()` call as it will already be logged elsewhere
       log( "#{exception.backtrace.first}: (#{exception.class})", Verbosity::DEBUG )
-      log( exception.backtrace.drop(1).map{|s| "\t#{s}"}.join("\n"),                  Verbosity::DEBUG )
+      log( exception.backtrace.drop(1).map{|s| "\t#{s}"}.join("\n"), Verbosity::DEBUG )
   end
 
 
@@ -200,6 +201,12 @@ class Loginator
       prepend = '❌ '
     when LogLabels::TITLE
       prepend = '🌱 '
+    when LogLabels::DOCUMENTATION
+      prepend = '📝 '
+    when LogLabels::COMMERCIAL
+      prepend = '💼 '
+    when LogLabels::REQUEST
+      prepend = '🙏 '
     end
 
     return prepend + str


### PR DESCRIPTION
1. Resolved logging interleaving bug with Rake task help.
1. Rake task help formatting better matches Thor help formatting.
1. Added a footer to `help` output:
   1. _Ceedling Packet_ documentation link, incorporating version tag
   1. Ceedling Suite link to ThingamaByte
   1. GitHub Sponsors link