### PR TITLE
🐛 Preserve directory components in reconciled Partials #include directives (1.1.4)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -20,6 +20,7 @@ This changelog is complemented by three other documents:
 - Fixed C variable extraction discarding a pointer's own qualifier (e.g. the second `const` in `const uint8_t* const ptr;`) whenever the same qualifier keyword also led the declaration.
 - [#1190](https://github.com/ThrowTheSwitch/Ceedling/issues/1190)/[#1187](https://github.com/ThrowTheSwitch/Ceedling/issues/1187) Fixed a module's typedefs and aggregate (struct/enum/union) definitions being generated into both its Test Partial and Mock Partial headers, causing a redefinition error when a test file uses both for the same module. Such content is now generated once into a shared header with unique include guard that both Partial headers, in turn, include.
 - [#1188](https://github.com/ThrowTheSwitch/Ceedling/issues/1188)/[#1187](https://github.com/ThrowTheSwitch/Ceedling/issues/1187) Fixed a long C declaration silently vanishing from a Partial (and everything textually after it in the same file) once it exceeded an internal, fixed sized buffer length. Refactored to rely on a different dynamically resized buffer with a configurable size ceiling (new `:partials` ↳ `:max_extraction_length`). C feature extraction now raises a clear error if the limit is exceeded.
+- [#1194](https://github.com/ThrowTheSwitch/Ceedling/issues/1194) Fixed generated Partials stripping directory components from system include directives (e.g. `<sys/stat.h>` becoming `<stat.h>`).
 
 ---
 

--- a/lib/ceedling/includes/includes.rb
+++ b/lib/ceedling/includes/includes.rb
@@ -32,10 +32,15 @@ class Includes
         else raise ArgumentError, "Unknown Include type: #{include.class}"
         end
 
-      {
+      hash = {
         'type' => type,
         'filepath' => include.filepath,
       }
+      # `include_path` is only ever meaningful on a reconciled SystemInclude, so it's
+      # written only when actually set -- a cached build's YAML stays uncluttered for
+      # the common, plain case.
+      hash['include_path'] = include.include_path if include.include_path
+      hash
     end
   end
 
@@ -63,11 +68,11 @@ class Includes
       
       case hash['type']
       when 'user'
-        UserInclude.new(hash['filepath'])
+        UserInclude.new(hash['filepath'], include_path: hash['include_path'])
       when 'mock'
         MockInclude.new(hash['filepath'])
       when 'system'
-        SystemInclude.new(hash['filepath'])
+        SystemInclude.new(hash['filepath'], include_path: hash['include_path'])
       else
         raise ArgumentError, "Invalid include type: #{hash['type']}. Must be 'user' or 'system'"
       end
@@ -153,6 +158,16 @@ class Includes
   # Compares bare includes against user and system includes and applies the following rules:
   # 1. Intersection of bare includes and system includes.
   # 2. Intersection of bare includes and user includes.
+  #
+  # A matched system include's `filepath` is its real, resolved location (possibly
+  # absolute), which is what identity and deduplication need but is wrong to render
+  # verbatim into a generated file. Each matched system include is therefore rebuilt
+  # carrying `include_path:` recovered from `bare` -- the original, as-written directive
+  # text -- via `best_bare_match`, so `<sys/stat.h>` renders as written instead of
+  # collapsing to `<stat.h>`. User includes are left untouched; unlike a system header's
+  # `<...>` text, a quoted include's own bare-includes pass can be resolved by GCC's
+  # directory-relative search before reconciliation ever sees it, so `bare` isn't a
+  # reliable source of "the literal, as-written spelling" for a user include.
   def self.reconcile(bare:, user:, system:)
     # Validate input types
 
@@ -179,10 +194,15 @@ class Includes
     # Create set of bare include filenames for O(1) lookup
     bare_filenames = Set.new(bare.map(&:filename))
 
-    # Intersect system includes with bare includes based on filename.
-    # Keep system includes that have matching filenames in bare list.
+    # Intersect system includes with bare includes based on filename, then rebuild each
+    # matched system include carrying the original, as-written directive spelling
+    # recovered from bare via best_bare_match, since filepath alone (the real, resolved
+    # location) is wrong to render verbatim.
     system_includes = system.select do |include|
       bare_filenames.include?(include.filename)
+    end.map do |include|
+      original = best_bare_match(bare, include.filepath)
+      SystemInclude.new(include.filepath, include_path: original.filepath)
     end
 
     # Intersect user includes with bare includes based on filename.
@@ -195,6 +215,36 @@ class Includes
     # Always system includes first (C best practice).
     return (system_includes + user_includes)
   end
+
+  # Two filepaths correspond if the shorter one's path segments equal the longer one's
+  # own trailing segments, exactly, in order -- checked without regard for which side is
+  # shorter, since either a bare entry or its candidate may be the one carrying less path.
+  def self.paths_correspond?(a, b)
+    segments_a = a.split(/[\\\/]/).reject(&:empty?)
+    segments_b = b.split(/[\\\/]/).reject(&:empty?)
+    shorter, longer = segments_a.length <= segments_b.length ? [segments_a, segments_b] : [segments_b, segments_a]
+    return longer.last(shorter.length) == shorter
+  end
+  private_class_method :paths_correspond?
+
+  # Finds the bare entry that best identifies a resolved system include's original,
+  # as-written spelling. A bare entry carries no information about whether its own
+  # #include was quoted or bracketed, so a project's own same-named quoted include
+  # (`#include "stat.h"`) can sit in `bare` right alongside a system one
+  # (`#include <sys/stat.h>`). Preferring the *longest* path correspondence, rather than
+  # merely the first one found, keeps a short, unrelated bare entry -- which trivially
+  # "corresponds" to any longer resolved path ending in the same filename -- from
+  # shadowing the correct, more specific entry. Falls back to the longest same-filename
+  # candidate, even without path correspondence, only when the compiler's real
+  # search-path structure doesn't literally match the directive's own spelling (a
+  # symlinked or vendored include root, for instance).
+  def self.best_bare_match(bare, filepath)
+    candidates = bare.select { |bare_include| bare_include.filename == File.basename(filepath) }
+    corresponding = candidates.select { |bare_include| paths_correspond?(bare_include.filepath, filepath) }
+    pool = corresponding.empty? ? candidates : corresponding
+    return pool.max_by { |bare_include| bare_include.filepath.split(/[\\\/]/).reject(&:empty?).length }
+  end
+  private_class_method :best_bare_match
 
   # Sort list so system includes are at the beginning
   # (Best practice)
@@ -216,6 +266,7 @@ class Include
   attr_reader :filepath
   attr_reader :filename
   attr_reader :path
+  attr_reader :include_path
 
   # Initialize an Include object from a C include statement or simple filepath.
   #
@@ -224,18 +275,21 @@ class Include
   #  - #include <stdio.h>
   #  - A quoted/bracketed filepath (e.g., '"header.h"' or <stdio.h>')
   #  - A plain filepath (e.g., 'path/to/header.h')
-  # @param use_path [Boolean] (default: false)
-  #  - If true, use the full filepath in the include directive
-  #  - If false, use only the filename
+  # @param include_path [String, nil] (default: nil)
+  #  - When set, this exact spelling is used in the include directive, taking
+  #    precedence over `filepath`/`filename`. This exists for a reconciled
+  #    SystemInclude, whose `filepath` is deliberately the header's real, resolved
+  #    location (needed elsewhere for identity -- see `Includes.sanitize!`) rather than
+  #    the original, as-written directive text a reconciled render needs.
   # @raise [ArgumentError] If the statement is empty or becomes empty after cleaning
-  def initialize(statement, use_path: false)
+  def initialize(statement, include_path: nil)
     @filepath = clean(statement)
 
     raise ArgumentError, "Empty include statement" if @filepath.empty?
 
     @filename = File.basename(@filepath)
     @path = File.dirname(@filepath)
-    @use_path = use_path
+    @include_path = clean(include_path) if include_path
   end
 
   # Method specialized by subclasses
@@ -294,7 +348,8 @@ class Include
 
   # Returns the configured entry to use in the include directive
   def include()
-    @use_path ? @filepath : @filename
+    return @include_path if @include_path
+    @filename
   end
 
   private

--- a/spec/units/includes/include_spec.rb
+++ b/spec/units/includes/include_spec.rb
@@ -30,9 +30,9 @@ describe UserInclude do
       expect(include_obj).to eq('header.h')
     end
 
-    it "creates a UserInclude with a path and used path in string expansion" do
-      include_obj = UserInclude.new("path/to/header.h", use_path: true)
-      
+    it "creates a UserInclude with an include_path override used in string expansion" do
+      include_obj = UserInclude.new("path/to/header.h", include_path: "path/to/header.h")
+
       expect(include_obj.filename).to eq("header.h")
       expect(include_obj.filepath).to eq("path/to/header.h")
       expect("#{include_obj}").to eq('#include "path/to/header.h"')
@@ -110,13 +110,25 @@ describe SystemInclude do
       expect(include_obj).to eq('header.h')
     end
 
-    it "creates a SystemInclude with a path and used path in string expansion" do
-      include_obj = SystemInclude.new("path/to/header.h", use_path: true)
-      
+    it "creates a SystemInclude with an include_path override used in string expansion" do
+      include_obj = SystemInclude.new("path/to/header.h", include_path: "path/to/header.h")
+
       expect(include_obj.filename).to eq("header.h")
       expect(include_obj.filepath).to eq("path/to/header.h")
       expect("#{include_obj}").to eq('#include <path/to/header.h>')
       expect(include_obj).to eq('path/to/header.h')
+    end
+
+    it "renders include_path instead of the bare filename, while filepath/filename keep the resolved identity" do
+      include_obj = SystemInclude.new(
+        "/usr/include/x86_64-linux-gnu/sys/stat.h", include_path: "sys/stat.h"
+      )
+
+      expect(include_obj.filepath).to eq("/usr/include/x86_64-linux-gnu/sys/stat.h")
+      expect(include_obj.filename).to eq("stat.h")
+      expect(include_obj.include_path).to eq("sys/stat.h")
+      expect("#{include_obj}").to eq('#include <sys/stat.h>')
+      expect(include_obj).to eq('sys/stat.h')
     end
   end
 
@@ -189,9 +201,9 @@ describe "Include equality" do
     end
 
     it "compares not equal to another UserInclude with same filename but different paths" do
-      include1 = UserInclude.new("path1/header.h", use_path: true)
-      include2 = UserInclude.new("path2/header.h", use_path: true)
-      
+      include1 = UserInclude.new("path1/header.h", include_path: "path1/header.h")
+      include2 = UserInclude.new("path2/header.h", include_path: "path2/header.h")
+
       expect(include1).not_to eq(include2)
       expect(include2).not_to eq(include1)
     end
@@ -266,9 +278,9 @@ describe "Include equality" do
     end
 
     it "compares not equal to another SystemInclude with same filename but different paths" do
-      include1 = SystemInclude.new("sys/stdio.h", use_path: true)
-      include2 = SystemInclude.new("other/stdio.h", use_path: true)
-      
+      include1 = SystemInclude.new("sys/stdio.h", include_path: "sys/stdio.h")
+      include2 = SystemInclude.new("other/stdio.h", include_path: "other/stdio.h")
+
       expect(include1).not_to eq(include2)
       expect(include2).not_to eq(include1)
     end
@@ -342,9 +354,9 @@ describe "Include equality" do
     end
 
     it "compares not equal to another MockInclude with same filename but different paths" do
-      include1 = MockInclude.new("mocks/mock_module.h", use_path: true)
-      include2 = MockInclude.new("test/mocks/mock_module.h", use_path: true)
-      
+      include1 = MockInclude.new("mocks/mock_module.h", include_path: "mocks/mock_module.h")
+      include2 = MockInclude.new("test/mocks/mock_module.h", include_path: "test/mocks/mock_module.h")
+
       expect(include1).not_to eq(include2)
       expect(include2).not_to eq(include1)
     end
@@ -547,9 +559,9 @@ describe "Include string coercion (to_str)" do
       expect(include_obj.to_str).to eq("header.h")
     end
 
-    it "returns the full filepath when constructed with use_path: true" do
-      include_obj = UserInclude.new("sub/dir/header.h", use_path: true)
-      # to_str always returns @filename (the basename) regardless of use_path
+    it "returns the basename even when constructed with an include_path override" do
+      include_obj = UserInclude.new("sub/dir/header.h", include_path: "sub/dir/header.h")
+      # to_str always returns @filename (the basename) regardless of include_path
       expect(include_obj.to_str).to eq("header.h")
     end
   end

--- a/spec/units/includes/includes_spec.rb
+++ b/spec/units/includes/includes_spec.rb
@@ -111,20 +111,38 @@ describe "Includes serialization" do
       expect(restored.map(&:filename)).to eq(["first.h", "second.h", "third.h", "fourth.h"])
     end
 
-    it "handles includes with paths during serialization" do
+    it "handles includes with an include_path override during serialization" do
       original = [
-        UserInclude.new("path/to/header.h", use_path: true),
-        SystemInclude.new("sys/stdio.h", use_path: true),
-        MockInclude.new("mocks/mock_module.h", use_path: true)
+        UserInclude.new("path/to/header.h", include_path: "path/to/header.h"),
+        SystemInclude.new("sys/stdio.h", include_path: "sys/stdio.h"),
+        MockInclude.new("mocks/mock_module.h")
       ]
-      
+
       hashes = Includes.to_hashes(original)
       restored = Includes.from_hashes(hashes)
-      
+
       expect(restored.length).to eq(3)
       expect(restored[0].filepath).to eq("path/to/header.h")
       expect(restored[1].filepath).to eq("sys/stdio.h")
       expect(restored[2].filepath).to eq("mocks/mock_module.h")
+      # `include_path` must itself round-trip, not merely `filepath` -- otherwise a cached
+      # build silently reverts to filename-only rendering on its next, cache-hit run.
+      expect("#{restored[0]}").to eq('#include "path/to/header.h"')
+      expect("#{restored[1]}").to eq('#include <sys/stdio.h>')
+    end
+
+    it "round-trips include_path, and has it take rendering precedence over filepath/filename" do
+      original = [
+        SystemInclude.new("/usr/include/x86_64-linux-gnu/sys/stat.h", include_path: "sys/stat.h")
+      ]
+
+      hashes = Includes.to_hashes(original)
+      restored = Includes.from_hashes(hashes)
+
+      expect(restored.length).to eq(1)
+      expect(restored[0].filepath).to eq("/usr/include/x86_64-linux-gnu/sys/stat.h")
+      expect(restored[0].include_path).to eq("sys/stat.h")
+      expect("#{restored[0]}").to eq("#include <sys/stat.h>")
     end
 
     it "handles empty array" do
@@ -1054,16 +1072,88 @@ describe "Includes reconciliation" do
         Include.new("subdir/header.h"),
         Include.new("sys/types.h")
       ]
-      
+
       user = [UserInclude.new("header.h")]
       system = [SystemInclude.new("types.h")]
-      
+
       result = Includes.reconcile(bare: bare, user: user, system: system)
-      
+
       # Should match by filename only
       expect(result.length).to eq(2)
       expect(result[0].filename).to eq("types.h")
       expect(result[1].filename).to eq("header.h")
     end
+
+    it "preserves a system include directive's original directory components instead of collapsing to its bare filename" do
+      bare = [Include.new("sys/stat.h")]
+      user = []
+      system = [SystemInclude.new("/usr/include/x86_64-linux-gnu/sys/stat.h")]
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.length).to eq(1)
+      expect(result[0]).to be_a(SystemInclude)
+      expect(result[0].filepath).to eq("/usr/include/x86_64-linux-gnu/sys/stat.h")
+      expect("#{result[0]}").to eq("#include <sys/stat.h>")
+      expect(Includes.from_hashes(Includes.to_hashes(result)).map(&:to_s)).to eq(["#include <sys/stat.h>"])
+    end
+
+    it "prefers the more specific bare entry when a system header's basename collides with an unrelated bare entry" do
+      # A project's own quoted `#include "stat.h"` sitting alongside a system
+      # `#include <sys/stat.h>` in the same file: both reach `bare` as plain, untyped
+      # Include objects, and the short entry trivially "corresponds" to any longer
+      # resolved path ending in the same filename. The longer, genuinely-corresponding
+      # entry must still win, regardless of which one happens to appear first in `bare`.
+      bare = [
+        Include.new("stat.h"),
+        Include.new("sys/stat.h")
+      ]
+      user = []
+      system = [SystemInclude.new("/usr/include/x86_64-linux-gnu/sys/stat.h")]
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.length).to eq(1)
+      expect("#{result[0]}").to eq("#include <sys/stat.h>")
+    end
+
+    it "falls back to a same-filename bare entry when nothing corresponds by path" do
+      # The compiler's real search-path structure can diverge from a directive's own
+      # literal spelling (a symlinked or vendored include root, for instance), so a
+      # resolved system path may not share any trailing segment with its bare entry
+      # beyond the filename itself. Rendering the bare entry's own spelling is still
+      # strictly better than collapsing to the bare filename alone.
+      bare = [Include.new("compat/stat.h")]
+      user = []
+      system = [SystemInclude.new("/usr/include/x86_64-linux-gnu/bits/stat.h")]
+
+      result = Includes.reconcile(bare: bare, user: user, system: system)
+
+      expect(result.length).to eq(1)
+      expect("#{result[0]}").to eq("#include <compat/stat.h>")
+    end
+
+    it "does not hard-error over two same-named system headers, a normal toolchain wrapper-chain pattern rather than a project-file conflict" do
+      # e.g. a compiler-provided stdint.h #include_next-ing its libc counterpart --
+      # both real, both legitimately entered, both sharing a basename, neither a
+      # project file whose identity is actually in question.
+      bare = [Include.new("stdint.h")]
+
+      user = []
+      system = [
+        SystemInclude.new("/usr/lib/gcc/x86_64-linux-gnu/14/include/stdint.h"),
+        SystemInclude.new("/usr/include/stdint.h")
+      ]
+
+      result = nil
+      expect {
+        result = Includes.reconcile(bare: bare, user: user, system: system)
+      }.not_to raise_error
+
+      expect(result.length).to eq(2)
+      expect(result.map(&:filepath)).to include(
+        "/usr/lib/gcc/x86_64-linux-gnu/14/include/stdint.h", "/usr/include/stdint.h"
+      )
+    end
   end
-end    
+end


### PR DESCRIPTION
## Summary

Fixes #1194 for the upcoming 1.1.4 patch release.

A resolved `SystemInclude` renders `File.basename` of its real, resolved header location, so `#include <sys/stat.h>` collapsed to `#include <stat.h>` in generated Partials. A matched system include is now rebuilt carrying the original, as-written directive spelling recovered from the bare-includes extraction pass.

This is a separate, independently-implemented fix from PR #1196 (originally reported and fixed by @KaSroka, targeting `next_version`/1.2.0). `next_version`'s `Includes.reconcile` has diverged from `master`'s (different matching strategy entirely), so that fix isn't directly portable here — this reimplements the same conceptual fix against `master`'s simpler reconciliation logic, so 1.1.4 doesn't have to wait for the larger 1.2.0 release to carry it.

## Test plan
- `bundle exec rspec spec/units/includes/includes_spec.rb spec/units/includes/include_spec.rb`
- `bundle exec rake specs:units`
- Reproduced issue #1194's own repro steps end to end against this branch
