### PR TITLE
Preserve system include paths in Partials

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -45,6 +45,7 @@ Because of the support added for handling paths and distinguishing duplicated fi
 
 ### Partials
 
+- [#1194](https://github.com/ThrowTheSwitch/Ceedling/issues/1194) Fixed generated Partials stripping directory components from system include directives (e.g. `<sys/stat.h>` becoming `<stat.h>`).
 - [#1189](https://github.com/ThrowTheSwitch/Ceedling/issues/1189)/[#1187](https://github.com/ThrowTheSwitch/Ceedling/issues/1187) Fixed `const`/`volatile`/`restrict` qualifiers stripped from a Partial's generated `extern` declaration and definition for a promoted variable.
 - Fixed C variable extraction discarding a pointer's own qualifier (e.g. the second `const` in `const uint8_t* const ptr;`) whenever the same qualifier keyword also led the declaration.
 - [#1190](https://github.com/ThrowTheSwitch/Ceedling/issues/1190)/[#1187](https://github.com/ThrowTheSwitch/Ceedling/issues/1187) Fixed a module's typedefs and aggregate (struct/enum/union) definitions being generated into both its Test Partial and Mock Partial headers, causing a redefinition error when a test file uses both for the same module. Such content is now generated once into a shared header with unique include guard that both Partial headers, in turn, include.
@@ -755,4 +756,3 @@ If you want to incorporate environment variables into your tool definitions, you
 This project setting existed from Ceedling’s earliest days and was a crude stand-in for command line debug verbosity handling.
 
 It has been removed as it was rarely if ever utilized and needlessly complicated internal mechanisms for verbosity handling and project validation.
-

--- a/lib/ceedling/includes/includes.rb
+++ b/lib/ceedling/includes/includes.rb
@@ -39,10 +39,13 @@ class Includes
         else raise ArgumentError, "Unknown Include type: #{include.class}"
         end
 
-      {
+      hash = {
         'type' => type,
         'filepath' => include.filepath,
       }
+      hash['use_path'] = true if include.use_path
+      hash['include_path'] = include.include_path if include.include_path
+      hash
     end
   end
 
@@ -70,11 +73,11 @@ class Includes
       
       case hash['type']
       when 'user'
-        UserInclude.new(hash['filepath'])
+        UserInclude.new(hash['filepath'], use_path: hash.fetch('use_path', false), include_path: hash['include_path'])
       when 'mock'
         MockInclude.new(hash['filepath'])
       when 'system'
-        SystemInclude.new(hash['filepath'])
+        SystemInclude.new(hash['filepath'], use_path: hash.fetch('use_path', false), include_path: hash['include_path'])
       when 'bare'
         Include.new(hash['filepath'])
       else
@@ -208,6 +211,10 @@ class Includes
 
     system_includes = system.select do |include|
       bare_filenames.include?(include.filename)
+    end.map do |include|
+      original = bare.find { |bare_include| paths_correspond?(bare_include.filepath, include.filepath) } ||
+        bare.find { |bare_include| bare_include.filename == include.filename }
+      SystemInclude.new(include.filepath, include_path: original.filepath)
     end
 
     user_filepaths = user.map(&:filepath)
@@ -285,6 +292,8 @@ class Include
   attr_reader :filepath
   attr_reader :filename
   attr_reader :path
+  attr_reader :use_path
+  attr_reader :include_path
 
   # Initialize an Include object from a C include statement or simple filepath.
   #
@@ -297,7 +306,7 @@ class Include
   #  - If true, use the full filepath in the include directive
   #  - If false, use only the filename
   # @raise [ArgumentError] If the statement is empty or becomes empty after cleaning
-  def initialize(statement, use_path: false)
+  def initialize(statement, use_path: false, include_path: nil)
     @filepath = clean(statement)
 
     raise ArgumentError, "Empty include statement" if @filepath.empty?
@@ -305,6 +314,7 @@ class Include
     @filename = File.basename(@filepath)
     @path = File.dirname(@filepath)
     @use_path = use_path
+    @include_path = clean(include_path) if include_path
   end
 
   # Method specialized by subclasses
@@ -363,6 +373,7 @@ class Include
 
   # Returns the configured entry to use in the include directive
   def include()
+    return @include_path if @include_path
     @use_path ? @filepath : @filename
   end
 

--- a/lib/ceedling/includes/includes.rb
+++ b/lib/ceedling/includes/includes.rb
@@ -43,7 +43,9 @@ class Includes
         'type' => type,
         'filepath' => include.filepath,
       }
-      hash['use_path'] = true if include.use_path
+      # `include_path` is only ever meaningful on a reconciled UserInclude/SystemInclude,
+      # so it's written only when actually set -- a cached build's YAML stays
+      # uncluttered for the common, plain case.
       hash['include_path'] = include.include_path if include.include_path
       hash
     end
@@ -73,11 +75,11 @@ class Includes
       
       case hash['type']
       when 'user'
-        UserInclude.new(hash['filepath'], use_path: hash.fetch('use_path', false), include_path: hash['include_path'])
+        UserInclude.new(hash['filepath'], include_path: hash['include_path'])
       when 'mock'
         MockInclude.new(hash['filepath'])
       when 'system'
-        SystemInclude.new(hash['filepath'], use_path: hash.fetch('use_path', false), include_path: hash['include_path'])
+        SystemInclude.new(hash['filepath'], include_path: hash['include_path'])
       when 'bare'
         Include.new(hash['filepath'])
       else
@@ -184,6 +186,27 @@ class Includes
   # candidate module Ceedling needs to build -- there's no project-identity question here
   # worth hard-erroring over.
   #
+  # A matched system include's `filepath` is its real, resolved location (possibly
+  # absolute), which is what identity and deduplication need but is wrong to render
+  # verbatim into a generated file. Each matched system include is therefore rebuilt
+  # carrying `include_path:` recovered from `bare` -- the original, as-written directive
+  # text -- via `best_bare_match`, so `<sys/stat.h>` renders as written instead of
+  # collapsing to `<stat.h>`.
+  #
+  # A matched user include is deliberately left rendering filename-only, even when its
+  # own `#include` was genuinely subdirectory-qualified as written. Recovering "the
+  # original spelling" from `bare` the same way system includes do isn't safe here: a
+  # quoted include's bare-includes pass still performs GCC's standard directory-relative
+  # search for the including file (nothing about `-nostdinc` suppresses that), so a bare
+  # `#include "Types.h"` inside `src/LightSensor.h` resolves in the bare pass itself to
+  # `src/Types.h`, the moment a real `src/Types.h` exists on disk -- there's no literal
+  # spelling left in `bare` to recover at that point. Rendering that resolved path
+  # verbatim breaks Ceedling's own convention of adding every source directory as its
+  # own search path (`src/Types.h` isn't found via a `-Isrc` search path; only
+  # `Types.h` is). A system include's bare entry never has this problem: `<...>`
+  # includes are never resolved against a real file under `-nostdinc`, so its bare text
+  # is always exactly what was written.
+  #
   # `test_filepath` plays no part in matching -- it's carried only so the ambiguity error
   # below can name the one test file whose #include statement actually needs editing,
   # since nothing further up the call stack adds that context on its own.
@@ -212,8 +235,7 @@ class Includes
     system_includes = system.select do |include|
       bare_filenames.include?(include.filename)
     end.map do |include|
-      original = bare.find { |bare_include| paths_correspond?(bare_include.filepath, include.filepath) } ||
-        bare.find { |bare_include| bare_include.filename == include.filename }
+      original = best_bare_match(bare, include.filepath)
       SystemInclude.new(include.filepath, include_path: original.filepath)
     end
 
@@ -240,6 +262,9 @@ class Includes
         filepath = matched.first
         next if seen.include?(filepath)
         seen << filepath
+        # Deliberately not carrying an include_path override here -- see the class
+        # comment above `reconcile` for why that isn't safe for a user include the way
+        # it is for a system include. This renders filename-only, same as it always has.
         user_includes << user_by_filepath[filepath]
       else
         location = test_filepath ? " within '#{test_filepath}'" : ''
@@ -267,6 +292,27 @@ class Includes
   end
   private_class_method :paths_correspond?
 
+  # Finds the bare entry that best identifies a resolved system include's original,
+  # as-written spelling. A bare entry carries no information about whether its own
+  # #include was quoted or bracketed -- PreprocessinatorBareIncludesExtractor can't see
+  # that far -- so a project's own same-named quoted include (`#include "stat.h"`) can
+  # sit in `bare` right alongside a system one (`#include <sys/stat.h>`). Preferring the
+  # *longest* path correspondence, rather than merely the first one found, keeps a short,
+  # unrelated bare entry -- which trivially "corresponds" to any longer resolved path
+  # ending in the same filename -- from shadowing the correct, more specific entry.
+  # Falls back to the longest same-filename candidate, even without path correspondence,
+  # only when the compiler's real search-path structure doesn't literally match the
+  # directive's own spelling (a symlinked or vendored include root, for instance) --
+  # this still can't happen for the filename-only match itself, since `system_includes`
+  # was only reached because some bare entry already shares this filename.
+  def self.best_bare_match(bare, filepath)
+    candidates = bare.select { |bare_include| bare_include.filename == File.basename(filepath) }
+    corresponding = candidates.select { |bare_include| paths_correspond?(bare_include.filepath, filepath) }
+    pool = corresponding.empty? ? candidates : corresponding
+    return pool.max_by { |bare_include| bare_include.filepath.split(/[\\\/]/).reject(&:empty?).length }
+  end
+  private_class_method :best_bare_match
+
   # Sort list so system includes are at the beginning
   # (Best practice)
   def self.sort(includes)
@@ -292,7 +338,6 @@ class Include
   attr_reader :filepath
   attr_reader :filename
   attr_reader :path
-  attr_reader :use_path
   attr_reader :include_path
 
   # Initialize an Include object from a C include statement or simple filepath.
@@ -302,18 +347,20 @@ class Include
   #  - #include <stdio.h>
   #  - A quoted/bracketed filepath (e.g., '"header.h"' or <stdio.h>')
   #  - A plain filepath (e.g., 'path/to/header.h')
-  # @param use_path [Boolean] (default: false)
-  #  - If true, use the full filepath in the include directive
-  #  - If false, use only the filename
+  # @param include_path [String, nil] (default: nil)
+  #  - When set, this exact spelling is used in the include directive, taking
+  #    precedence over `filepath`/`filename`. This exists for a reconciled
+  #    UserInclude/SystemInclude, whose `filepath` is deliberately the header's real,
+  #    resolved location (needed elsewhere for identity -- see `Includes.sanitize!`)
+  #    rather than the original, as-written directive text a reconciled render needs.
   # @raise [ArgumentError] If the statement is empty or becomes empty after cleaning
-  def initialize(statement, use_path: false, include_path: nil)
+  def initialize(statement, include_path: nil)
     @filepath = clean(statement)
 
     raise ArgumentError, "Empty include statement" if @filepath.empty?
 
     @filename = File.basename(@filepath)
     @path = File.dirname(@filepath)
-    @use_path = use_path
     @include_path = clean(include_path) if include_path
   end
 
@@ -374,7 +421,7 @@ class Include
   # Returns the configured entry to use in the include directive
   def include()
     return @include_path if @include_path
-    @use_path ? @filepath : @filename
+    @filename
   end
 
   private

--- a/spec/units/includes/include_spec.rb
+++ b/spec/units/includes/include_spec.rb
@@ -30,9 +30,9 @@ describe UserInclude do
       expect(include_obj).to eq('header.h')
     end
 
-    it "creates a UserInclude with a path and used path in string expansion" do
-      include_obj = UserInclude.new("path/to/header.h", use_path: true)
-      
+    it "creates a UserInclude with an include_path override used in string expansion" do
+      include_obj = UserInclude.new("path/to/header.h", include_path: "path/to/header.h")
+
       expect(include_obj.filename).to eq("header.h")
       expect(include_obj.filepath).to eq("path/to/header.h")
       expect("#{include_obj}").to eq('#include "path/to/header.h"')
@@ -110,13 +110,25 @@ describe SystemInclude do
       expect(include_obj).to eq('header.h')
     end
 
-    it "creates a SystemInclude with a path and used path in string expansion" do
-      include_obj = SystemInclude.new("path/to/header.h", use_path: true)
-      
+    it "creates a SystemInclude with an include_path override used in string expansion" do
+      include_obj = SystemInclude.new("path/to/header.h", include_path: "path/to/header.h")
+
       expect(include_obj.filename).to eq("header.h")
       expect(include_obj.filepath).to eq("path/to/header.h")
       expect("#{include_obj}").to eq('#include <path/to/header.h>')
       expect(include_obj).to eq('path/to/header.h')
+    end
+
+    it "renders include_path instead of the bare filename, while filepath/filename keep the resolved identity" do
+      include_obj = SystemInclude.new(
+        "/usr/include/x86_64-linux-gnu/sys/stat.h", include_path: "sys/stat.h"
+      )
+
+      expect(include_obj.filepath).to eq("/usr/include/x86_64-linux-gnu/sys/stat.h")
+      expect(include_obj.filename).to eq("stat.h")
+      expect(include_obj.include_path).to eq("sys/stat.h")
+      expect("#{include_obj}").to eq('#include <sys/stat.h>')
+      expect(include_obj).to eq('sys/stat.h')
     end
   end
 
@@ -189,9 +201,9 @@ describe "Include equality" do
     end
 
     it "compares not equal to another UserInclude with same filename but different paths" do
-      include1 = UserInclude.new("path1/header.h", use_path: true)
-      include2 = UserInclude.new("path2/header.h", use_path: true)
-      
+      include1 = UserInclude.new("path1/header.h", include_path: "path1/header.h")
+      include2 = UserInclude.new("path2/header.h", include_path: "path2/header.h")
+
       expect(include1).not_to eq(include2)
       expect(include2).not_to eq(include1)
     end
@@ -266,9 +278,9 @@ describe "Include equality" do
     end
 
     it "compares not equal to another SystemInclude with same filename but different paths" do
-      include1 = SystemInclude.new("sys/stdio.h", use_path: true)
-      include2 = SystemInclude.new("other/stdio.h", use_path: true)
-      
+      include1 = SystemInclude.new("sys/stdio.h", include_path: "sys/stdio.h")
+      include2 = SystemInclude.new("other/stdio.h", include_path: "other/stdio.h")
+
       expect(include1).not_to eq(include2)
       expect(include2).not_to eq(include1)
     end
@@ -342,9 +354,9 @@ describe "Include equality" do
     end
 
     it "compares not equal to another MockInclude with same filename but different paths" do
-      include1 = MockInclude.new("mocks/mock_module.h", use_path: true)
-      include2 = MockInclude.new("test/mocks/mock_module.h", use_path: true)
-      
+      include1 = MockInclude.new("mocks/mock_module.h", include_path: "mocks/mock_module.h")
+      include2 = MockInclude.new("test/mocks/mock_module.h", include_path: "test/mocks/mock_module.h")
+
       expect(include1).not_to eq(include2)
       expect(include2).not_to eq(include1)
     end
@@ -547,9 +559,9 @@ describe "Include string coercion (to_str)" do
       expect(include_obj.to_str).to eq("header.h")
     end
 
-    it "returns the full filepath when constructed with use_path: true" do
-      include_obj = UserInclude.new("sub/dir/header.h", use_path: true)
-      # to_str always returns @filename (the basename) regardless of use_path
+    it "returns the basename even when constructed with an include_path override" do
+      include_obj = UserInclude.new("sub/dir/header.h", include_path: "sub/dir/header.h")
+      # to_str always returns @filename (the basename) regardless of include_path
       expect(include_obj.to_str).to eq("header.h")
     end
   end

--- a/spec/units/includes/includes_spec.rb
+++ b/spec/units/includes/includes_spec.rb
@@ -140,6 +140,8 @@ describe "Includes serialization" do
       expect(restored[0].filepath).to eq("path/to/header.h")
       expect(restored[1].filepath).to eq("sys/stdio.h")
       expect(restored[2].filepath).to eq("mocks/mock_module.h")
+      expect("#{restored[0]}").to eq('#include "path/to/header.h"')
+      expect("#{restored[1]}").to eq('#include <sys/stdio.h>')
     end
 
     it "handles empty array" do
@@ -1105,6 +1107,18 @@ describe "Includes reconciliation" do
       expect(result.length).to eq(2)
       expect(result[0].filepath).to eq("sys/types.h")
       expect(result[1].filepath).to eq("subdir/header.h")
+    end
+
+    it "preserves directory components from a system include directive" do
+      bare = [Include.new("sys/stat.h")]
+      user = []
+      system = [SystemInclude.new("/usr/include/x86_64-linux-gnu/sys/stat.h")]
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.map(&:to_s)).to eq(["#include <sys/stat.h>"])
+      expect(result.first.filepath).to eq("/usr/include/x86_64-linux-gnu/sys/stat.h")
+      expect(Includes.from_hashes(Includes.to_hashes(result)).map(&:to_s)).to eq(["#include <sys/stat.h>"])
     end
 
     it "matches a bare entry with more resolved path than its candidate carries" do

--- a/spec/units/includes/includes_spec.rb
+++ b/spec/units/includes/includes_spec.rb
@@ -126,22 +126,38 @@ describe "Includes serialization" do
       expect(restored.map(&:filename)).to eq(["first.h", "second.h", "third.h", "fourth.h"])
     end
 
-    it "handles includes with paths during serialization" do
+    it "handles includes with an include_path override during serialization" do
       original = [
-        UserInclude.new("path/to/header.h", use_path: true),
-        SystemInclude.new("sys/stdio.h", use_path: true),
-        MockInclude.new("mocks/mock_module.h", use_path: true)
+        UserInclude.new("path/to/header.h", include_path: "path/to/header.h"),
+        SystemInclude.new("sys/stdio.h", include_path: "sys/stdio.h"),
+        MockInclude.new("mocks/mock_module.h")
       ]
-      
+
       hashes = Includes.to_hashes(original)
       restored = Includes.from_hashes(hashes)
-      
+
       expect(restored.length).to eq(3)
       expect(restored[0].filepath).to eq("path/to/header.h")
       expect(restored[1].filepath).to eq("sys/stdio.h")
       expect(restored[2].filepath).to eq("mocks/mock_module.h")
+      # `include_path` must itself round-trip, not merely `filepath` -- otherwise a cached
+      # build silently reverts to filename-only rendering on its next, cache-hit run.
       expect("#{restored[0]}").to eq('#include "path/to/header.h"')
       expect("#{restored[1]}").to eq('#include <sys/stdio.h>')
+    end
+
+    it "round-trips include_path, and has it take rendering precedence over filepath/filename" do
+      original = [
+        SystemInclude.new("/usr/include/x86_64-linux-gnu/sys/stat.h", include_path: "sys/stat.h")
+      ]
+
+      hashes = Includes.to_hashes(original)
+      restored = Includes.from_hashes(hashes)
+
+      expect(restored.length).to eq(1)
+      expect(restored[0].filepath).to eq("/usr/include/x86_64-linux-gnu/sys/stat.h")
+      expect(restored[0].include_path).to eq("sys/stat.h")
+      expect("#{restored[0]}").to eq("#include <sys/stat.h>")
     end
 
     it "handles empty array" do
@@ -1109,18 +1125,6 @@ describe "Includes reconciliation" do
       expect(result[1].filepath).to eq("subdir/header.h")
     end
 
-    it "preserves directory components from a system include directive" do
-      bare = [Include.new("sys/stat.h")]
-      user = []
-      system = [SystemInclude.new("/usr/include/x86_64-linux-gnu/sys/stat.h")]
-
-      result = Includes.reconcile(bare: bare, user: user, system: system)
-
-      expect(result.map(&:to_s)).to eq(["#include <sys/stat.h>"])
-      expect(result.first.filepath).to eq("/usr/include/x86_64-linux-gnu/sys/stat.h")
-      expect(Includes.from_hashes(Includes.to_hashes(result)).map(&:to_s)).to eq(["#include <sys/stat.h>"])
-    end
-
     it "matches a bare entry with more resolved path than its candidate carries" do
       # A module source's own bare-includes extraction can resolve a quoted #include
       # via the including file's own directory (real, standard C search behavior)
@@ -1198,6 +1202,102 @@ describe "Includes reconciliation" do
         expect(error.message).to include("foo/bar.h")
         expect(error.message).to include("baz/bar.h")
       end
+    end
+
+    it "preserves a system include directive's original directory components instead of collapsing to its bare filename" do
+      bare = [Include.new("sys/stat.h")]
+      user = []
+      system = [SystemInclude.new("/usr/include/x86_64-linux-gnu/sys/stat.h")]
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.length).to eq(1)
+      expect(result[0]).to be_a(SystemInclude)
+      expect(result[0].filepath).to eq("/usr/include/x86_64-linux-gnu/sys/stat.h")
+      expect("#{result[0]}").to eq("#include <sys/stat.h>")
+      expect(Includes.from_hashes(Includes.to_hashes(result)).map(&:to_s)).to eq(["#include <sys/stat.h>"])
+    end
+
+    it "prefers the more specific bare entry when a system header's basename collides with an unrelated bare entry" do
+      # A project's own quoted `#include "stat.h"` sitting alongside a system
+      # `#include <sys/stat.h>` in the same file: both reach `bare` as plain, untyped
+      # Include objects (bare extraction can't tell quoted from bracketed apart), and
+      # the short entry trivially "corresponds" to any longer resolved path ending in
+      # the same filename. The longer, genuinely-corresponding entry must still win,
+      # regardless of which one happens to appear first in `bare`.
+      bare = [
+        Include.new("stat.h"),
+        Include.new("sys/stat.h")
+      ]
+      user = []
+      system = [SystemInclude.new("/usr/include/x86_64-linux-gnu/sys/stat.h")]
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.length).to eq(1)
+      expect("#{result[0]}").to eq("#include <sys/stat.h>")
+    end
+
+    it "falls back to a same-filename bare entry when nothing corresponds by path" do
+      # The compiler's real search-path structure can diverge from a directive's own
+      # literal spelling (a symlinked or vendored include root, for instance), so a
+      # resolved system path may not share any trailing segment with its bare entry
+      # beyond the filename itself. Rendering the bare entry's own spelling is still
+      # strictly better than collapsing to the bare filename alone.
+      bare = [Include.new("compat/stat.h")]
+      user = []
+      system = [SystemInclude.new("/usr/include/x86_64-linux-gnu/bits/stat.h")]
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.length).to eq(1)
+      expect("#{result[0]}").to eq("#include <compat/stat.h>")
+    end
+
+    it "renders a matched user include filename-only even when both bare and candidate carry the same subdirectory" do
+      # Deliberately not preserving subdirectory qualification for user includes, unlike
+      # system includes -- a bare quoted #include is resolved by GCC's own
+      # directory-relative search even under -nostdinc, so bare's own text can't be
+      # trusted as "the literal, as-written spelling" the way a system include's can.
+      bare = [Include.new("drivers/gpio.h")]
+      user = [UserInclude.new("drivers/gpio.h")]
+      system = []
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.length).to eq(1)
+      expect(result[0]).to be_a(UserInclude)
+      expect("#{result[0]}").to eq('#include "gpio.h"')
+    end
+
+    it "renders a bare, unqualified UserInclude bare even when its candidate resolves to a fuller path" do
+      # A bare #include "Types.h" commonly resolves, via directives-only preprocessing, to a
+      # fuller, project-root-relative candidate location like "src/Types.h" -- Ceedling adds
+      # each source directory as its own search path, so rendering that fuller resolved path
+      # verbatim breaks the build ("src/Types.h" isn't found via a "-Isrc" search path, only
+      # "Types.h" is). The reconciled render must stay bare, matching what the user actually
+      # wrote, regardless of how much extra path the candidate resolved to.
+      bare = [Include.new("Types.h")]
+      user = [UserInclude.new("src/Types.h")]
+      system = []
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.length).to eq(1)
+      expect(result[0]).to be_a(UserInclude)
+      expect("#{result[0]}").to eq('#include "Types.h"')
+    end
+
+    it "renders a matched MockInclude the same way regardless of the include_path fix, since MockInclude#to_s never consults it" do
+      bare = [Include.new("mock_module.h")]
+      user = [MockInclude.new("mocks/subdir/mock_module.h")]
+      system = []
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.length).to eq(1)
+      expect(result[0]).to be_a(MockInclude)
+      expect("#{result[0]}").to eq('#include "mocks/subdir/mock_module.h"')
     end
 
     it "does not hard-error over two same-named system headers, a normal toolchain wrapper-chain pattern rather than a project-file conflict" do


### PR DESCRIPTION
## Summary

- Preserve the original spelling of system include directives when Partials reconstruct source files.
- Keep the resolved system-header filepath for identity and path reconciliation.
- Persist the rendered include path across cached builds.

This prevents directives such as `#include <sys/stat.h>` from becoming `#include <stat.h>`.

Fixes #1194.

## Validation

- `bundle exec rake spec:unit:includes`: 79 examples, 0 failures
- `bundle exec rake specs:units`: 2,415 examples, 0 failures, 1 pending
- `bundle exec rake spec:system:include_path_reconciliation`: 1 example, 0 failures
- Issue reproducer passed twice: once from a clean build and once using cached include metadata.

The complete system suite was also started in a minimal Ruby 3.3 container, but unrelated environment prerequisites prevented a clean run: generated docs were absent, `gcovr` was unavailable, and locale-specific tests inherited a US-ASCII locale.

## Attribution

This implementation and its tests were generated with OpenAI Codex and reviewed and validated by the contributor.