### PR TITLE
Gcov plugin: More options for untestested sources

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -68,7 +68,9 @@ _NOTE:_ The `ReportGenerator` tool does not support extracting MC/DC even if tho
 
 This feature addition resolves a longstanding feature request for coverage reporting (#329 and others).
 
-The Gcov plugin now includes an option (defaults to enabled) that causes all source files in the project that have not been exercised by unit tests to also be compiled with coverage. Doing so causes all source files to appear in the final coverage report; those untouched by unit tests are represented with 0% coverage.
+The Gcov plugin now includes an `:untested_sources` option that controls how source files not exercised by any test are handled in coverage reporting — from full omission (`:ignore`), to a warning-level filepath listing of files not present in the coverage report (`:warning`), to full compile-for-0%-coverage (`:compile`). The default is `:warning`.
+
+When `:compile` is active, a `gcov:untested_sources` task is available for iterating coverage compilation for untested sources without needing to re-run an entire `gcov:` test suite build each time. Untested sources can require defines, flags, and platform headers & symbols not present in a test suite configuration.
 
 See the [GCov plugin documentation](https://throwtheswitch.github.io/Ceedling/1.1.0/plugins/gcov/setup#coverage-for-untested-sources) for more details on the new `:untested_sources` option.
 

--- a/docs/mkdocs/plugins/gcov/setup.md
+++ b/docs/mkdocs/plugins/gcov/setup.md
@@ -84,7 +84,7 @@ To generate reports:
 
 The next sections explain each of these steps.
 
-## Modified Condition / Decision Coverage
+### Modified Condition / Decision Coverage
 
 As of version 14, the GNU Compiler Collection supports MC/DC. If your environment
 contains a minimum of GCC 14 you can enable MC/DC in coverage summaries.
@@ -104,14 +104,35 @@ NOTE: ReportGenerator does not support MC/DC reporting.
 ```
 **Default:** `FALSE`
 
-## Coverage for untested sources
+### Coverage for untested sources
 
-When enabled, the GCov plugin will compile all source files in the project with
-coverage, not only those exercised with tests. This causes all source files to 
-appear in any generated reporting (untested source files with 0% coverage).
+This setting controls how the GCov plugin handles project source files that
+are not exercised by any test. It takes one of three values:
+
+* `:ignore` — Untested source files are not processed at all. Nothing is
+  logged, nothing is compiled, and these files are simply absent from the
+  coverage report.
+* `:list` — Untested source files are not compiled with coverage, but their
+  filepaths are logged as a warning so you know which files will not appear
+  in the coverage report.
+* `:compile` — All untested source files are compiled with coverage so they
+  appear in the final report with 0% coverage (since no test exercises
+  them). This causes all source files to appear in any generated reporting.
+  If a source file fails to compile, Ceedling logs guidance at the console,
+  and the build fails.
+
+```yaml
+:plugins:
+  :enabled:
+    - gcov
+
+:gcov:
+  :untested_sources: :list
+```
+**Default:** `:list`
 
 !!! warning
-    **Compiling all untested sources for 0% coverage reporting will likely require additional work.**
+    **Compiling all untested sources for 0% coverage reporting (`:compile`) will likely require additional work.**
 
     Successful compilation of untested source files may require certain symbols 
     to be defined, certain flags to be set, or entire stand-in shims for platform 
@@ -129,17 +150,22 @@ appear in any generated reporting (untested source files with 0% coverage).
 Notes:
 
 * Versions of GCovr before 7.0 do not include the necessary options to produce 
-  0% coverage results for source files only compiled (but never executed.)
+  0% coverage results for source files only compiled (but never executed).
 
-```yaml
-:plugins:
-  :enabled:
-    - gcov
+---
 
-:gcov:
-  :untested_sources: TRUE
+When `:untested_sources` is `:compile`, an additional `gcov:untested_sources`
+build task becomes available:
+
+```shell
+ > ceedling gcov:untested_sources
 ```
-**Default:** `TRUE`
+
+This task exists to let you work through the compilation problems described
+in the warning above — missing symbols, flags, or platform header/code
+stand-ins — by re-running just the untested-source compilation step
+directly. No test suite build is needed while iterating on source compilation 
+fixes.
 
 ### Reporting utilities installation
 

--- a/docs/mkdocs/reference/gcov-plugin.md
+++ b/docs/mkdocs/reference/gcov-plugin.md
@@ -62,7 +62,7 @@ This feature is dependent on minimum tool versions.
 ### `:untested_sources`
 
 !!! warning
-    **Compiling all untested sources for 0% coverage reporting will likely require additional work.**
+    **Compiling all untested sources for 0% coverage reporting (`:compile`) will likely require additional work.**
 
     Successful compilation of untested source files may require certain symbols 
     to be defined, certain flags to be set, or entire stand-in shims for platform 
@@ -77,16 +77,25 @@ This feature is dependent on minimum tool versions.
     by default. If you need something special for coverage builds, use the `:gcov` 
     context for these matchers instead.
 
-Enable or disable coverage compilation for all untested source files.
-When enabled, coverage results will exist in the final report for all source
-files in the project (untested source files will be listed with 0% coverage.)
+Controls handling of source files not exercised by any test. Valid values:
 
-**Default:** `TRUE`
+* `:ignore` — Skip untested sources entirely (no logging, no compilation).
+* `:list` — Log the filepaths of untested sources as a warning; do not compile them.
+* `:compile` — Compile all untested sources with coverage so they appear in
+  the report at 0% coverage. On compilation failure, Ceedling logs
+  guidance and fails the build.
+
+**Default:** `:list`
 
 ```yaml
 :gcov:
-  :untested_sources: TRUE
+  :untested_sources: :list
 ```
+
+When `:untested_sources` is set to `:compile`, a `gcov:untested_sources` task is
+also available, letting you re-run just the untested-source compilation step
+on its own — without a full `gcov:` test suite run — while iterating on source
+compilation fixes.
 
 ---
 

--- a/lib/ceedling/test_invoker/test_invoker.rb
+++ b/lib/ceedling/test_invoker/test_invoker.rb
@@ -36,6 +36,23 @@ class TestInvoker
   # Public API
   # -------------------------------------------------------------------------
 
+  # Run the test-build pipeline for the given tests.
+  #
+  # options: — free-form hash forwarded to every pipeline stage as `state.options`.
+  # Recognized keys (stages not listed read nothing from `options`):
+  #   :build_only   — Boolean. Skip stage 17 (Executing) only. Compile and link
+  #                   test executables but do not run them.
+  #   :sources_only — Boolean. Skip stages 15-17 (Building Objects, Building Test
+  #                   Executables, Executing). Runs only context-extraction/metadata
+  #                   stages 1-14, enough to populate each testable's `.sources` —
+  #                   i.e. no compiler, linker, or test fixture is invoked.
+  #   :test_linker  — Tool config for stage 16 (Building Test Executables). Ignored
+  #                   when :sources_only or :build_only skips that stage.
+  #   :test_fixture — Tool config for stage 17 (Executing). Ignored when :sources_only
+  #                   or :build_only skips that stage.
+  # Other keys occasionally merged in by callers (e.g. :test_compiler, :force_run) are
+  # currently not read by any pipeline stage; tool selection for compiling is instead
+  # resolved per-context via the `pre_compile_execute` plugin hook.
   def setup_and_invoke(tests:, context: TEST_SYM, options: {})
     timestamp_s = SystemWrapper.time_stopwatch_s()
     @plugin_manager.pre_test_build( context, timestamp_s )
@@ -98,7 +115,8 @@ class TestInvoker
     use_partials      = -> (s) { @configurator.project_use_partials }
     use_mocks         = -> (s) { @configurator.project_use_mocks }
     use_mocks_preproc = -> (s) { @configurator.project_use_mocks && @configurator.project_use_test_preprocessor_mocks }
-    not_build_only    = -> (s) { !s.options[:build_only] }
+    not_build_only    = -> (s) { !s.options[:build_only] }   # skip stage 17 only
+    not_sources_only  = -> (s) { !s.options[:sources_only] } # skip stages 15-17
 
     [
       # Stage 1
@@ -199,19 +217,22 @@ class TestInvoker
             body: ->(s) { @test_build_planner.stage_flatten_objects_list(s) }
       ),
 
-      # Stage 15
+      # Stage 15 — skipped under :sources_only (no object compilation needed to
+      # determine which sources a test references).
       stage("Building Objects",
+            condition: not_sources_only,
             body: ->(s) { @test_build_executor.stage_build_objects(s) }
       ),
 
-      # Stage 16
+      # Stage 16 — skipped under :sources_only (no linking needed either).
       stage("Building Test Executables",
+            condition: not_sources_only,
             body: ->(s) { @test_build_executor.stage_build_executables(s) }
       ),
 
-      # Stage 17
+      # Stage 17 — skipped under :build_only or :sources_only.
       stage("Executing",
-            condition: not_build_only,
+            condition: ->(s) { not_build_only.call(s) && not_sources_only.call(s) },
             body: ->(s) { @test_build_executor.stage_execute(s) }
       ),
     ]

--- a/plugins/gcov/config/defaults.yml
+++ b/plugins/gcov/config/defaults.yml
@@ -9,7 +9,7 @@
 :gcov:
   :summaries: TRUE                # Enable simple coverage summaries to console after tests
   :report_task: FALSE             # Disabled dedicated report generation task (this enables automatic report generation)
-  :untested_sources: TRUE         # Perform compilation with coverage for untested sources (to produce a complete coverage report)
+  :untested_sources: :list        # :ignore (skip entirely), :list (log filepaths not in report), :compile (compile all for 0% coverage)
   :mcdc: FALSE                    # MC/DC (modified condition/decision) coverage — requires GCC 14+ and gcovr 8+
 
   :utilities:

--- a/plugins/gcov/gcov.rake
+++ b/plugins/gcov/gcov.rake
@@ -107,3 +107,24 @@ namespace GCOV_REPORT_NAMESPACE_SYM do
 end
 end
 
+# Only defined when :untested_sources is ':compile' — lets a user iterate on getting
+# untested-source coverage compilation working (symbols/flags/platform stand-ins, per
+# the setup docs) without paying for or triggering a full gcov: test suite run each time.
+if @ceedling[GCOV_SYM].untested_sources_compile_enabled?
+namespace GCOV_SYM do
+
+  desc 'Compile all untested source files with coverage'
+  task :untested_sources => [:prepare] do
+    # sources_only: true — populate the tested-sources mapping (which sources each test
+    # references) without compiling, linking, or executing any test.
+    @ceedling[:test_invoker].setup_and_invoke(
+      tests: COLLECTION_ALL_TESTS,
+      context: GCOV_SYM,
+      options: { sources_only: true }
+    )
+    @ceedling[:gcov].process_untested_sources( sources: COLLECTION_ALL_SOURCE, guidance: false )
+  end
+
+end
+end
+

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -24,6 +24,9 @@ class Gcov < Plugin
 
     @project_config = @ceedling[:configurator].project_config_hash
 
+    # Check for a valid :untested_sources configuration value
+    validate_untested_sources( @project_config )
+
     # Are any reports enabled?
     @reports_enabled = reports_enabled?( @project_config[:gcov_reports] )
     @cli_gcov_task = false
@@ -77,42 +80,88 @@ class Gcov < Plugin
     return (@project_config[:gcov_report_task] == false)
   end
 
+  # Called within class and also externally by plugin Rakefile to conditionally
+  # create the standalone `gcov:untested_sources` task
+  def untested_sources_compile_enabled?
+    return (@project_config[:gcov_untested_sources] == GCOV_UNTESTED_SOURCES_COMPILE)
+  end
 
-  def process_untested_sources(sources:)
-    unless @project_config[:gcov_untested_sources]
-      msg = 'Skipping code coverage processing of untested sources'
-      @loginator.log( msg, Verbosity::NORMAL, LogLabels::NOTICE )
+
+  # guidance: — log actionable notice text when a `:compile` mode compilation fails.
+  # Left `true` for a full build reached through plugin hooks (`gcov:all`, etc.), where
+  # a failure may be unexpected. Set `false` by the standalone `gcov:untested_sources`
+  # task, whose entire purpose is iterating on these failures directly at the compiler's
+  # own error output, without Ceedling's added narrative repeating each run.
+  def process_untested_sources(sources:, guidance: true)
+    mode = @project_config[:gcov_untested_sources]
+
+    case mode
+    when GCOV_UNTESTED_SOURCES_IGNORE
+      # Disabled entirely — no heading, no listing, no compilation, no log line at all.
       return
-    end
 
-    msg = 'Processing Untested Sources'
-    msg = @reportinator.generate_heading( @loginator.decorate( msg, LogLabels::RUN ) )
-    @loginator.log( msg )
+    when GCOV_UNTESTED_SOURCES_LIST
+      msg = 'Processing Untested Sources'
+      msg = @reportinator.generate_heading( @loginator.decorate( msg, LogLabels::RUN ) )
+      @loginator.log( msg )
 
-    tested_sources = []
-    @test_invoker.each_test_with_sources { |_, srcs| tested_sources.concat( srcs ) }
-    untested_sources = sources - tested_sources
+      untested_sources = collect_untested_sources( sources )
+      # Retained for post_build's console reportinator, which still prints its own
+      # (basename-keyed) "Untested Source Files" section from this same list.
+      @untested_sources = untested_sources
 
-    @untested_sources = untested_sources
+      if untested_sources.empty?
+        @loginator.log( 'No untested sources to process.' )
+        return
+      end
 
-    if untested_sources.empty?
-      @loginator.log( 'No untested sources to process.' )
-      return
-    end
+      # Full filepaths (not basenames)
+      header = "Untested source files not in the coverage report (:untested_sources is :list):"
+      @loginator.log_list( untested_sources.sort, header, Verbosity::COMPLAIN, LogLabels::WARNING )
 
-    untested_sources.each do |filepath|
-      filename = File.basename(filepath)
-      @generator.generate_object_file_c(
-        tool:         TOOLS_GCOV_COMPILER,
-        module_name:  filename.ext(),
-        context:      GCOV_SYM,
-        source:       filepath,
-        object:       @file_path_utils.form_test_object_filepath( filepath, context:GCOV_SYM ),
-        search_paths: @configurator.collection_paths_include,
-        flags:        @flaginator.flag_down( context:GCOV_SYM, operation:OPERATION_COMPILE_SYM ),
-        defines:      @defineinator.defines( subkey:GCOV_SYM ),
-        dependencies: @file_path_utils.form_test_dependencies_filepath( filepath, context:GCOV_SYM )
-      )
+    when GCOV_UNTESTED_SOURCES_COMPILE
+      msg = 'Processing Untested Sources'
+      msg = @reportinator.generate_heading( @loginator.decorate( msg, LogLabels::RUN ) )
+      @loginator.log( msg )
+
+      untested_sources = collect_untested_sources( sources )
+      @untested_sources = untested_sources
+
+      if untested_sources.empty?
+        @loginator.log( 'No untested sources to process.' )
+        return
+      end
+
+      untested_sources.each do |filepath|
+        filename = File.basename(filepath)
+        begin
+          @generator.generate_object_file_c(
+            tool:         TOOLS_GCOV_COMPILER,
+            module_name:  filename.ext(),
+            context:      GCOV_SYM,
+            source:       filepath,
+            object:       @file_path_utils.form_test_object_filepath( filepath, context:GCOV_SYM ),
+            search_paths: @configurator.collection_paths_include,
+            flags:        @flaginator.flag_down( context:GCOV_SYM, operation:OPERATION_COMPILE_SYM ),
+            defines:      @defineinator.defines( subkey:GCOV_SYM ),
+            dependencies: @file_path_utils.form_test_dependencies_filepath( filepath, context:GCOV_SYM )
+          )
+        rescue ShellException => ex
+          # Log actionable guidance then re-raise immediately (omitted when `guidance` is false)
+          if guidance
+            notice = "Compiling untested '#{filename}' with coverage failed.\n" \
+                     "NOTE: Compilation of an untested source for coverage (:gcov ↳ :untested_sources ➡️ :compile) " \
+                     "may require defines, flags, or platform symbols & headers not present in the test suite build.\n" \
+                     "OPTIONS:\n" \
+                     "  1) Provide needed compilation essentials using Ceedling features and/or code stand-ins.\n" \
+                     "  2) Switch :gcov ↳ :untested_sources to :list to log untested files without compiling them.\n" \
+                     "  3) Switch :gcov ↳ :untested_sources to :ignore to disable this feature entirely.\n" \
+                     "See Gcov plugin docs for more explanation and recommendations.\n\n"
+            @loginator.log( notice, Verbosity::COMPLAIN, LogLabels::NOTICE )
+          end
+          raise ex
+        end
+      end
     end
   end
 
@@ -241,6 +290,26 @@ class Gcov < Plugin
 
   def utility_enabled?(opts, utility_name)
     return opts.map(&:upcase).include?( utility_name.upcase )
+  end
+
+  # Fail fast at plugin setup if :untested_sources holds anything other than a
+  # recognized mode symbol (e.g. a leftover TRUE/FALSE from before this option
+  # became an enum, or a typo'd symbol).
+  def validate_untested_sources(config)
+    value = config[:gcov_untested_sources]
+    if not GCOV_UNTESTED_SOURCES_OPTIONS.include?( value )
+      options = GCOV_UNTESTED_SOURCES_OPTIONS.map{ |opt| "':#{opt}'" }.join(', ')
+      msg = "Plugin configuration :gcov ↳ :untested_sources ➡️ `#{value.inspect}` is not a recognized option {#{options}}."
+      raise CeedlingException.new(msg)
+    end
+  end
+
+  # All project sources minus every source any test references — works whether that
+  # mapping came from a full test build (gcov:all) or a sources-only pass (gcov:untested_sources).
+  def collect_untested_sources(sources)
+    tested_sources = []
+    @test_invoker.each_test_with_sources { |_, srcs| tested_sources.concat( srcs ) }
+    return sources - tested_sources
   end
 
   def build_reportinators(config, enabled)

--- a/plugins/gcov/lib/gcov_constants.rb
+++ b/plugins/gcov/lib/gcov_constants.rb
@@ -41,6 +41,15 @@ GCOV_UTILITY_NAME_GCOVR = "gcovr"
 GCOV_UTILITY_NAME_REPORT_GENERATOR = "ReportGenerator"
 GCOV_UTILITY_NAMES = [GCOV_UTILITY_NAME_GCOVR, GCOV_UTILITY_NAME_REPORT_GENERATOR]
 
+# Untested Sources Processing Modes
+# :ignore  — Skip untested sources entirely (no logging, no compilation).
+# :list    — Log untested source filepaths as a warning; do not compile them.
+# :compile — Compile all untested sources with coverage instrumentation.
+GCOV_UNTESTED_SOURCES_IGNORE  = :ignore
+GCOV_UNTESTED_SOURCES_LIST    = :list
+GCOV_UNTESTED_SOURCES_COMPILE = :compile
+GCOV_UNTESTED_SOURCES_OPTIONS = [GCOV_UNTESTED_SOURCES_IGNORE, GCOV_UNTESTED_SOURCES_LIST, GCOV_UNTESTED_SOURCES_COMPILE]
+
 # Report Types
 class ReportTypes
   HTML_BASIC = "HtmlBasic"

--- a/spec/system/gcov_deployment_spec.rb
+++ b/spec/system/gcov_deployment_spec.rb
@@ -40,6 +40,10 @@ ceedling_system_tests do
       # test_case :project_with_gcov_success_because_of_ignore_uncovered_list
       # test_case :project_with_gcov_success_because_of_ignore_uncovered_list_with_globs
       test_case :project_with_gcov_compile_error
+      test_case :project_with_gcov_untested_sources_ignore
+      test_case :project_with_gcov_untested_sources_list
+      test_case :project_with_gcov_untested_sources_compile_failure
+      test_case :project_with_gcov_untested_sources_standalone_task
       test_case :help_tasks_include_gcov
       test_case :create_html_report
       test_case :create_html_report_with_gcovr_config_file_overrides_default

--- a/spec/system/support/gcov_common_test_cases.rb
+++ b/spec/system/support/gcov_common_test_cases.rb
@@ -427,8 +427,9 @@ module GcovCommonTestCases
         expect($?.exitstatus).not_to eq(0) # Fail-fast: compile failure fails the build
         expect(output).to match(/Compiling.+with coverage failed/)
         expect(output).to match(/:untested_sources.*:compile/)
-        expect(output).to match(/Switch :gcov ↳ :untested_sources to :list/)
-        expect(output).to match(/Switch :gcov ↳ :untested_sources to :ignore/)
+        # Avoid unicode character matching in log matching, since some shells may not support them.
+        expect(output).to match(/Switch :gcov.+:untested_sources to :list/)
+        expect(output).to match(/Switch :gcov.+:untested_sources to :ignore/)
       end
     end
   end

--- a/spec/system/support/gcov_common_test_cases.rb
+++ b/spec/system/support/gcov_common_test_cases.rb
@@ -426,7 +426,7 @@ module GcovCommonTestCases
         output = `bundle exec ruby -S ceedling gcov:all 2>&1`
         expect($?.exitstatus).not_to eq(0) # Fail-fast: compile failure fails the build
         expect(output).to match(/Compiling.+with coverage failed/)
-        expect(output).to match(/:untested_sources.*':compile'/)
+        expect(output).to match(/:untested_sources.*:compile/)
         expect(output).to match(/Switch :gcov ↳ :untested_sources to ':list'/)
         expect(output).to match(/Switch :gcov ↳ :untested_sources to ':ignore'/)
       end

--- a/spec/system/support/gcov_common_test_cases.rb
+++ b/spec/system/support/gcov_common_test_cases.rb
@@ -397,7 +397,7 @@ module GcovCommonTestCases
         output = `bundle exec ruby -S ceedling gcov:all 2>&1`
         expect($?.exitstatus).to match(0)
         # Immediate warning-level filepath listing (no compilation attempted).
-        expect(output).to match(/will NOT appear in the coverage report/)
+        expect(output).to match(/Untested.+not.+coverage report/)
         expect(output).to match(/uncovered_example_file\.c/)
         expect(output).not_to match(/Compiling with coverage.*uncovered_example_file/)
         # Post-build console summary still lists it (basename-keyed).
@@ -425,7 +425,7 @@ module GcovCommonTestCases
 
         output = `bundle exec ruby -S ceedling gcov:all 2>&1`
         expect($?.exitstatus).not_to eq(0) # Fail-fast: compile failure fails the build
-        expect(output).to match(/outside of its normal test suite build failed/)
+        expect(output).to match(/Compiling.+with coverage failed/)
         expect(output).to match(/:untested_sources.*':compile'/)
         expect(output).to match(/Switch :gcov ↳ :untested_sources to ':list'/)
         expect(output).to match(/Switch :gcov ↳ :untested_sources to ':ignore'/)

--- a/spec/system/support/gcov_common_test_cases.rb
+++ b/spec/system/support/gcov_common_test_cases.rb
@@ -427,8 +427,8 @@ module GcovCommonTestCases
         expect($?.exitstatus).not_to eq(0) # Fail-fast: compile failure fails the build
         expect(output).to match(/Compiling.+with coverage failed/)
         expect(output).to match(/:untested_sources.*:compile/)
-        expect(output).to match(/Switch :gcov ↳ :untested_sources to ':list'/)
-        expect(output).to match(/Switch :gcov ↳ :untested_sources to ':ignore'/)
+        expect(output).to match(/Switch :gcov ↳ :untested_sources to :list/)
+        expect(output).to match(/Switch :gcov ↳ :untested_sources to :ignore/)
       end
     end
   end

--- a/spec/system/support/gcov_common_test_cases.rb
+++ b/spec/system/support/gcov_common_test_cases.rb
@@ -362,4 +362,95 @@ module GcovCommonTestCases
       end
     end
   end
+
+  def project_with_gcov_untested_sources_ignore
+    @c.with_context do
+      Dir.chdir @proj_name do
+        prep_project_yml_for_coverage
+        add_gcov_option("untested_sources", ":ignore")
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        # Untested — no test references this source file.
+        FileUtils.cp test_asset_path("uncovered_example_file.c"), 'src/'
+
+        output = `bundle exec ruby -S ceedling gcov:all 2>&1`
+        expect($?.exitstatus).to match(0)
+        expect(output).not_to match(/Untested Source Files/)
+        expect(output).not_to match(/Processing Untested Sources/)
+        expect(output).not_to match(/uncovered_example_file/)
+      end
+    end
+  end
+
+  def project_with_gcov_untested_sources_list
+    @c.with_context do
+      Dir.chdir @proj_name do
+        prep_project_yml_for_coverage
+        add_gcov_option("untested_sources", ":list")
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        # Untested — no test references this source file.
+        FileUtils.cp test_asset_path("uncovered_example_file.c"), 'src/'
+
+        output = `bundle exec ruby -S ceedling gcov:all 2>&1`
+        expect($?.exitstatus).to match(0)
+        # Immediate warning-level filepath listing (no compilation attempted).
+        expect(output).to match(/will NOT appear in the coverage report/)
+        expect(output).to match(/uncovered_example_file\.c/)
+        expect(output).not_to match(/Compiling with coverage.*uncovered_example_file/)
+        # Post-build console summary still lists it (basename-keyed).
+        expect(output).to match(/Untested Source Files/)
+        expect(output).to match(/uncovered_example_file\.c \| No tests executed: 0% coverage/)
+      end
+    end
+  end
+
+  def project_with_gcov_untested_sources_compile_failure
+    @c.with_context do
+      Dir.chdir @proj_name do
+        prep_project_yml_for_coverage
+        add_gcov_option("untested_sources", ":compile")
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        # Untested source with a syntax error — fails to compile regardless of
+        # any :defines/:flags, deliberately triggering the guidance notice.
+        File.write('src/broken_uncovered_file.c', <<~C)
+          int broken_uncovered_function(int a, int b) {
+            return a + b // Missing semicolon and closing brace: guaranteed compile error.
+        C
+
+        output = `bundle exec ruby -S ceedling gcov:all 2>&1`
+        expect($?.exitstatus).not_to eq(0) # Fail-fast: compile failure fails the build
+        expect(output).to match(/outside of its normal test suite build failed/)
+        expect(output).to match(/:untested_sources.*':compile'/)
+        expect(output).to match(/Switch :gcov ↳ :untested_sources to ':list'/)
+        expect(output).to match(/Switch :gcov ↳ :untested_sources to ':ignore'/)
+      end
+    end
+  end
+
+  def project_with_gcov_untested_sources_standalone_task
+    @c.with_context do
+      Dir.chdir @proj_name do
+        prep_project_yml_for_coverage
+        add_gcov_option("untested_sources", ":compile")
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        # Untested — no test references this source file.
+        FileUtils.cp test_asset_path("uncovered_example_file.c"), 'src/'
+
+        # Run the standalone task directly — no prior `gcov:all` in this invocation,
+        # so no test fixture is ever built or executed.
+        output = `bundle exec ruby -S ceedling gcov:untested_sources 2>&1`
+        expect($?.exitstatus).to match(0)
+        expect(output).not_to match(/TESTED:\s+\d/) # No test build/run occurred
+        expect(File.exist?('build/gcov/out/uncovered_example_file.o')).to eq true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Instead of `:untested_sources` being a boolean, it now supports different modes: `:ignore`, `:list`, `:compile`.