### PR TITLE
Add missing NORMAL logging to Partials/mocks stages; skip them entirely when empty

### DIFF
--- a/lib/ceedling/generators/generator.rb
+++ b/lib/ceedling/generators/generator.rb
@@ -40,7 +40,14 @@ class Generator
   # rather than duplicated by generate_partial_implementation and generate_partial_interface.
   # Returns the bare generated filename (for the caller to add to each header's own includes
   # list) or nil when the module has no typedefs or aggregate definitions to share.
-  def generate_partial_types(name:, c_module:, output_path:)
+  def generate_partial_types(name:, partial:, c_module:, output_path:)
+    msg = @reportinator.generate_module_progress(
+      operation: "Generating shared Partial types for",
+      module_name: name,
+      filename: partial # Partial module name, not filename
+    )
+    @loginator.log( msg )
+
     arg_hash = {
       :name => name,
       :c_module => c_module,

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -389,6 +389,7 @@ test_pipeline_manager:
     - test_build_executor
     - configurator
     - batchinator
+    - loginator
 
 test_build_setup:
   compose:

--- a/lib/ceedling/test_invoker/test_build_executor.rb
+++ b/lib/ceedling/test_invoker/test_build_executor.rb
@@ -74,19 +74,26 @@ class TestBuildExecutor
       details.preprocessed_target = target
       details.stale               = @dependinator.stale?( target )
 
-      next if details.stale
+      if details.stale
+        msg = @reportinator.generate_module_progress(
+          operation:   'Preprocessing partial header for',
+          module_name: name,
+          filename:    File.basename( config.filepath )
+        )
+        @loginator.log( msg )
+      else
+        msg = @reportinator.generate_module_progress(
+          operation:   'Skipping partial header preprocessing for',
+          module_name: name,
+          filename:    File.basename( config.filepath )
+        )
+        @loginator.log( msg, Verbosity::OBNOXIOUS )
+        skipped += 1
 
-      msg = @reportinator.generate_module_progress(
-        operation:   'Skipping partial header preprocessing for',
-        module_name: name,
-        filename:    File.basename( config.filepath )
-      )
-      @loginator.log( msg, Verbosity::OBNOXIOUS )
-      skipped += 1
-
-      config.directives_only_filepath = target
-      config.includes                 = @preprocessinator.load_includes_list( test: name, filepath: config.filepath )
-      config.full_expansion_filepath  = @file_path_utils.form_preprocessed_file_full_expansion_filepath( config.filepath, name )
+        config.directives_only_filepath = target
+        config.includes                 = @preprocessinator.load_includes_list( test: name, filepath: config.filepath )
+        config.full_expansion_filepath  = @file_path_utils.form_preprocessed_file_full_expansion_filepath( config.filepath, name )
+      end
     end
 
     log_skip_summary( task: "partial header preprocessing", count: skipped, noun: "headers" )
@@ -180,19 +187,26 @@ class TestBuildExecutor
       details.preprocessed_target = target
       details.stale               = @dependinator.stale?( target )
 
-      next if details.stale
+      if details.stale
+        msg = @reportinator.generate_module_progress(
+          operation:   'Preprocessing partial source for',
+          module_name: name,
+          filename:    File.basename( config.filepath )
+        )
+        @loginator.log( msg )
+      else
+        msg = @reportinator.generate_module_progress(
+          operation:   'Skipping partial source preprocessing for',
+          module_name: name,
+          filename:    File.basename( config.filepath )
+        )
+        @loginator.log( msg, Verbosity::OBNOXIOUS )
+        skipped += 1
 
-      msg = @reportinator.generate_module_progress(
-        operation:   'Skipping partial source preprocessing for',
-        module_name: name,
-        filename:    File.basename( config.filepath )
-      )
-      @loginator.log( msg, Verbosity::OBNOXIOUS )
-      skipped += 1
-
-      config.directives_only_filepath = target
-      config.includes                 = @preprocessinator.load_includes_list( test: name, filepath: config.filepath )
-      config.full_expansion_filepath  = @file_path_utils.form_preprocessed_file_full_expansion_filepath( config.filepath, name )
+        config.directives_only_filepath = target
+        config.includes                 = @preprocessinator.load_includes_list( test: name, filepath: config.filepath )
+        config.full_expansion_filepath  = @file_path_utils.form_preprocessed_file_full_expansion_filepath( config.filepath, name )
+      end
     end
 
     log_skip_summary( task: "partial source preprocessing", count: skipped, noun: "sources" )
@@ -302,6 +316,7 @@ class TestBuildExecutor
       # exactly one C definition of each of its typedefs and aggregate types.
       types_header = @generator.generate_partial_types(
         name:        name,
+        partial:     config.module,
         c_module:    module_contents,
         output_path: testable.paths[:partials]
       )

--- a/lib/ceedling/test_invoker/test_invoker_types.rb
+++ b/lib/ceedling/test_invoker/test_invoker_types.rb
@@ -90,9 +90,25 @@ module TestInvokerTypes
   end
 
   # Describes one pipeline step — either a named build_step or a silent transform.
-  Stage = Struct.new(:name, :heading, :condition, :transform, :body, keyword_init: true) do
-    def run?(state)
+  # `condition` gates whether this stage's feature is in play at all for the project
+  # (e.g. Partials or mocking enabled) -- when false, the stage is skipped in total
+  # silence, exactly as if it didn't exist. `empty_condition` (nil for most stages)
+  # gates a narrower case: the feature IS enabled, but this particular run happens to
+  # have none of that stage's kind of work to do -- when true, the stage's heading and
+  # body are both skipped, but `empty_notice` is logged at OBNOXIOUS so a verbose run
+  # can still see that the stage was considered and correctly found nothing to do,
+  # distinct from the feature being off project-wide.
+  Stage = Struct.new(:name, :heading, :condition, :empty_condition, :empty_notice, :transform, :body, keyword_init: true) do
+    def enabled?(state)
       condition.nil? || condition.call(state)
+    end
+
+    def empty?(state)
+      !empty_condition.nil? && empty_condition.call(state)
+    end
+
+    def run?(state)
+      enabled?(state) && !empty?(state)
     end
   end
 

--- a/lib/ceedling/test_invoker/test_pipeline_manager.rb
+++ b/lib/ceedling/test_invoker/test_pipeline_manager.rb
@@ -22,7 +22,8 @@ class TestPipelineManager
     :test_build_planner,
     :test_build_executor,
     :configurator,
-    :batchinator
+    :batchinator,
+    :loginator
   )
 
   # `options:` (an Array of Symbols; see `TestInvoker#setup_and_invoke`) is a flat
@@ -56,7 +57,12 @@ class TestPipelineManager
     validate_stop_point_options!( state.options )
 
     build_stage_sequence().each do |stage|
-      next unless stage.run?( state )
+      next unless stage.enabled?( state )
+
+      if stage.empty?( state )
+        @loginator.log( "#{stage.name}: #{stage.empty_notice}", Verbosity::OBNOXIOUS )
+        next
+      end
 
       if stage.transform
         stage.body.call( state )
@@ -128,19 +134,25 @@ class TestPipelineManager
 
       # Stage 6
       stage("Preprocessing for Testing & Mocking Partials",
-            condition: use_partials,
+            condition:       use_partials,
+            empty_condition: ->(s) { s.partials_headers.empty? },
+            empty_notice:    "no Partials to process",
             body: ->(s) { @test_build_executor.stage_preprocess_partial_headers(s) }
       ),
 
       # Stage 7
       stage("Preprocessing for Testing Partials",
-            condition: use_partials,
+            condition:       use_partials,
+            empty_condition: ->(s) { s.partials_sources.empty? },
+            empty_notice:    "no Partials to process",
             body: ->(s) { @test_build_executor.stage_preprocess_partial_sources(s) }
       ),
 
       # Stage 8
       stage("Partials",
-            condition: use_partials,
+            condition:       use_partials,
+            empty_condition: ->(s) { s.partials_headers.empty? && s.partials_sources.empty? },
+            empty_notice:    "no Partials to generate",
             body: ->(s) { @test_build_executor.stage_generate_partials(s) }
       ),
 
@@ -152,13 +164,17 @@ class TestPipelineManager
 
       # Stage 9
       stage("Preprocessing for Mocks",
-            condition: use_mocks_preproc,
+            condition:       use_mocks_preproc,
+            empty_condition: ->(s) { s.mocks_list.empty? },
+            empty_notice:    "no mocks to process",
             body: ->(s) { @test_build_executor.stage_preprocess_mocks(s) }
       ),
 
       # Stage 10 — the :mocking stop point runs through here, then halts.
       stage("Mocking",
-            condition: use_mocks,
+            condition:       use_mocks,
+            empty_condition: ->(s) { s.mocks_list.empty? },
+            empty_notice:    "no mocks to generate",
             body: ->(s) { @test_build_executor.stage_generate_mocks(s) }
       ),
 
@@ -220,13 +236,15 @@ class TestPipelineManager
     ]
   end
 
-  def stage(name = nil, heading: true, condition: nil, transform: false, body:)
+  def stage(name = nil, heading: true, condition: nil, empty_condition: nil, empty_notice: nil, transform: false, body:)
     Stage.new(
-      name:      name,
-      heading:   heading,
-      condition: condition,
-      transform: transform,
-      body:      body
+      name:            name,
+      heading:         heading,
+      condition:       condition,
+      empty_condition: empty_condition,
+      empty_notice:    empty_notice,
+      transform:       transform,
+      body:            body
     )
   end
 

--- a/spec/units/test_build_executor_spec.rb
+++ b/spec/units/test_build_executor_spec.rb
@@ -741,6 +741,33 @@ describe TestBuildExecutor do
 
       @executor.stage_preprocess_partial_headers( @state )
     end
+
+    it "logs a NORMAL progress line for a header that needs preprocessing, and no OBNOXIOUS skip line" do
+      allow(@configurator).to receive(:test_build_preprocess_directives_only_available).and_return( true )
+      allow(@dependinator).to receive(:stale?).and_return( true )
+      allow(@reportinator).to receive(:generate_module_progress)
+        .with( operation: 'Preprocessing partial header for', module_name: 'a_test', filename: 'Foo.h' )
+        .and_return( 'Preprocessing partial header for a_test::Foo.h...' )
+
+      expect(@loginator).to receive(:log).with( 'Preprocessing partial header for a_test::Foo.h...' )
+      expect(@loginator).to_not receive(:log).with( anything, Verbosity::OBNOXIOUS )
+
+      @executor.stage_preprocess_partial_headers( @state )
+    end
+
+    it "logs an OBNOXIOUS skip line for a header recalled from cache, and no NORMAL preprocessing line" do
+      allow(@configurator).to receive(:test_build_preprocess_directives_only_available).and_return( true )
+      allow(@dependinator).to receive(:stale?).and_return( false )
+      allow(@reportinator).to receive(:generate_module_progress)
+        .with( operation: 'Skipping partial header preprocessing for', module_name: 'a_test', filename: 'Foo.h' )
+        .and_return( 'Skipping partial header preprocessing for a_test::Foo.h...' )
+
+      expect(@loginator).to receive(:log).with( 'Skipping partial header preprocessing for a_test::Foo.h...', Verbosity::OBNOXIOUS )
+      expect(@reportinator).to_not receive(:generate_module_progress)
+        .with( operation: 'Preprocessing partial header for', module_name: anything, filename: anything )
+
+      @executor.stage_preprocess_partial_headers( @state )
+    end
   end
 
   context "#stage_preprocess_partial_sources" do
@@ -806,6 +833,33 @@ describe TestBuildExecutor do
       expect( @config.directives_only_filepath ).to eq( 'build/preprocess/Foo.c' )
       expect( @config.includes ).to eq( cached_includes )
       expect( @config.full_expansion_filepath ).to eq( 'build/preprocess/full_expansion/Foo.c' )
+    end
+
+    it "logs a NORMAL progress line for a source that needs preprocessing, and no OBNOXIOUS skip line" do
+      allow(@configurator).to receive(:test_build_preprocess_directives_only_available).and_return( true )
+      allow(@dependinator).to receive(:stale?).and_return( true )
+      allow(@reportinator).to receive(:generate_module_progress)
+        .with( operation: 'Preprocessing partial source for', module_name: 'a_test', filename: 'Foo.c' )
+        .and_return( 'Preprocessing partial source for a_test::Foo.c...' )
+
+      expect(@loginator).to receive(:log).with( 'Preprocessing partial source for a_test::Foo.c...' )
+      expect(@loginator).to_not receive(:log).with( anything, Verbosity::OBNOXIOUS )
+
+      @executor.stage_preprocess_partial_sources( @state )
+    end
+
+    it "logs an OBNOXIOUS skip line for a source recalled from cache, and no NORMAL preprocessing line" do
+      allow(@configurator).to receive(:test_build_preprocess_directives_only_available).and_return( true )
+      allow(@dependinator).to receive(:stale?).and_return( false )
+      allow(@reportinator).to receive(:generate_module_progress)
+        .with( operation: 'Skipping partial source preprocessing for', module_name: 'a_test', filename: 'Foo.c' )
+        .and_return( 'Skipping partial source preprocessing for a_test::Foo.c...' )
+
+      expect(@loginator).to receive(:log).with( 'Skipping partial source preprocessing for a_test::Foo.c...', Verbosity::OBNOXIOUS )
+      expect(@reportinator).to_not receive(:generate_module_progress)
+        .with( operation: 'Preprocessing partial source for', module_name: anything, filename: anything )
+
+      @executor.stage_preprocess_partial_sources( @state )
     end
   end
 

--- a/spec/units/test_invoker_types_spec.rb
+++ b/spec/units/test_invoker_types_spec.rb
@@ -128,5 +128,63 @@ describe "TestInvokerTypes" do
       expect(stage.run?( TestInvokerTypes::PipelineState.new( options: [:build_only] ) )).to be true
       expect(stage.run?( TestInvokerTypes::PipelineState.new( options: [] ) )).to be false
     end
+
+    describe "#enabled? and #empty?" do
+      it "is enabled whenever its condition returns true, regardless of empty_condition" do
+        stage = TestInvokerTypes::Stage.new(
+          name: 'A stage', condition: ->(_s) { true }, empty_condition: ->(_s) { true }, body: ->(_s) {}
+        )
+
+        expect(stage.enabled?( nil )).to be true
+      end
+
+      it "is not enabled when its condition returns false" do
+        stage = TestInvokerTypes::Stage.new( name: 'A stage', condition: ->(_s) { false }, body: ->(_s) {} )
+
+        expect(stage.enabled?( nil )).to be false
+      end
+
+      it "is never empty when given no empty_condition" do
+        stage = TestInvokerTypes::Stage.new( name: 'A stage', body: ->(_s) {} )
+
+        expect(stage.empty?( nil )).to be false
+      end
+
+      it "is empty only when its empty_condition returns true" do
+        stage = TestInvokerTypes::Stage.new(
+          name: 'A stage', empty_condition: ->(s) { s.mocks_list.empty? }, body: ->(_s) {}
+        )
+
+        expect(stage.empty?( TestInvokerTypes::PipelineState.new( mocks_list: [] ) )).to be true
+        expect(stage.empty?( TestInvokerTypes::PipelineState.new( mocks_list: [double("Mock")] ) )).to be false
+      end
+
+      it "does not run when enabled but empty, though it remains enabled" do
+        stage = TestInvokerTypes::Stage.new(
+          name: 'A stage',
+          condition:       ->(_s) { true },
+          empty_condition: ->(s) { s.mocks_list.empty? },
+          body:            ->(_s) {}
+        )
+        state = TestInvokerTypes::PipelineState.new( mocks_list: [] )
+
+        expect(stage.enabled?( state )).to be true
+        expect(stage.empty?( state )).to be true
+        expect(stage.run?( state )).to be false
+      end
+
+      it "does not run when disabled, even if it would otherwise have work to do" do
+        stage = TestInvokerTypes::Stage.new(
+          name: 'A stage',
+          condition:       ->(_s) { false },
+          empty_condition: ->(s) { s.mocks_list.empty? },
+          body:            ->(_s) {}
+        )
+        state = TestInvokerTypes::PipelineState.new( mocks_list: [double("Mock")] )
+
+        expect(stage.enabled?( state )).to be false
+        expect(stage.run?( state )).to be false
+      end
+    end
   end
 end

--- a/spec/units/test_pipeline_manager_spec.rb
+++ b/spec/units/test_pipeline_manager_spec.rb
@@ -17,8 +17,10 @@ describe TestPipelineManager do
     @test_build_executor  = double( "TestBuildExecutor" )
     @configurator         = double( "Configurator" )
     @batchinator          = double( "Batchinator" )
+    @loginator            = double( "Loginator" )
 
     allow(@batchinator).to receive(:build_step) { |*_args, &block| block.call }
+    allow(@loginator).to receive(:log)
 
     allow(@configurator).to receive(:project_use_test_preprocessor_tests).and_return( false )
     allow(@configurator).to receive(:project_use_partials).and_return( false )
@@ -54,13 +56,23 @@ describe TestPipelineManager do
         :test_build_planner  => @test_build_planner,
         :test_build_executor => @test_build_executor,
         :configurator        => @configurator,
-        :batchinator         => @batchinator
+        :batchinator         => @batchinator,
+        :loginator           => @loginator
       }
     )
   end
 
-  def state(options: [])
-    TestInvokerTypes::PipelineState.new( :testables => {}, :context => :test, :options => options )
+  # Defaults every flattened list to non-empty, real-shaped-enough content, so every
+  # existing test below exercises the "has work to do" path without having to know or
+  # care about T1/T2's output -- exactly as it would if a project had at least one
+  # Partial and one mock. Tests specifically about the "enabled but nothing to do this
+  # run" case (below) override one or more of these to `[]`.
+  def state(options: [], partials_headers: [double("PartialWork")], partials_sources: [double("PartialWork")], mocks_list: [double("MockWork")])
+    TestInvokerTypes::PipelineState.new(
+      :testables        => {}, :context => :test, :options => options,
+      :partials_headers => partials_headers, :partials_sources => partials_sources, :mocks_list => mocks_list,
+      :objects_list     => []
+    )
   end
 
   describe "#run" do
@@ -207,7 +219,7 @@ describe TestPipelineManager do
     end
 
     context "when Partials is disabled" do
-      it "skips the Partials transform and its three stages, independent of any stop-point option" do
+      it "skips the Partials transform and its three stages, independent of any stop-point option, in total silence" do
         allow(@configurator).to receive(:project_use_partials).and_return( false )
 
         expect(@test_build_planner).to_not receive(:stage_flatten_partials_lists)
@@ -215,21 +227,61 @@ describe TestPipelineManager do
         expect(@test_build_executor).to_not receive(:stage_preprocess_partial_sources)
         expect(@test_build_executor).to_not receive(:stage_generate_partials)
         expect(@test_build_planner).to receive(:stage_determine_files)
+        expect(@loginator).to_not receive(:log)
 
         @manager.run( state(options: []) )
       end
     end
 
     context "when mocking is disabled" do
-      it "skips the mocks transform and both mocking stages, independent of any stop-point option" do
+      it "skips the mocks transform and both mocking stages, independent of any stop-point option, in total silence" do
         allow(@configurator).to receive(:project_use_mocks).and_return( false )
 
         expect(@test_build_planner).to_not receive(:stage_flatten_mocks_list)
         expect(@test_build_executor).to_not receive(:stage_preprocess_mocks)
         expect(@test_build_executor).to_not receive(:stage_generate_mocks)
         expect(@test_build_executor).to receive(:stage_generate_runners)
+        expect(@loginator).to_not receive(:log)
 
         @manager.run( state(options: []) )
+      end
+    end
+
+    context "when Partials is enabled but this run has no Partials" do
+      it "skips the three Partials stages and logs an OBNOXIOUS notice for each, instead of running them" do
+        allow(@configurator).to receive(:project_use_partials).and_return( true )
+
+        expect(@test_build_planner).to receive(:stage_flatten_partials_lists)
+        expect(@test_build_executor).to_not receive(:stage_preprocess_partial_headers)
+        expect(@test_build_executor).to_not receive(:stage_preprocess_partial_sources)
+        expect(@test_build_executor).to_not receive(:stage_generate_partials)
+
+        expect(@loginator).to receive(:log)
+          .with( "Preprocessing for Testing & Mocking Partials: no Partials to process", Verbosity::OBNOXIOUS )
+        expect(@loginator).to receive(:log)
+          .with( "Preprocessing for Testing Partials: no Partials to process", Verbosity::OBNOXIOUS )
+        expect(@loginator).to receive(:log)
+          .with( "Partials: no Partials to generate", Verbosity::OBNOXIOUS )
+
+        @manager.run( state(options: [], partials_headers: [], partials_sources: []) )
+      end
+    end
+
+    context "when mocking is enabled but this run has no mocks" do
+      it "skips both mocking stages and logs an OBNOXIOUS notice for each, instead of running them" do
+        allow(@configurator).to receive(:project_use_mocks).and_return( true )
+        allow(@configurator).to receive(:project_use_test_preprocessor_mocks).and_return( true )
+
+        expect(@test_build_planner).to receive(:stage_flatten_mocks_list)
+        expect(@test_build_executor).to_not receive(:stage_preprocess_mocks)
+        expect(@test_build_executor).to_not receive(:stage_generate_mocks)
+
+        expect(@loginator).to receive(:log)
+          .with( "Preprocessing for Mocks: no mocks to process", Verbosity::OBNOXIOUS )
+        expect(@loginator).to receive(:log)
+          .with( "Mocking: no mocks to generate", Verbosity::OBNOXIOUS )
+
+        @manager.run( state(options: [], mocks_list: []) )
       end
     end
 


### PR DESCRIPTION
## Summary

Two stacked commits fixing related logging gaps in the test pipeline's Partials and mocks stages.

**Commit 1** -- at default verbosity, "Preprocessing for Testing & Mocking Partials", "Preprocessing for Testing Partials", and "Partials" printed their headings with nothing logged underneath, even though real work was happening -- unlike every sibling stage in the same pipeline. Confirmed via git history: never present, not removed.
- Restructures `stage_preprocess_partial_headers`/`stage_preprocess_partial_sources`'s per-item staleness check into an explicit `if/else` so the stale (real-work) branch gets a NORMAL progress line symmetric with the existing OBNOXIOUS skip line.
- Adds a matching log call to `Generator#generate_partial_types` (now taking the partial's own module name, like its siblings `generate_partial_implementation`/`generate_partial_interface` already do), so every partial logs at least one line under "Partials" regardless of whether its extraction yields a separate implementation or interface.

**Commit 2** -- manual verification of commit 1 surfaced a further, related gap: a stage whose *feature* is enabled project-wide (Partials, mocking) still printed its full heading and ran its body even when *this particular run* had none of that stage's kind of work to do.
- `Stage` (in `test_invoker_types.rb`) gains `empty_condition`/`empty_notice` alongside its existing `condition`, and `enabled?`/`empty?` predicates (`run?` is now their combination, unchanged for every existing caller).
- `TestPipelineManager#run`: when a stage's feature is enabled but this run's flattened `partials_headers`/`partials_sources`/`mocks_list` is empty, its heading and body are skipped and a single OBNOXIOUS line notes there was nothing to do -- covering all five headings: "Preprocessing for Testing & Mocking Partials", "Preprocessing for Testing Partials", "Partials", "Preprocessing for Mocks", and "Mocking". This is distinct from the fully-silent skip that already happens when the feature is off project-wide.

## Test plan
- [x] `bundle exec rspec spec/units/` -- 2414 examples, 0 failures, 1 pre-existing pending
- [x] New/expanded unit coverage in `test_build_executor_spec.rb`, `test_invoker_types_spec.rb`, and `test_pipeline_manager_spec.rb` for both the new per-item logging and the new empty-stage gating (including confirming the pre-existing "feature disabled" case stays fully silent, distinct from the new "enabled but empty" case)
- [x] End-to-end verification against the `wondrous_forest` example project:
  - A full `test:all` run (every test uses mocks and Partials) shows unchanged, full per-item output under all five headings
  - A scoped `test:pattern[UartDriver]` run against its one mock/Partial-free test shows none of the five headings at default verbosity, and the correct OBNOXIOUS notice for each at `--verbosity=obnoxious`