### PR TITLE
Fix link markdown formatting in Ceedling Packet

### DIFF
--- a/docs/CeedlingPacket.md
+++ b/docs/CeedlingPacket.md
@@ -636,7 +636,7 @@ those header files. It's kinda magical.
 
 For more on the assertions and mocking shown above, consult the 
 documentation for [Unity] and [CMock] or the resources in
-Ceedling’s [README][/README.md].
+Ceedling’s [README](/README.md).
 
 Ceedling, Unity, and CMock rely on a variety of
 [conventions to make your life easier][conventions-and-behaviors].


### PR DESCRIPTION
This fixes a small typo in the Ceedling Packet documentation, which was intended to be a link.