### PR TITLE
Github Actions workflow redesign

### DIFF
--- a/.github/workflows/_generate-docs.yml
+++ b/.github/workflows/_generate-docs.yml
@@ -1,0 +1,75 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# -----------------------------------------------------------------------
+# Internal reusable workflow — not intended to be triggered directly.
+# Called by ci.yml, prerelease.yml, and release.yml.
+#
+# Purpose:
+#   Build the local HTML documentation bundle (MkDocs) for inclusion in
+#   the Ceedling gem and upload it as the artifact 'gem-docs-site-local'.
+#   Subsequent jobs in the calling workflow download this artifact to
+#   make the docs bundle available for testing and gem packaging.
+# -----------------------------------------------------------------------
+
+---
+name: "Generate Local Docs Bundle"
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  generate-docs:
+    name: "Generate Local Docs Bundle for Gem Inclusion"
+    runs-on: ubuntu-latest
+
+    steps:
+      # Use a cache for our tools to speed up builds
+      # No matrix here; Ruby version is hardcoded to match the cache key format used by test jobs
+      - uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: bundle-use-ruby-${{ runner.os }}-3.3-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            bundle-use-ruby-${{ runner.os }}-3.3-
+
+      - name: Checkout Latest Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set Up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      # This is overkill, but it's the sanest way to ensure all Rakefile dependencies are available when we run docs:build:local task
+      - name: Install Gem Dependencies
+        run: |
+          bundle install
+
+      # --break-system-packages is required on Ubuntu 24.04+ (PEP 668 prevents pip from
+      # installing to the system Python environment without explicit opt-in)
+      - name: Install MkDocs and mkdocs-material
+        run: |
+          pip install --break-system-packages mkdocs mkdocs-material
+
+      # Builds local HTML bundle for gem inclusion; invokes MkDocs via the project's
+      # venv_sh wrapper in the Rakefile (skips venv activation when no .docsenv is present)
+      - name: Build HTML Documentation Bundle
+        run: |
+          rake docs:build:local --trace
+
+      - name: Upload HTML Documentation Bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: gem-docs-site-local
+          path: site-local/
+          if-no-files-found: error

--- a/.github/workflows/_publish-gem.yml
+++ b/.github/workflows/_publish-gem.yml
@@ -97,13 +97,16 @@ jobs:
         id: changelog
         shell: bash
         run: |
-          GEM_VERSION="${GITHUB_REF_NAME#v}"
-          GEM_VERSION="${GEM_VERSION/-/.}"
+          # Strip the leading 'v' then take only the MAJOR.MINOR.PATCH core,
+          # discarding any pre-release suffix (e.g. v1.2.3-pre.1 → 1.2.3).
+          # Changelog entries are keyed on the semver core, not the full tag.
+          SEMVER="${GITHUB_REF_NAME#v}"
+          SEMVER="${SEMVER%%-*}"
           BODY_FILE="${RUNNER_TEMP}/release_body.md"  # $RUNNER_TEMP: Actions-provided temp dir
 
           echo "found=false" >> "$GITHUB_OUTPUT"
 
-          if .github/workflows/extract_changelog.sh "${GEM_VERSION}" "docs/Changelog.md" "${BODY_FILE}"; then
+          if .github/workflows/extract_changelog.sh "${SEMVER}" "docs/Changelog.md" "${BODY_FILE}"; then
             # Write the extracted markdown content as a multi-line step output.
             # A unique timestamp-based delimiter guards against any text in the changelog
             # accidentally matching the EOF marker and closing the heredoc early.
@@ -140,15 +143,14 @@ jobs:
           files: ceedling-*.gem
           body: ${{ steps.changelog.outputs.body }}
 
-      # Fall back to GitHub's auto-generated release notes (commit comparison since
-      # the previous tag) when no changelog section exists for this version
+      # Fall back to GitHub's auto-generated release notes (from last commit)
+      # when no changelog section exists for this version
       - name: Publish GitHub Release (auto-generated notes)
         if: steps.changelog.outputs.found != 'true'
         uses: softprops/action-gh-release@v2
         with:
           prerelease: ${{ inputs.prerelease }}
           files: ceedling-*.gem
-          generate_release_notes: true
 
       # Uncomment and add RUBYGEMS_API_KEY secret to automate RubyGems.org publishing
       # - name: Push to RubyGems.org

--- a/.github/workflows/_publish-gem.yml
+++ b/.github/workflows/_publish-gem.yml
@@ -80,15 +80,7 @@ jobs:
       # version is computed here from the tag and is never manually set.
       - name: Stamp Gem Version from Git Tag
         shell: bash
-        run: |
-          # Strip leading 'v' from the Git tag (e.g. v1.1.0-pre.1 → 1.1.0-pre.1)
-          GEM_VERSION="${GITHUB_REF_NAME#v}"
-          # Replace the first hyphen with a dot (RubyGems pre-release notation)
-          # e.g. 1.1.0-pre.1 → 1.1.0.pre.1 ; 1.1.0 → 1.1.0 (no-op for release tags)
-          GEM_VERSION="${GEM_VERSION/-/.}"
-          # Stamp the computed version into lib/version.rb for this build only
-          sed -i "s/GEM = '.*'/GEM = '${GEM_VERSION}'/" lib/version.rb
-          echo "Building gem version: ${GEM_VERSION}"
+        run: .github/workflows/stamp_gem_version.sh "${GITHUB_REF_NAME}" lib/version.rb
 
       # Extract the changelog section matching this release version for use as the
       # release body. The script exits 0 (found) or 1 (not found / file missing).
@@ -135,6 +127,10 @@ jobs:
       # body and generate_release_notes within a single step via expressions.
 
       # Use the extracted changelog section as the release body when the section was found
+      - name: Log Release Notes Source (changelog body)
+        if: steps.changelog.outputs.found == 'true'
+        run: echo "Publishing release with Changelog.md section as release notes body."
+
       - name: Publish GitHub Release (changelog body)
         if: steps.changelog.outputs.found == 'true'
         uses: softprops/action-gh-release@v2
@@ -145,6 +141,10 @@ jobs:
 
       # Fall back to GitHub's auto-generated release notes (from last commit)
       # when no changelog section exists for this version
+      - name: Log Release Notes Source (auto-generated)
+        if: steps.changelog.outputs.found != 'true'
+        run: echo "No Changelog.md section found for this version; publishing release with GitHub auto-generated release notes."
+
       - name: Publish GitHub Release (auto-generated notes)
         if: steps.changelog.outputs.found != 'true'
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/_publish-gem.yml
+++ b/.github/workflows/_publish-gem.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          draft: true # Temporary for testing
           prerelease: ${{ inputs.prerelease }}
           files: ceedling-*.gem
 

--- a/.github/workflows/_publish-gem.yml
+++ b/.github/workflows/_publish-gem.yml
@@ -90,6 +90,24 @@ jobs:
           sed -i "s/GEM = '.*'/GEM = '${GEM_VERSION}'/" lib/version.rb
           echo "Building gem version: ${GEM_VERSION}"
 
+      # Extract the changelog section matching this release version for use as the
+      # release body. The script exits 0 (found) or 1 (not found / file missing).
+      # Shell vars don't persist across steps; version is re-derived from the tag.
+      - name: Extract Changelog Section for Release Notes
+        id: changelog
+        shell: bash
+        run: |
+          GEM_VERSION="${GITHUB_REF_NAME#v}"
+          GEM_VERSION="${GEM_VERSION/-/.}"
+          BODY_FILE="${RUNNER_TEMP}/release_body.md"  # $RUNNER_TEMP: Actions-provided temp dir
+
+          if .github/workflows/extract_changelog.sh "${GEM_VERSION}" "docs/Changelog.md" "${BODY_FILE}"; then
+            echo "found=true"             >> "$GITHUB_OUTPUT"
+            echo "body_path=${BODY_FILE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false"            >> "$GITHUB_OUTPUT"
+          fi
+
       # Download HTML docs bundle built by _generate-docs.yml
       # Artifacts are shared within the same workflow run by run_id
       - name: Download HTML Documentation Bundle
@@ -103,13 +121,28 @@ jobs:
           gem build ceedling.gemspec
 
       # softprops/action-gh-release@v2 replaces the archived actions/create-release@v1
-      # and actions/upload-release-asset@v1
-      - name: Publish GitHub Release
+      # and actions/upload-release-asset@v1.
+      # Two conditional steps are used because the action cannot switch between
+      # body_path and generate_release_notes within a single step via expressions.
+
+      # Use the extracted changelog section as the release body when the section was found
+      - name: Publish GitHub Release (changelog body)
+        if: steps.changelog.outputs.found == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          draft: true # Temporary for testing
           prerelease: ${{ inputs.prerelease }}
           files: ceedling-*.gem
+          body_path: ${{ steps.changelog.outputs.body_path }}
+
+      # Fall back to GitHub's auto-generated release notes (commit comparison since
+      # the previous tag) when no changelog section exists for this version
+      - name: Publish GitHub Release (auto-generated notes)
+        if: steps.changelog.outputs.found != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: ${{ inputs.prerelease }}
+          files: ceedling-*.gem
+          generate_release_notes: true
 
       # Uncomment and add RUBYGEMS_API_KEY secret to automate RubyGems.org publishing
       # - name: Push to RubyGems.org

--- a/.github/workflows/_publish-gem.yml
+++ b/.github/workflows/_publish-gem.yml
@@ -101,11 +101,17 @@ jobs:
           GEM_VERSION="${GEM_VERSION/-/.}"
           BODY_FILE="${RUNNER_TEMP}/release_body.md"  # $RUNNER_TEMP: Actions-provided temp dir
 
+          echo "found=false" >> "$GITHUB_OUTPUT"
+
           if .github/workflows/extract_changelog.sh "${GEM_VERSION}" "docs/Changelog.md" "${BODY_FILE}"; then
-            echo "found=true"             >> "$GITHUB_OUTPUT"
-            echo "body_path=${BODY_FILE}" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false"            >> "$GITHUB_OUTPUT"
+            # Write the extracted markdown content as a multi-line step output.
+            # A unique timestamp-based delimiter guards against any text in the changelog
+            # accidentally matching the EOF marker and closing the heredoc early.
+            EOF_MARKER="RELEASE_BODY_EOF_$(date +%s)"
+            echo "body<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+            cat "${BODY_FILE}"         >> "$GITHUB_OUTPUT"
+            echo "${EOF_MARKER}"       >> "$GITHUB_OUTPUT"
+            echo "found=true"          >> "$GITHUB_OUTPUT"
           fi
 
       # Download HTML docs bundle built by _generate-docs.yml
@@ -123,7 +129,7 @@ jobs:
       # softprops/action-gh-release@v2 replaces the archived actions/create-release@v1
       # and actions/upload-release-asset@v1.
       # Two conditional steps are used because the action cannot switch between
-      # body_path and generate_release_notes within a single step via expressions.
+      # body and generate_release_notes within a single step via expressions.
 
       # Use the extracted changelog section as the release body when the section was found
       - name: Publish GitHub Release (changelog body)
@@ -132,7 +138,7 @@ jobs:
         with:
           prerelease: ${{ inputs.prerelease }}
           files: ceedling-*.gem
-          body_path: ${{ steps.changelog.outputs.body_path }}
+          body: ${{ steps.changelog.outputs.body }}
 
       # Fall back to GitHub's auto-generated release notes (commit comparison since
       # the previous tag) when no changelog section exists for this version

--- a/.github/workflows/_publish-gem.yml
+++ b/.github/workflows/_publish-gem.yml
@@ -1,0 +1,117 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# -----------------------------------------------------------------------
+# Internal reusable workflow — not intended to be triggered directly.
+# Called by prerelease.yml (with prerelease: true) and release.yml
+# (with prerelease: false).
+#
+# Purpose:
+#   Stamp the gem version from the calling workflow's Git tag, build the
+#   Ceedling gem, and publish a GitHub release or pre-release using
+#   softprops/action-gh-release@v2.
+#
+# Version stamping:
+#   lib/version.rb carries a .dev suffix between releases (e.g. 1.1.1.dev).
+#   This job derives the actual release version from the Git tag and stamps
+#   it into lib/version.rb before building — the file is never manually
+#   edited to match a release tag.
+#
+#   Tag-to-gem-version conversion:
+#     v1.1.0-pre.1  →  1.1.0.pre.1  (hyphen becomes dot: RubyGems pre-release notation)
+#     v1.1.0        →  1.1.0         (no suffix; substitution is a no-op)
+#
+# RubyGems.org publishing:
+#   The "Push to RubyGems.org" step below is stubbed and commented out.
+#   To enable automated publishing: uncomment the step and add a
+#   RUBYGEMS_API_KEY secret to the repository settings.
+# -----------------------------------------------------------------------
+
+---
+name: "Build and Publish Gem"
+
+on:
+  workflow_call:
+    inputs:
+      prerelease:
+        type: boolean
+        required: true
+        description: 'true = GitHub pre-release, false = full release'
+
+# contents: write is required to create and upload GitHub releases
+permissions:
+  contents: write
+
+jobs:
+  build-and-publish:
+    name: "Build and Publish Ceedling Gem"
+    runs-on: ubuntu-latest
+
+    steps:
+      # Use a cache for our tools to speed up builds
+      # No matrix here; Ruby version is hardcoded to match the cache key format used by test jobs
+      - uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: bundle-use-ruby-${{ runner.os }}-3.3-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            bundle-use-ruby-${{ runner.os }}-3.3-
+
+      - name: Checkout Latest Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set Up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install Gem Dependencies
+        run: |
+          bundle install
+
+      # Derive the gem version from the Git tag and stamp it into lib/version.rb.
+      # The in-tree version.rb carries a .dev suffix between releases; the release
+      # version is computed here from the tag and is never manually set.
+      - name: Stamp Gem Version from Git Tag
+        shell: bash
+        run: |
+          # Strip leading 'v' from the Git tag (e.g. v1.1.0-pre.1 → 1.1.0-pre.1)
+          GEM_VERSION="${GITHUB_REF_NAME#v}"
+          # Replace the first hyphen with a dot (RubyGems pre-release notation)
+          # e.g. 1.1.0-pre.1 → 1.1.0.pre.1 ; 1.1.0 → 1.1.0 (no-op for release tags)
+          GEM_VERSION="${GEM_VERSION/-/.}"
+          # Stamp the computed version into lib/version.rb for this build only
+          sed -i "s/GEM = '.*'/GEM = '${GEM_VERSION}'/" lib/version.rb
+          echo "Building gem version: ${GEM_VERSION}"
+
+      # Download HTML docs bundle built by _generate-docs.yml
+      # Artifacts are shared within the same workflow run by run_id
+      - name: Download HTML Documentation Bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-docs-site-local
+          path: site-local/
+
+      - name: Build Gem
+        run: |
+          gem build ceedling.gemspec
+
+      # softprops/action-gh-release@v2 replaces the archived actions/create-release@v1
+      # and actions/upload-release-asset@v1
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: ${{ inputs.prerelease }}
+          files: ceedling-*.gem
+
+      # Uncomment and add RUBYGEMS_API_KEY secret to automate RubyGems.org publishing
+      # - name: Push to RubyGems.org
+      #   run: gem push ceedling-*.gem
+      #   env:
+      #     GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,77 +1,61 @@
 # =========================================================================
 #   Ceedling - Test-Centered Build System for C
 #   ThrowTheSwitch.org
-#   Copyright (c) 2010-24 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
 #   SPDX-License-Identifier: MIT
 # =========================================================================
 
----
+# -----------------------------------------------------------------------
 # Continuous Integration Workflow
+#
+# Purpose:
+#   Run the full test suite and verify a clean gem build on every push.
+#   No releases are created here — publishing is handled by prerelease.yml
+#   and release.yml, which trigger only on intentional Git tags.
+#
+# Triggers:
+#   - Push to any branch
+#   - Pull request targeting master
+#   - Manual dispatch (workflow_dispatch)
+#
+# Skip-CI:
+#   Add any of the following to your commit message to skip this workflow:
+#     [skip ci]  [ci skip]  [no ci]  [skip actions]  [actions skip]
+#   Note: skip keywords have no effect on workflow_dispatch runs.
+#
+# Branch exclusions:
+#   To permanently exclude a branch pattern from CI, add a branches-ignore
+#   list under the push: trigger below (e.g. docs/**, wip/**).
+# -----------------------------------------------------------------------
+
+---
 name: CI
 
-# Triggers the workflow on push or pull request events for master & test branches
+# Triggers the workflow on push to any branch, pull requests targeting master,
+# or manual dispatch
 on:
-  push:
-    branches:
-      - 'master'
-      - 'test/**'
+  push:                  # All branches — no branch filter; see Skip-CI above
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 
-# Needed by softprops/action-gh-release
+# Cancel any in-progress run on the same ref when a new push arrives,
+# preventing stale run pile-up on active branches
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+
 permissions:
-  # Allow built gem file push to Github release
-  contents: write
+  contents: read
 
 
 jobs:
   # Job: Build MkDocs HTML documentation bundle for gem inclusion
   generate-docs:
     name: "Generate Local Docs Bundle for Gem Inclusion"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: [3.3]
-    steps:
-      # Use a cache for our tools to speed up testing
-      - uses: actions/cache@v4
-        with:
-          path: vendor/bundle
-          key: bundle-use-ruby-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            bundle-use-ruby-${{ runner.os }}-${{ matrix.ruby }}-
-
-      - name: Checkout Latest Repo
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Set Up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-
-      # This is overkill, but it's the sanest way to ensure all Rakefile dependencies are available when we run docs:build:local task
-      - name: Install Gem Dependencies
-        run: |
-          bundle install
-
-      - name: Install MkDocs and mkdocs-material
-        run: |
-          pip install mkdocs mkdocs-material
-
-      - name: Build HTML Documentation Bundle
-        run: |
-          rake docs:build:local --trace
-
-      - name: Upload HTML Documentation Bundle
-        uses: actions/upload-artifact@v4
-        with:
-          name: gem-docs-site-local
-          path: site-local/
-          if-no-files-found: error
+    uses: ./.github/workflows/_generate-docs.yml
 
 
   # Job: Linux unit test suite
@@ -82,7 +66,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Add 3.4 with resolution of bundler permission issue
         ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
     steps:
       # Use a cache for our tools to speed up testing
@@ -100,13 +83,15 @@ jobs:
           submodules: recursive
 
       # Set up Ruby to run test & build steps on multiple ruby versions
-      # This action install Ruby and the Bundler gem using the version captured in Gemfile.lock
+      # This action installs Ruby and the Bundler gem using the version captured in Gemfile.lock
       - name: Set Up Ruby with Version Matrix
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
 
       # Workaround: Fix Ruby toolcache Gem directory permissions (Bundler exit 38)
+      # This is an environmental Ruby/toolcache issue, not a Bundler issue; the fix must
+      # run after setup-ruby (which populates the toolcache) but before bundle install.
       # Issue: https://github.com/rubygems/rubygems/issues/7983
       - name: Apply Workaround for Ruby toolcache Gem Directory Permissions
         run: |
@@ -124,10 +109,11 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install --assume-yes --quiet gdb
 
-      # Install GCovr for Gcov plugin
+      # --break-system-packages is required on Ubuntu 24.04+ (PEP 668 prevents pip from
+      # installing to the system Python environment without explicit opt-in)
       - name: "Install GCovr for Tests of Ceedling Plugin: Gcov"
         run: |
-          sudo pip install gcovr
+          pip install --break-system-packages gcovr
 
       # Install ReportGenerator for Gcov plugin
       # Fix PATH before tool installation
@@ -162,19 +148,6 @@ jobs:
           path: systest.*.fail.log
           if-no-files-found: ignore
 
-      # Build & Install Ceedling Gem
-      - name: Build and Install Ceedling Gem
-        run: |
-          gem build ceedling.gemspec
-          gem install --local ceedling-*.gem
-
-      # Run temp_sensor
-      - name: Run Tests on temp_sensor Project
-        run: |
-          cd examples/temp_sensor
-          ceedling test:all
-          cd ../..
-
       # Run FFF Plugin Tests
       - name: "Run Tests on Ceedling Plugin: FFF"
         run: |
@@ -195,6 +168,7 @@ jobs:
           cd plugins/dependencies
           rake
           cd ../..
+
 
   # Job: Windows unit test suite
   tests-windows:
@@ -221,7 +195,7 @@ jobs:
           submodules: recursive
 
       # Set up Ruby to run test & build steps on multiple ruby versions
-      # This action install Ruby and the Bundler gem using the version captured in Gemfile.lock
+      # This action installs Ruby and the Bundler gem using the version captured in Gemfile.lock
       - name: Set Up Ruby with Version Matrix
         uses: ruby/setup-ruby@v1
         with:
@@ -267,19 +241,6 @@ jobs:
           path: systest.*.fail.log
           if-no-files-found: ignore
 
-      # Build & Install Gem
-      - name:  Build and Install Ceedling Gem
-        run: |
-          gem build ceedling.gemspec
-          gem install --local ceedling-*.gem
-
-      # Run temp_sensor example project
-      - name: Run Tests on temp_sensor Project
-        run: |
-          cd examples/temp_sensor
-          ceedling test:all
-          cd ../..
-
       # Run FFF Plugin Tests
       - name: "Run Tests on Ceedling Plugin: FFF"
         run: |
@@ -302,52 +263,39 @@ jobs:
           cd ../..
 
 
-  # Job: Automatic Minor Release
-  auto-release:
-    name: "Automatic Minor Release"
+  # Job: Build the Ceedling gem once all tests pass
+  # Verifies a clean gem build is possible; the built gem is uploaded as a
+  # downloadable workflow artifact. No release is created here.
+  build-gem:
+    name: "Build Ceedling Gem"
     needs:
-      - generate-docs
       - tests-linux
       - tests-windows
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby: [3.3]
 
     steps:
-      # Checks out repository under $GITHUB_WORKSPACE
+      # Use a cache for our tools to speed up builds
+      # No matrix here; Ruby version is hardcoded to match the cache key format used by test jobs
+      - uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: bundle-use-ruby-${{ runner.os }}-3.3-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            bundle-use-ruby-${{ runner.os }}-3.3-
+
       - name: Checkout Latest Repo
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      # Set Up Ruby Tools
-      - name: Set Up Ruby Tools
+      - name: Set Up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: '3.3'
 
-      # Capture the SHA string
-      - name: Git commit short SHA as environment variable
-        shell: bash
+      - name: Install Gem Dependencies
         run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-      - name: Ceedling tag as environment variable
-        shell: bash
-        run: |
-          echo "ceedling_tag=$(ruby ./lib/version.rb)" >> $GITHUB_ENV
-
-      - name: Ceedling build string as environment variable
-        shell: bash
-        run: |
-          echo "ceedling_build=${{ env.ceedling_tag }}-${{ env.sha_short }}" >> $GITHUB_ENV
-
-      # Create Git Commit SHA file in root of checkout
-      - name: Git Commit SHA file
-        shell: bash
-        run: |
-          echo "${{ env.sha_short }}" > ${{ github.workspace }}/GIT_COMMIT_SHA
+          bundle install
 
       # Download HTML docs bundle built by generate-docs job
       - name: Download HTML Documentation Bundle
@@ -356,31 +304,14 @@ jobs:
           name: gem-docs-site-local
           path: site-local/
 
-      # Build Gem
-      - name:  Build Gem
+      - name: Build Ceedling Gem
         run: |
           gem build ceedling.gemspec
 
-      # Create Unofficial Release
-      - name: Create Pre-Release
-        uses: actions/create-release@v1
-        id: create_release
+      # Upload the built gem as a workflow artifact (downloadable from the Actions UI)
+      - name: Upload Built Gem Artifact
+        uses: actions/upload-artifact@v4
         with:
-          draft: false
-          prerelease: true
-          release_name: ${{ env.ceedling_build }}
-          tag_name: ${{ env.ceedling_build }}
-          body: "Automatic pre-release for ${{ env.ceedling_build }}"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      # Post Gem to Unofficial Release
-      - name: Upload Pre-Release Gem
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./ceedling-${{ env.ceedling_tag }}.gem
-          asset_name: ceedling-${{ env.ceedling_build }}.gem
-          asset_content_type: test/x-gemfile
+          name: ceedling-gem
+          path: ceedling-*.gem
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,13 @@
 ---
 name: CI
 
-# Triggers the workflow on push to any branch, pull requests targeting master,
-# or manual dispatch
+# Triggers the workflow on push to any branch (tag pushes excluded — handled by
+# prerelease.yml and release.yml), pull requests targeting master, or manual dispatch
 on:
-  push:                  # All branches — no branch filter; see Skip-CI above
+  push:
+    branches:
+      - '**'             # All branches; branches: ['**'] scopes push to refs/heads/ only,
+                         # excluding refs/tags/ pushes — see Skip-CI above
   pull_request:
     branches: [master]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,18 @@ jobs:
           path: systest.*.fail.log
           if-no-files-found: ignore
 
+      # Build & Install Ceedling Gem
+      # Plugin test suites (FFF, module_generator, dependencies) require the installed gem
+      - name: Build and Install Ceedling Gem
+        run: |
+          gem build ceedling.gemspec
+          gem install --local ceedling-*.gem
+
       # Run FFF Plugin Tests
       - name: "Run Tests on Ceedling Plugin: FFF"
         run: |
           cd plugins/fff
-          rake --trace
+          rake
           cd ../..
 
       # Run Module Generator Plugin Tests
@@ -240,6 +247,13 @@ jobs:
           name: systest-failure-logs-${{ runner.os }}-ruby-${{ matrix.ruby }}
           path: systest.*.fail.log
           if-no-files-found: ignore
+
+      # Build & Install Ceedling Gem
+      # Plugin test suites (FFF, module_generator, dependencies) require the installed gem
+      - name: Build and Install Ceedling Gem
+        run: |
+          gem build ceedling.gemspec
+          gem install --local ceedling-*.gem
 
       # Run FFF Plugin Tests
       - name: "Run Tests on Ceedling Plugin: FFF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,8 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install --assume-yes --quiet gdb
 
-      # --break-system-packages is required on Ubuntu 24.04+ (PEP 668 prevents pip from
-      # installing to the system Python environment without explicit opt-in)
+      # --break-system-packages is required on Ubuntu 24.04+
+      # (PEP 668 prevents pip from installing to the system Python environment without explicit opt-in)
       - name: "Install GCovr for Tests of Ceedling Plugin: Gcov"
         run: |
           pip install --break-system-packages gcovr
@@ -152,7 +152,7 @@ jobs:
       - name: "Run Tests on Ceedling Plugin: FFF"
         run: |
           cd plugins/fff
-          rake
+          rake --trace
           cd ../..
 
       # Run Module Generator Plugin Tests

--- a/.github/workflows/extract_changelog.sh
+++ b/.github/workflows/extract_changelog.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# Extract a version section from a Keep a Changelog formatted file.
+#
+# Usage: extract_changelog.sh <version> <changelog_path> <output_path>
+#
+#   <version>        Gem version string (e.g. 1.1.0 or 1.1.0.pre.1)
+#   <changelog_path> Path to the Changelog.md file
+#   <output_path>    Path to write the extracted section into
+#
+# Exits 0 and writes content to <output_path> if the section is found.
+# Exits 1 if the changelog file is missing or the version section is absent.
+#
+# Version section headers are matched by the pattern "^# [VERSION]".
+# Any text following the closing "]" on the header line is ignored
+# (dates, labels, "Prerelease", em-dashes, hyphens, etc. are all fine).
+# The extracted section includes the version header line itself.
+#
+# Local testing examples:
+#   bash extract_changelog.sh 1.0.1 ../../docs/Changelog.md /tmp/out.md && cat /tmp/out.md
+#   bash extract_changelog.sh 9.9.9 ../../docs/Changelog.md /tmp/out.md; echo "exit: $?"
+
+set -euo pipefail
+
+GEM_VERSION="${1:?version argument required}"
+CHANGELOG="${2:?changelog path argument required}"
+OUTPUT_FILE="${3:?output file path argument required}"
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "Changelog not found at '${CHANGELOG}'; release notes will use GitHub default."
+  exit 1
+fi
+
+# Extract from the matching "# [VERSION]" header to just before the next "# [" header.
+#
+# Dots in the version string are escaped in the awk BEGIN block so that e.g.
+# 1.1.0 matches literally rather than treating "." as a regex wildcard.
+awk -v ver="${GEM_VERSION}" '
+  BEGIN { gsub(/\./, "\\.", ver); pat = "^# \\[" ver "\\]" }
+  $0 ~ pat          { found=1; print; next }
+  found && /^# \[/  { exit }
+  found             { print }
+' "$CHANGELOG" > "$OUTPUT_FILE"
+
+# -s: file exists AND is non-empty
+# (handles the edge case where the version header is present but has no content beneath it)
+if [ -s "$OUTPUT_FILE" ]; then
+  echo "Changelog section found for version '${GEM_VERSION}'."
+  exit 0
+else
+  echo "Changelog section not found for version '${GEM_VERSION}'; release notes will use GitHub default."
+  exit 1
+fi

--- a/.github/workflows/extract_changelog.sh
+++ b/.github/workflows/extract_changelog.sh
@@ -10,7 +10,7 @@
 #
 # Usage: extract_changelog.sh <version> <changelog_path> <output_path>
 #
-#   <version>        Gem version string (e.g. 1.1.0 or 1.1.0.pre.1)
+#   <version>        Semver core string (e.g. 1.1.0 or 1.2.3)
 #   <changelog_path> Path to the Changelog.md file
 #   <output_path>    Path to write the extracted section into
 #
@@ -20,7 +20,8 @@
 # Version section headers are matched by the pattern "^# [VERSION]".
 # Any text following the closing "]" on the header line is ignored
 # (dates, labels, "Prerelease", em-dashes, hyphens, etc. are all fine).
-# The extracted section includes the version header line itself.
+# The extracted section does NOT include the version header line itself —
+# only the body content beneath it is written to <output_path>.
 #
 # Local testing examples:
 #   bash extract_changelog.sh 1.0.1 ../../docs/Changelog.md /tmp/out.md && cat /tmp/out.md
@@ -28,7 +29,7 @@
 
 set -euo pipefail
 
-GEM_VERSION="${1:?version argument required}"
+SEMVER="${1:?version argument required}"
 CHANGELOG="${2:?changelog path argument required}"
 OUTPUT_FILE="${3:?output file path argument required}"
 
@@ -41,9 +42,9 @@ fi
 #
 # Dots in the version string are escaped in the awk BEGIN block so that e.g.
 # 1.1.0 matches literally rather than treating "." as a regex wildcard.
-awk -v ver="${GEM_VERSION}" '
+awk -v ver="${SEMVER}" '
   BEGIN { gsub(/\./, "\\.", ver); pat = "^# \\[" ver "\\]" }
-  $0 ~ pat          { found=1; print; next }
+  $0 ~ pat          { found=1; next }
   found && /^# \[/  { exit }
   found             { print }
 ' "$CHANGELOG" > "$OUTPUT_FILE"
@@ -51,9 +52,9 @@ awk -v ver="${GEM_VERSION}" '
 # -s: file exists AND is non-empty
 # (handles the edge case where the version header is present but has no content beneath it)
 if [ -s "$OUTPUT_FILE" ]; then
-  echo "Changelog section found for version '${GEM_VERSION}'."
+  echo "Changelog section found for version '${SEMVER}'."
   exit 0
 else
-  echo "Changelog section not found for version '${GEM_VERSION}'; release notes will use GitHub default."
+  echo "Changelog section not found for version '${SEMVER}'."
   exit 1
 fi

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,68 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# -----------------------------------------------------------------------
+# Pre-Release Publishing Workflow
+#
+# Purpose:
+#   Build the Ceedling gem and publish it as a GitHub pre-release.
+#   The test suite is NOT re-run here — ci.yml must have passed on the
+#   commit being tagged before the tag is pushed.
+#
+# Trigger:
+#   Push of a tag matching one of these patterns:
+#     v*.*.*-pre.*    (e.g. v1.1.0-pre.1)
+#     v*.*.*-beta.*   (e.g. v1.1.0-beta.1)
+#     v*.*.*-alpha.*  (e.g. v1.1.0-alpha.1)
+#
+# Tag-to-gem-version convention:
+#   v1.1.0-pre.1  →  ceedling-1.1.0.pre.1.gem
+#   (hyphens become dots per RubyGems pre-release notation)
+#
+# Typical workflow:
+#   1. Push v1.0.3-pre.1 tag → CI builds ceedling-1.0.3.pre.1.gem, posts GitHub pre-release
+#   2. Iterate with v1.0.3-pre.2, etc. as needed
+#   3. Push v1.0.3 tag (release.yml) → CI builds ceedling-1.0.3.gem, posts GitHub release
+#   4. Bump lib/version.rb to 1.0.4.dev in a commit and continue
+#
+# Related workflows:
+#   ci.yml       — runs on every push to any branch; no publishing
+#   release.yml  — triggered by full release tags (v*.*.*, no suffix)
+# -----------------------------------------------------------------------
+
+---
+name: Pre-Release
+
+# Triggers on pre-release tag patterns only
+on:
+  push:
+    tags:
+      - 'v*.*.*-pre.*'
+      - 'v*.*.*-beta.*'
+      - 'v*.*.*-alpha.*'
+
+
+# contents: write is required to create and upload GitHub releases
+permissions:
+  contents: write
+
+
+jobs:
+  # Job: Build MkDocs HTML documentation bundle for gem inclusion
+  generate-docs:
+    name: "Generate Local Docs Bundle for Gem Inclusion"
+    uses: ./.github/workflows/_generate-docs.yml
+
+  # Job: Build gem and publish GitHub pre-release
+  publish:
+    name: "Build and Publish Pre-Release Gem"
+    needs: generate-docs
+    uses: ./.github/workflows/_publish-gem.yml
+    with:
+      prerelease: true
+    # Pass GITHUB_TOKEN and any other secrets through to the reusable workflow
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,15 @@
 ---
 name: Release
 
-# Triggers on release tag pattern; see 'if' guard on publish job for the
-# second line of defense against pre-release tags matching this glob
+# Triggers on release tag pattern only.
+# Primary defense: the negative pattern '!v*.*.*-*' excludes any tag containing
+# a hyphen (e.g. v1.0.0-pre.1), which would otherwise match the v*.*.* glob.
+# Fallback defense: the 'if' guard on the publish job also rejects hyphenated tags.
 on:
   push:
     tags:
       - 'v*.*.*'
+      - '!v*.*.*-*'   # Exclude pre-release tags (e.g. v1.0.0-pre.1, v1.0.0-beta.1)
 
 
 # contents: write is required to create and upload GitHub releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# -----------------------------------------------------------------------
+# Release Publishing Workflow
+#
+# Purpose:
+#   Build the Ceedling gem and publish it as a GitHub full release.
+#   The test suite is NOT re-run here — ci.yml must have passed on the
+#   commit being tagged before the tag is pushed.
+#
+# Trigger:
+#   Push of a tag matching: v*.*.*  (e.g. v1.1.0)
+#
+#   Important: the v*.*.* glob also matches pre-release tags (e.g. v1.1.0-pre.1).
+#   The 'if' guard on the publish job provides a second line of defense:
+#   any tag containing a hyphen is rejected and the publish job is skipped,
+#   so only clean version tags (no suffix) produce a full release.
+#
+# Tag-to-gem-version convention:
+#   v1.1.0  →  ceedling-1.1.0.gem
+#
+# Post-release steps (manual):
+#   After pushing a release tag, bump lib/version.rb to the next .dev
+#   version (e.g. GEM = '1.1.1.dev') and commit to continue development.
+#
+# RubyGems.org publishing:
+#   The "Push to RubyGems.org" step in _publish-gem.yml is stubbed and
+#   commented out. Uncomment it and add a RUBYGEMS_API_KEY repository
+#   secret to enable automated publishing to rubygems.org.
+#
+# Related workflows:
+#   ci.yml          — runs on every push to any branch; no publishing
+#   prerelease.yml  — triggered by pre-release tags (v*.*.*-pre.*, etc.)
+# -----------------------------------------------------------------------
+
+---
+name: Release
+
+# Triggers on release tag pattern; see 'if' guard on publish job for the
+# second line of defense against pre-release tags matching this glob
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+
+# contents: write is required to create and upload GitHub releases
+permissions:
+  contents: write
+
+
+jobs:
+  # Job: Build MkDocs HTML documentation bundle for gem inclusion
+  generate-docs:
+    name: "Generate Local Docs Bundle for Gem Inclusion"
+    uses: ./.github/workflows/_generate-docs.yml
+
+  # Job: Build gem and publish GitHub full release
+  # The 'if' guard rejects tags that contain a hyphen (e.g. v1.1.0-pre.1),
+  # which would otherwise match the v*.*.* trigger glob and create a spurious
+  # full release instead of a pre-release
+  publish:
+    name: "Build and Publish Release Gem"
+    needs: generate-docs
+    if: ${{ !contains(github.ref_name, '-') }}
+    uses: ./.github/workflows/_publish-gem.yml
+    with:
+      prerelease: false
+    # Pass GITHUB_TOKEN and any other secrets through to the reusable workflow
+    secrets: inherit

--- a/.github/workflows/stamp_gem_version.sh
+++ b/.github/workflows/stamp_gem_version.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-25 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# Derive a RubyGems version string from a Git tag and stamp it into version.rb.
+#
+# Usage: stamp_gem_version.sh <tag> <version_file>
+#
+#   <tag>           Git tag (e.g. v1.1.0-pre.1 or v1.1.0)
+#   <version_file>  Path to the version.rb file to patch in place
+#
+# Exits 0 on success. Exits 1 if the version file is missing.
+#
+# Tag-to-gem-version conversion:
+#   v1.1.0-pre.1  →  1.1.0.pre.1  (hyphen becomes dot: RubyGems pre-release notation)
+#   v1.1.0        →  1.1.0         (no suffix; substitution is a no-op)
+#
+# Local testing examples:
+#   bash stamp_gem_version.sh v1.1.0 ../../lib/version.rb && grep GEM ../../lib/version.rb
+#   bash stamp_gem_version.sh v1.1.0-pre.1 ../../lib/version.rb && grep GEM ../../lib/version.rb
+
+set -euo pipefail
+
+TAG="${1:?tag argument required}"
+VERSION_FILE="${2:?version file path argument required}"
+
+if [ ! -f "$VERSION_FILE" ]; then
+  echo "Version file not found at '${VERSION_FILE}'."
+  exit 1
+fi
+
+# Strip leading 'v' from the Git tag (e.g. v1.1.0-pre.1 → 1.1.0-pre.1)
+GEM_VERSION="${TAG#v}"
+# Replace the first hyphen with a dot (RubyGems pre-release notation)
+# e.g. 1.1.0-pre.1 → 1.1.0.pre.1 ; 1.1.0 → 1.1.0 (no-op for release tags)
+GEM_VERSION="${GEM_VERSION/-/.}"
+
+sed -i "s/GEM = '.*'/GEM = '${GEM_VERSION}'/" "${VERSION_FILE}"
+echo "Stamped gem version: ${GEM_VERSION}"

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9,23 +9,41 @@ This changelog is complemented by two other documents:
 
 ---
 
-# [0.0.1] — Github Action testing
+# [1.1.0] — Prerelease
 
 ## 🌟 Added
 
-- Placeholder
+- **Partials.** [A Partial](https://throwtheswitch.github.io/Ceedling/dev/testing-guide/partials/) is a new feature that allows a test author to work with portions of the same C module under test differently from within the same test file. For example, a test can now cause some functions in the source module under test to be mocked while other source functions are executed against assertions (see #936).
+- CLI additions:
+   - `ceedling help` output provides links for further support and Github sponsorship.
+   - `ceedling check` validates your configuration and produces logs from processing it without executing a build.
+   - `ceedling docs` exports new HTML-based documentation site to your filesystem.
+- Preprocessing support for distinguishing and handling system includes (`#include <system.h>`) and user includes (`#include "user.h"`).
 
 ## 💪 Fixed
 
-- Placeholder
+- #1011 Performance Improvements.
+- #1014 Line Continuations not working in test name.
+- #1015 directive-only issue.
+- #1024 Fixed bug in options-handling for warnings log report.
+- #358 Mocks with relative path in include .
+- `:gcov` section of `:flags` is able to use filename matchers again (like `:test` section).
+- Now properly reports timing for single-batch builds (i.e. non-parallel builds).
+- Fixes to `#include`s handling and encoding.
+- PR #1126 fix for race condition in cache handling of `#include` listings in YAML files.
+- PR #1056 fix for extracting `#include` directive filenames that contain dashes.
+- Type handling in example `temp_sensor` project compatible with C23 (and previous C standards).
 
 ## ⚠️ Changed
 
-- Placeholder
-
-## 👋 Removed
-
-- Placeholder
+- The monolothic _CeedlingPacket.md_ user manual has been replaced by a full web-based documentation site.
+   - A verion that is navigable from your filesystem is included within Ceedling and exportable through CLI functions.
+   - The online version is available at: https://throwtheswitch.github.io/Ceedling/
+- PR #1003 improvements for Mixin merges — clearer logging and edge case handling.
+- Significant refactoring and improvements to logging and parallel processing.
+- Streamlined preprocessing, eliminating redundant steps and reducing memory usage.
+- Resolved ambiguity in updated `ceedling new` handling from 0.31.1 to 1.0.0.
+- Fixes for typos and grammar in documentation and logging.
 
 # [1.0.1] — 2025-01-30
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9,6 +9,24 @@ This changelog is complemented by two other documents:
 
 ---
 
+# [1.1.0] - Prerelease
+
+## 🌟 Added
+
+- Placeholder
+
+## 💪 Fixed
+
+- Placeholder
+
+## ⚠️ Changed
+
+- Placeholder
+
+## 👋 Removed
+
+- Placeholder
+
 # [1.0.1] - 2025-01-30
 
 ## 💪 Fixed

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9,7 +9,7 @@ This changelog is complemented by two other documents:
 
 ---
 
-# [1.1.0] - Prerelease
+# [1.1.0] — Prerelease
 
 ## 🌟 Added
 
@@ -27,7 +27,7 @@ This changelog is complemented by two other documents:
 
 - Placeholder
 
-# [1.0.1] - 2025-01-30
+# [1.0.1] — 2025-01-30
 
 ## 💪 Fixed
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9,7 +9,7 @@ This changelog is complemented by two other documents:
 
 ---
 
-# [1.1.0] — Prerelease
+# [0.0.1] — Github Action testing
 
 ## 🌟 Added
 


### PR DESCRIPTION
- Decomposed workflows into CI (docs, tests, & gem building), prerelease, and release.
- Broke out complex steps into individual shell scripts called from workflows.
- Prereleases and releases initiated from tags.
- Github release body populated from Changelog.md extracted content matching semver of tag.