### PR TITLE
Add support for dashes in filenames to test context extractor

### DIFF
--- a/lib/ceedling/test_context_extractor.rb
+++ b/lib/ceedling/test_context_extractor.rb
@@ -308,7 +308,7 @@ class TestContextExtractor
     includes = []
 
     # Look for #include statements
-    results = line.match(/#\s*include\s+\"\s*((\w|\.)+)\s*\"/)
+    results = line.match(/#\s*include\s+\"\s*([\w\.\-]+)\s*\"/)
     includes << results[1] if !results.nil?
 
     return includes

--- a/spec/test_context_extractor_spec.rb
+++ b/spec/test_context_extractor_spec.rb
@@ -109,8 +109,8 @@ describe TestContextExtractor do
         #include "unity.h"
 
       #include "mock_File.h"
-        #include "mock_another_file.h"
-      #include  " mock_another_file.h "  // Duplicate to be ignored
+        #include "mock_another-file.h"
+      #include  " mock_another-file.h "  // Duplicate to be ignored
       CONTENTS
 
       input = StringIO.new( file_contents )
@@ -120,7 +120,7 @@ describe TestContextExtractor do
         'more_source.h',
         'unity.h',
         'mock_File.h',
-        'mock_another_file.h'
+        'mock_another-file.h'
       ]
 
       expect( @extractor.extract_includes( input ) ).to eq expected


### PR DESCRIPTION
It looks like commit [#b75b523](https://github.com/bidds95/Ceedling/commit/b75b523a73fc6be4fa7521e7b60eb74d4e78b993) may have inadvertently broken support for dashes in filenames. A small change to the regex pattern in _extract_includes() fixes the issue. 

I haven't found any open issues or anything to suggest support was dropped (Issue [#439](https://github.com/ThrowTheSwitch/Ceedling/issues/439) suggests it was supported in release 1.0.0). Let me know if I've missed something.

I've tweaked an existing unit test to cover dashes in filenames.