### PR TITLE
ci: fix bundler issue in ruby 3.4 unit test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,14 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          
+
+      # Workaround: fix Ruby toolcache gem dir permissions (Bundler exit 38)
+      # Issue: https://github.com/rubygems/rubygems/issues/7983
+      - name: Fix Ruby toolcache gem directory permissions
+        if: runner.os == 'Linux'
+        run: |
+          sudo chmod -R go-w /opt/hostedtoolcache/Ruby/**/**/lib/ruby/gems/**/gems || true
+
       # Install Gem Depdencies (Bundler version should match the one in Gemfile.lock)
       - name: Install Gem Dependencies for Testing and Ceedling Gem Builds
         run: |
@@ -136,9 +143,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: vendor/bundle
-          key: bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+          key: bundle-use-ruby-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby-version }}-
+            bundle-use-ruby-${{ runner.os }}-${{ matrix.ruby }}-
 
       # Checks out repository under $GITHUB_WORKSPACE
       - name: Checkout Latest Repo
@@ -151,7 +158,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          
+
       # Install Gem Depdencies (Bundler version should match the one in Gemfile.lock)
       - name: Install Gem Dependencies for Testing and Ceedling Gem Builds
         shell: bash
@@ -284,4 +291,3 @@ jobs:
           asset_path: ./ceedling-${{ env.ceedling_tag }}.gem
           asset_name: ceedling-${{ env.ceedling_build }}.gem
           asset_content_type: test/x-gemfile
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: vendor/bundle
-          key: bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+          key: bundle-use-ruby-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby-version }}-
+            bundle-use-ruby-${{ runner.os }}-${{ matrix.ruby }}-
 
       # Checks out repository under $GITHUB_WORKSPACE
       - name: Checkout Latest Repo


### PR DESCRIPTION
This pull request updates the `.github/workflows/main.yml` file to adds a workaround for a known Ruby gem directory permissions issue on Linux runners, and a small fix for cache key usage (cache may need more work)

**Linux runner compatibility:**

* Added a step to fix Ruby toolcache gem directory permissions on Linux runners to avoid Bundler exit code 38, referencing a known RubyGems issue. This helps prevent CI failures related to permissions.

**Workflow reliability and correctness improvements:**

* Updated the cache key and restore-keys to use `runner.os` and `matrix.ruby` instead of `matrix.os` and `matrix.ruby-version` (they didn't exist) for the cache id. Whether cache was (is) actually working, requires further confirmation. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L43-R45) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L139-R148)