### PR TITLE
🐛 Fix exit code 0 even though tests fail

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -119,6 +119,7 @@ When test preprocessing is enabled, Ceedling discovers whether your toolchain su
    - Prevention of coverage corruption during `ReportGenerator` reporting runs.
 - #1144 Fixed flags for release build linking.
 - #1169 Fixed linking with :libraries ↳ :release.
+- #1112 Fixed test failures incorrectly returning exit code 0 when the stdout pretty printer plugin is disabled. (@corytodd)
 
 ## ⚠️ Changed
 

--- a/lib/ceedling/generators/generator_test_results.rb
+++ b/lib/ceedling/generators/generator_test_results.rb
@@ -171,7 +171,7 @@ class GeneratorTestResults
 
     @yaml_wrapper.dump(output_file, results)
 
-    return { :result_file => output_file, :result => results }
+    return { :result_file => output_file, :results => results }
   end
 
   # Filter list of test cases:

--- a/lib/ceedling/plugin_manager.rb
+++ b/lib/ceedling/plugin_manager.rb
@@ -54,11 +54,13 @@ class PluginManager
   end
 
   def print_plugin_failures
-    if (@build_fail_registry.size > 0)
+    # Deduplicate: post_test_fixture_execute and reporting plugins may both register the same message
+    failures = @build_fail_registry.uniq
+    if (failures.size > 0)
       report = @reportinator.generate_banner('BUILD FAILURE SUMMARY')
 
-      @build_fail_registry.each do |failure|
-        report += "#{' - ' if (@build_fail_registry.size > 1)}#{failure}\n"
+      failures.each do |failure|
+        report += "#{' - ' if (failures.size > 1)}#{failure}\n"
       end
 
       report += "\n"

--- a/lib/ceedling/plugin_manager.rb
+++ b/lib/ceedling/plugin_manager.rb
@@ -95,6 +95,8 @@ class PluginManager
   def post_test_fixture_execute(arg_hash)
     # Special arbitration: Raw test results are printed or taken over by plugins handling the job
     @loginator.log( arg_hash[:shell_result][:output] ) if @configurator.plugins_display_raw_test_results
+    # Core failure detection independent of any reporting plugin
+    register_build_failure( 'Unit test failures.' ) if arg_hash.dig(:results, :counts, :failed).to_i > 0
     execute_plugins(:post_test_fixture_execute, arg_hash)
   end
 

--- a/spec/units/generators/generator_test_results_spec.rb
+++ b/spec/units/generators/generator_test_results_spec.rb
@@ -198,6 +198,18 @@ describe GeneratorTestResults do
       expect(IO.read(@tmp_out_file)).to eq(IO.read('spec/support/test_example.pass'))
     end
 
+    it 'returns :results key containing parsed counts' do
+      result = @generate_test_results.process_and_write_results(
+        { :executable => 'test_example.out',
+          :output => NORMAL_OUTPUT,
+          :result_file => @tmp_out_file,
+          :test_file => 'some/place/test_example.c'
+        }
+      )
+      expect(result).to have_key(:results)
+      expect(result[:results][:counts]).to include(:failed => 0)
+    end
+
     it 'handles a normal test output with time' do
       @generate_test_results.process_and_write_results(
         { :executable => 'test_example.out',

--- a/spec/units/plugin_manager_spec.rb
+++ b/spec/units/plugin_manager_spec.rb
@@ -1,0 +1,48 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/constants'
+require 'ceedling/plugin_manager'
+
+describe PluginManager do
+  before(:each) do
+    @configurator          = double('configurator', :plugins_display_raw_test_results => false)
+    @plugin_manager_helper = double('plugin_manager_helper')
+    @loginator             = double('loginator')
+    @reportinator          = double('reportinator')
+    @system_wrapper        = double('system_wrapper')
+
+    @pm = described_class.new(
+      :configurator          => @configurator,
+      :plugin_manager_helper => @plugin_manager_helper,
+      :loginator             => @loginator,
+      :reportinator          => @reportinator,
+      :system_wrapper        => @system_wrapper
+    )
+  end
+
+  describe '#post_test_fixture_execute' do
+    it 'registers a build failure when tests fail' do
+      arg_hash = { :shell_result => { :output => '' }, :results => { :counts => { :failed => 1 } } }
+      @pm.post_test_fixture_execute(arg_hash)
+      expect(@pm.plugins_failed?).to be(true)
+    end
+
+    it 'does not register a build failure when all tests pass' do
+      arg_hash = { :shell_result => { :output => '' }, :results => { :counts => { :failed => 0 } } }
+      @pm.post_test_fixture_execute(arg_hash)
+      expect(@pm.plugins_failed?).to be(false)
+    end
+
+    it 'does not register a build failure when result counts are absent' do
+      arg_hash = { :shell_result => { :output => '' }, :results => {} }
+      @pm.post_test_fixture_execute(arg_hash)
+      expect(@pm.plugins_failed?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
:pineapple:

## Summary

Fix exit code always returning 0 on test failure when no reporting plugin is active.

#1112: Exit code is determined by whether an active reporting plugin passed a block to run_report returning a
non-empty failure string. With no stdout plugin configured,  register_build_failure was never called and the build
silently exited 0. Fix moves failure detection into post_test_fixture_execute, which fires regardless of plugin configuration.

`process_and_write_results` returned `:result`  (singular) but `generator.rb` read it as `:results`, so result counts were
always `nil` at `post_test_fixture_execute`. Fixed at the source in `generator_test_results.rb` for consistency with the rest
of the codebase.

### Workaround
Active reporting plugins still register failures via their block, producing duplicate banner entries
alongside the core registration. Deduplicated in `print_plugin_failures` with `.uniq`. A cleaner fix would split `run_report`'s
dual responsibilities but that is a breaking plugin API change.

## Testing

Verified against examples/temp_sensor with a manually broken assertion in `TestMain.c` and the removal of `report_tests_pretty_stdout` from enabled plugins. 

 - Before this patch, the failed test produces a return code of 0.
 - After this patch, the failed test produces a return code of 1.

With `report_tests_pretty_stdout` enabled, we still see exit 1 just as before and there  are no duplicated  banner messages. All new  and current tests are passing . Robucop doesn't seem offended by anything in this  patch set.

Resolves #1112