### PR TITLE
Fix typos in configurator_setup messages for `:defines`

### DIFF
--- a/lib/ceedling/configurator_setup.rb
+++ b/lib/ceedling/configurator_setup.rb
@@ -242,7 +242,7 @@ class ConfiguratorSetup
       else
         # Handle the (probably) common case of trying to use matchers for any context other than :test or :preprocess
         if config.class == Hash
-          msg = "#{walk} entry '#{config}' must be a list--matcher hashes only availalbe for :test & :preprocess contexts (see docs for details)"
+          msg = "#{walk} entry '#{config}' must be a list; matcher hashes are only available for :test & :preprocess contexts (see docs for details)"
           @loginator.log( msg, Verbosity::ERRORS )
           valid = false
         # Catchall for any oddball entries
@@ -438,7 +438,7 @@ class ConfiguratorSetup
         else
           # Handle the (probably) common case of trying to use matchers for operations in any context other than :test
           if config.class == Hash
-            msg = "#{walk} entry '#{config}' must be a list--matcher hashes only availalbe for :test context (see docs for details)"
+            msg = "#{walk} entry '#{config}' must be a list; matcher hashes are only available for :test context (see docs for details)"
             @loginator.log( msg, Verbosity::ERRORS )
             valid = false
           # Catchall for any oddball entries


### PR DESCRIPTION
This fixes some small typos in the error messages related to `:defines` configuration (`s/availalbe/available/g`), and adjusts the grammar of the message to clarify that `list` and `matcher` are separate concepts. New to Ceedling, I spent a moment trying to understand what a `list--matcher` was before realising what the message was saying.