### PR TITLE
🐛 Preserve a detected crash when diagnostic backtrace retries can't reproduce it

### DIFF
--- a/assets/fixtures/fake_crash_test_fixture.rb
+++ b/assets/fixtures/fake_crash_test_fixture.rb
@@ -1,0 +1,14 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# Deliberately ignores the real test executable path it's given and never runs it --
+# simulates a custom :test_fixture wrapper whose own crash-detection machinery (e.g. a
+# sanitizer's halt_on_error) kills the process before Unity ever gets to print its
+# summary. Exists to reproduce issue #1198 without needing a real sanitizer toolchain:
+# a diagnostic backtrace retry left at its default configuration runs the real
+# executable directly instead, unaffected by this fixture, and legitimately passes.
+exit 1

--- a/assets/fixtures/run_with_ubsan.rb
+++ b/assets/fixtures/run_with_ubsan.rb
@@ -1,0 +1,15 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# Enables UBSan's halt-on-error, then execs the real test executable in this script's
+# own place rather than as a child process -- this process's PID becomes the test
+# executable's PID, so the real Process::Status Ceedling observes is the test
+# executable's own. Regression fixture for issue #1198: a diagnostic backtrace retry
+# runs through a separate, unwrapped default tool that never sees this setting, so it
+# can legitimately recover from the same undefined behavior instead of halting on it.
+ENV['UBSAN_OPTIONS'] = 'halt_on_error=1'
+exec(*ARGV)

--- a/assets/fixtures/test_example_file_ub_shift_overflow.c
+++ b/assets/fixtures/test_example_file_ub_shift_overflow.c
@@ -1,0 +1,22 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* Left-shifting a value past its type's bit width is undefined behavior --
+   UBSan's -fsanitize=undefined flags it at runtime without a real crash
+   occurring at the OS level. */
+void test_shift_overflow(void) {
+  volatile uint8_t value = 128;
+  volatile uint32_t result = value << 24;
+  (void)result;
+}

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -43,6 +43,8 @@ Because of the support added for handling paths and distinguishing duplicated fi
 
 ## 💪 Fixed
 
+- [#1198](https://github.com/ThrowTheSwitch/Ceedling/issues/1198) Fixed a crash that could go unnoticed. If a test crashed but `:use_backtrace`'s diagnostic retry ran cleanly instead of reproducing the crash, Ceedling trusted that clean retry over the real crash and reported the test as passing, with a successful exit code.
+
 ### Partials
 
 - [#1194](https://github.com/ThrowTheSwitch/Ceedling/issues/1194) Fixed generated Partials stripping directory components from system include directives (e.g. `<sys/stat.h>` becoming `<stat.h>`).

--- a/lib/ceedling/generators/generator_helper.rb
+++ b/lib/ceedling/generators/generator_helper.rb
@@ -18,18 +18,37 @@ class GeneratorHelper
 
     crash = false
 
-    # Unix Signal 11 ==> SIGSEGV
-    # Applies to Unix-like systems including MSYS on Windows
-    if (shell_result[:status].termsig == 11)
-      @loginator.lazy( Verbosity::DEBUG, LogLabels::CRASH ) do 
-        "#{runner} process terminated with SIGSEGV (Unix Signal 11)"
+    # Any signal death is unconditionally a crash, whatever text made it out beforehand.
+    # Broadened from a SIGSEGV(11)-only check: a sanitizer's halt_on_error (UBSan, ASan)
+    # raises SIGABRT, not SIGSEGV, and there's no reason to trust a process that a
+    # signal actually killed regardless of which one. Applies to Unix-like systems
+    # including MSYS on Windows -- native (non-MSYS) Windows Ruby never reports
+    # `signaled?` true at all, so this check is inert there rather than wrong; the
+    # stats-footer and stderr checks below already carry Windows crash detection.
+    if shell_result[:status] && shell_result[:status].signaled?
+      @loginator.lazy( Verbosity::DEBUG, LogLabels::CRASH ) do
+        "#{runner} process terminated by signal #{shell_result[:status].termsig}"
       end
       crash = true
     end
 
     # No test results found in test executable output
-    if (shell_result[:output] =~ PATTERNS::TEST_STDOUT_STATISTICS).nil?
+    stats_match = shell_result[:output].match( PATTERNS::TEST_STDOUT_STATISTICS )
+    if stats_match.nil?
       # No debug logging here because we log this condition in the error log handling below
+      crash = true
+    end
+
+    # A clean summary (0 failures) is not trustworthy if the real process still exited
+    # nonzero afterward -- e.g. LeakSanitizer detecting a leak during teardown, after
+    # every test case already printed and Unity's own summary already looked clean.
+    # A nonzero exit consistent with Unity's own reported failures (its exit code
+    # convention is one per failed test case) is an ordinary failing run, not a crash.
+    if stats_match && shell_result[:status] && !shell_result[:status].success? &&
+       !shell_result[:status].signaled? && stats_match[2].to_i == 0
+      @loginator.lazy( Verbosity::DEBUG, LogLabels::CRASH ) do
+        "#{runner} reported a clean summary but exited with real status #{shell_result[:status].exitstatus}"
+      end
       crash = true
     end
 

--- a/lib/ceedling/generators/generator_test_results_backtrace.rb
+++ b/lib/ceedling/generators/generator_test_results_backtrace.rb
@@ -7,10 +7,13 @@
 
 class GeneratorTestResultsBacktrace
 
-  constructor :configurator, :tool_executor, :generator_test_results, :file_path_utils, :file_wrapper
+  constructor :configurator, :tool_executor, :generator_test_results, :generator_helper,
+              :file_path_utils, :file_wrapper, :loginator
 
   def setup()
     @RESULTS_COLLECTOR = Struct.new( :passed, :failed, :ignored, :output, keyword_init:true )
+    # Alias, matching Generator's own convention for the same dependency.
+    @helper = @generator_helper
   end
 
   # Re-runs each test case (or, for a parameterized test, each group of parameterized
@@ -28,6 +31,13 @@ class GeneratorTestResultsBacktrace
     shell_result[:time] = 0
 
     test_name = File.basename( filename, '.*' )
+
+    # True once some retry group has actually shown crash evidence of its own -- an
+    # unresolved member, or (below) a group whose real status contradicts a fully clean
+    # set of matches. If this stays false across every group, the whole diagnostic never
+    # reproduced or attributed the crash the main run already detected, and none of it
+    # can be trusted -- see the fallback after the loop.
+    any_group_crashed = false
 
     # Iterate on test cases, one sub-process run per group (see `group_test_cases`)
     group_test_cases( test_cases ).each do |group|
@@ -47,6 +57,10 @@ class GeneratorTestResultsBacktrace
       # Note: Running tests separately increases total execution time
       shell_result[:time] += crash_result[:time].to_f()
 
+      # Buffered separately from test_case_results and only merged in afterward, since
+      # the status check below can still discard every match here in favor of a crash
+      # attribution, once the whole group has been seen.
+      group_results = @RESULTS_COLLECTOR.new( passed:0, failed:0, ignored:0, output:[] )
       unresolved = []
 
       # Attribute each group member its own real result line, if Unity printed one
@@ -54,17 +68,17 @@ class GeneratorTestResultsBacktrace
         case crash_result[:output]
         # Success test case
         when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS\s*$)/
-          test_case_results[:passed]  += 1
-          test_case_results[:output] << $1
+          group_results[:passed]  += 1
+          group_results[:output] << $1
 
         # Ignored test case
         when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE\s*$)/
-          test_case_results[:ignored] += 1
-          test_case_results[:output] << $1
+          group_results[:ignored] += 1
+          group_results[:output] << $1
 
         when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:FAIL(:.+)?\s*$)/
-          test_case_results[:failed]  += 1
-          test_case_results[:output] << $1
+          group_results[:failed]  += 1
+          group_results[:output] << $1
 
         # No result line for this member -- either it crashed, or it never got to run
         # because an earlier member in this same group crashed. Resolved below.
@@ -73,81 +87,119 @@ class GeneratorTestResultsBacktrace
         end
       end
 
-      next if unresolved.empty?
-
-      # Prefer whichever unresolved member's own C symbol is actually named in the gdb
-      # backtrace (works regardless of position in the group); fall back to the first
-      # unresolved member if no member's symbol can be found in the transcript (e.g. a
-      # brief crash report with no frame information at all).
-      crashed_case = unresolved.find do |tc|
-        crash_result[:output].match?( /#{Regexp.escape(tc[:symbol])}\s*\(\)\sat/ )
-      end
-      crashed_case ||= unresolved.first
-
-      # Per-test-case log file: <log_path>/<context>/<test_name>/<test_case>.gdb.log
-      log_path = @file_path_utils.form_test_gdb_log( test_name, context: context, name: crashed_case[:test] )
-      @file_wrapper.mkdir( File.dirname( log_path ) )
-      @file_wrapper.write( log_path, "=== #{crashed_case[:test]} ===\n#{crash_result[:output]}\n", 'a' )
-
-      unresolved.each do |test_case|
-        test_case_results[:failed] += 1
-
-        if !test_case.equal?( crashed_case )
-          # An earlier case in this same parameterized group already crashed the
-          # process -- this member never got a chance to run.
-          test_case_results[:output] <<
-            "#{filename}:#{test_case[:line_number]}:#{test_case[:test]}:FAIL: " \
-            "Test case not run -- an earlier case in this parameterized test group crashed"
-          next
+      if !unresolved.empty?
+        # Prefer whichever unresolved member's own C symbol is actually named in the gdb
+        # backtrace (works regardless of position in the group); fall back to the first
+        # unresolved member if no member's symbol can be found in the transcript (e.g. a
+        # brief crash report with no frame information at all).
+        crashed_case = unresolved.find do |tc|
+          crash_result[:output].match?( /#{Regexp.escape(tc[:symbol])}\s*\(\)\sat/ )
         end
+        crashed_case ||= unresolved.first
 
-        # Collect file_name and line in which crash occurred.
-        # Match against the actual C symbol (`:symbol`), not the human-facing test name
-        # (`:test`): a parameterized test case crashes inside a generated wrapper function
-        # (`runner_args<N>_<test>`), not a function literally named `<test>(<args>)`.
-        matched = crash_result[:output].match( /#{Regexp.escape(test_case[:symbol])}\s*\(\)\sat.+#{filename}:(\d+)\n/ )
+        # Per-test-case log file: <log_path>/<context>/<test_name>/<test_case>.gdb.log
+        log_path = @file_path_utils.form_test_gdb_log( test_name, context: context, name: crashed_case[:test] )
+        @file_wrapper.mkdir( File.dirname( log_path ) )
+        @file_wrapper.write( log_path, "=== #{crashed_case[:test]} ===\n#{crash_result[:output]}\n", 'a' )
 
-        # If we found an error report line containing `test_case() at filename.c:###` in `gdb` output
-        if matched
-          # Line number
-          line_number = matched[1]
+        unresolved.each do |test_case|
+          group_results[:failed] += 1
 
-          # Build terse signal label: "[SIGNAL] Description"
-          signal_label = format_signal_label( crash_result[:output] )
-
-          # Extract the offending source line (nil for assertion crashes or when unavailable)
-          source_line = extract_source_line( crash_result[:output], test_case[:symbol], filename )
-
-          # Unity's test executable output is line oriented.
-          # Multi-line output is not possible (it looks like random `printf()` statements to the results parser).
-          # "Encode" newlines in multiline string to be handled by the test results parser.
-          crash_detail = source_line ? "#{NEWLINE_TOKEN}`#{source_line}`" : ''
-
-          # Log path appears on its own encoded line so the results parser treats it separately
-          test_case_results[:output] <<
-            "#{filename}:#{line_number}:#{test_case[:test]}:FAIL: Test case crashed" \
-            " >> #{signal_label}" \
-            "#{crash_detail}" \
-            "#{NEWLINE_TOKEN}(#{log_path})"
-
-        # Try to extract a useful label even when no crash location frame was found.
-        # A brief Windows assertion failure may report only the assertion text without frames.
-        else
-          label = format_signal_label( crash_result[:output] )
-
-          if !label.empty?
-            test_case_results[:output] <<
-              "#{filename}:#{test_case[:line_number]}:#{test_case[:test]}:FAIL: Test case crashed" \
-              " >> #{label}" \
-              "#{NEWLINE_TOKEN}(#{log_path})"
-          else
-            test_case_results[:output] <<
+          if !test_case.equal?( crashed_case )
+            # An earlier case in this same parameterized group already crashed the
+            # process -- this member never got a chance to run.
+            group_results[:output] <<
               "#{filename}:#{test_case[:line_number]}:#{test_case[:test]}:FAIL: " \
-              "Test case crashed (failed to extract `gdb` report)" \
+              "Test case not run -- an earlier case in this parameterized test group crashed"
+            next
+          end
+
+          # Collect file_name and line in which crash occurred.
+          # Match against the actual C symbol (`:symbol`), not the human-facing test name
+          # (`:test`): a parameterized test case crashes inside a generated wrapper function
+          # (`runner_args<N>_<test>`), not a function literally named `<test>(<args>)`.
+          matched = crash_result[:output].match( /#{Regexp.escape(test_case[:symbol])}\s*\(\)\sat.+#{filename}:(\d+)\n/ )
+
+          # If we found an error report line containing `test_case() at filename.c:###` in `gdb` output
+          if matched
+            # Line number
+            line_number = matched[1]
+
+            # Build terse signal label: "[SIGNAL] Description"
+            signal_label = format_signal_label( crash_result[:output] )
+
+            # Extract the offending source line (nil for assertion crashes or when unavailable)
+            source_line = extract_source_line( crash_result[:output], test_case[:symbol], filename )
+
+            # Unity's test executable output is line oriented.
+            # Multi-line output is not possible (it looks like random `printf()` statements to the results parser).
+            # "Encode" newlines in multiline string to be handled by the test results parser.
+            crash_detail = source_line ? "#{NEWLINE_TOKEN}`#{source_line}`" : ''
+
+            # Log path appears on its own encoded line so the results parser treats it separately
+            group_results[:output] <<
+              "#{filename}:#{line_number}:#{test_case[:test]}:FAIL: Test case crashed" \
+              " >> #{signal_label}" \
+              "#{crash_detail}" \
               "#{NEWLINE_TOKEN}(#{log_path})"
+
+          # Try to extract a useful label even when no crash location frame was found.
+          # A brief Windows assertion failure may report only the assertion text without frames.
+          else
+            label = format_signal_label( crash_result[:output] )
+
+            if !label.empty?
+              group_results[:output] <<
+                "#{filename}:#{test_case[:line_number]}:#{test_case[:test]}:FAIL: Test case crashed" \
+                " >> #{label}" \
+                "#{NEWLINE_TOKEN}(#{log_path})"
+            else
+              group_results[:output] <<
+                "#{filename}:#{test_case[:line_number]}:#{test_case[:test]}:FAIL: " \
+                "Test case crashed (failed to extract `gdb` report)" \
+                "#{NEWLINE_TOKEN}(#{log_path})"
+            end
           end
         end
       end
+
+      # Every member in this group resolved via a matched result line -- but gdb
+      # normally exits successfully after handling a crash regardless of what happened
+      # to the debuggee, so a clean-looking group here is a weaker signal than it is for
+      # `do_simple`. Still checked for the same reason: a diagnostic retry's own real
+      # status contradicting a fully clean set of matches is never trustworthy, whatever
+      # tool produced it.
+      if unresolved.empty? && @helper.test_crash?( filename, executable, crash_result )
+        group_results = @RESULTS_COLLECTOR.new(
+          passed: 0, ignored: 0, failed: group.size,
+          output: group.map { |test_case|
+            "#{filename}:#{test_case[:line_number]}:#{test_case[:test]}:FAIL: Test case crashed" \
+            " >> diagnostic retry's own exit status contradicts its reported clean result"
+          }
+        )
+        unresolved = group # non-empty now, marks this group as having shown crash evidence
+      end
+
+      any_group_crashed ||= !unresolved.empty?
+
+      test_case_results[:passed]  += group_results[:passed]
+      test_case_results[:ignored] += group_results[:ignored]
+      test_case_results[:failed]  += group_results[:failed]
+      test_case_results[:output].concat( group_results[:output] )
+    end
+
+    # No retry group, across the entire file, ever showed real crash evidence, yet this
+    # method only runs because the main run was already established as a crash. An
+    # all-clean diagnostic must never be allowed to overrule that -- fall back to the
+    # same whole-file crash-as-failure construction the :none backtrace setting uses.
+    unless any_group_crashed
+      @loginator.log(
+        "Diagnostic retry for `#{File.basename(executable)}` could not reproduce the crash " \
+        "already detected on the main run -- reporting the original crash rather than trusting " \
+        "an all-clear diagnostic that contradicts it.",
+        Verbosity::ERRORS, LogLabels::CRASH
+      )
+      return @generator_test_results.create_crash_failure( filename, shell_result, test_cases )
     end
 
     # Reset shell result exit code and output
@@ -175,6 +227,13 @@ class GeneratorTestResultsBacktrace
     # Reset time
     shell_result[:time] = 0
 
+    # True once some retry group has actually shown crash evidence of its own -- a
+    # member with no result line, or (below) a group whose real status contradicts a
+    # fully clean set of matches. If this stays false across every group, the whole
+    # diagnostic never reproduced or attributed the crash the main run already
+    # detected, and none of it can be trusted -- see the fallback after the loop.
+    any_group_crashed = false
+
     # Iterate on test cases, one sub-process run per group (see `group_test_cases`)
     group_test_cases( test_cases ).each do |group|
       # Build the test fixture to run with our test case (or parameterized group) of interest
@@ -192,6 +251,10 @@ class GeneratorTestResultsBacktrace
       # Note: Running tests separately increases total execution time
       shell_result[:time] += crash_result[:time].to_f()
 
+      # Buffered separately from test_case_results and only merged in afterward, since
+      # the status check below can still discard every match here in favor of a crash
+      # attribution, once the whole group has been seen.
+      group_results = @RESULTS_COLLECTOR.new( passed:0, failed:0, ignored:0, output:[] )
       crashed = false # Has the actual crash in this group already been attributed?
 
       # Attribute each group member its own real result line, if Unity printed one
@@ -199,25 +262,25 @@ class GeneratorTestResultsBacktrace
         case crash_result[:output]
         # Success test case
         when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS\s*$)/
-          test_case_results[:passed]  += 1
-          test_case_results[:output] << $1
+          group_results[:passed]  += 1
+          group_results[:output] << $1
 
         # Ignored test case
         when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE\s*$)/
-          test_case_results[:ignored] += 1
-          test_case_results[:output] << $1
+          group_results[:ignored] += 1
+          group_results[:output] << $1
 
         when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:FAIL(:.+)?\s*$)/
-          test_case_results[:failed]  += 1
-          test_case_results[:output] << $1
+          group_results[:failed]  += 1
+          group_results[:output] << $1
 
         # No result line for this member -- either it crashed, or it never got to run
         # because an earlier member in this same group crashed.
         else
-          test_case_results[:failed] += 1
+          group_results[:failed] += 1
 
           if crashed
-            test_case_results[:output] <<
+            group_results[:output] <<
               "#{filename}:#{test_case[:line_number]}:#{test_case[:test]}:FAIL: " \
               "Test case not run -- an earlier case in this parameterized test group crashed"
           else
@@ -226,10 +289,47 @@ class GeneratorTestResultsBacktrace
             extra = extract_simple_crash_output( crash_result[:output], filename )
             test_output = "#{filename}:#{test_case[:line_number]}:#{test_case[:test]}:FAIL: Test case crashed"
             test_output += " >> #{extra.join(NEWLINE_TOKEN)}" unless extra.empty?
-            test_case_results[:output] << test_output
+            group_results[:output] << test_output
           end
         end
       end
+
+      # Every member in this group resolved via a matched result line -- but a diagnostic
+      # retry running through its own, separately-configured tool (e.g. without the main
+      # :test_fixture's sanitizer options) can complete cleanly and print a legitimate-
+      # looking PASS even when it isn't a trustworthy stand-in for what actually happened.
+      # The same real-status check the main run itself relies on applies here too.
+      if !crashed && @helper.test_crash?( filename, executable, crash_result )
+        crashed = true
+        group_results = @RESULTS_COLLECTOR.new(
+          passed: 0, ignored: 0, failed: group.size,
+          output: group.map { |test_case|
+            "#{filename}:#{test_case[:line_number]}:#{test_case[:test]}:FAIL: Test case crashed" \
+            " >> diagnostic retry's own exit status contradicts its reported clean result"
+          }
+        )
+      end
+
+      any_group_crashed ||= crashed
+
+      test_case_results[:passed]  += group_results[:passed]
+      test_case_results[:ignored] += group_results[:ignored]
+      test_case_results[:failed]  += group_results[:failed]
+      test_case_results[:output].concat( group_results[:output] )
+    end
+
+    # No retry group, across the entire file, ever showed real crash evidence, yet this
+    # method only runs because the main run was already established as a crash. An
+    # all-clean diagnostic must never be allowed to overrule that -- fall back to the
+    # same whole-file crash-as-failure construction the :none backtrace setting uses.
+    unless any_group_crashed
+      @loginator.log(
+        "Diagnostic retry for `#{File.basename(executable)}` could not reproduce the crash " \
+        "already detected on the main run -- reporting the original crash rather than trusting " \
+        "an all-clear diagnostic that contradicts it.",
+        Verbosity::ERRORS, LogLabels::CRASH
+      )
+      return @generator_test_results.create_crash_failure( filename, shell_result, test_cases )
     end
 
     # Reset shell result exit code and output

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -238,8 +238,10 @@ generator_test_results_backtrace:
      - configurator
      - tool_executor
      - generator_test_results
+     - generator_helper
      - file_path_utils
      - file_wrapper
+     - loginator
 
 generator_test_results_sanity_checker:
   compose:

--- a/spec/support/system/spec_system_helper.rb
+++ b/spec/support/system/spec_system_helper.rb
@@ -195,6 +195,21 @@ def bullseye_available?
   tool_available?('covc --help 2>&1')
 end
 
+# Real UBSan support is Linux-specific in practice for this test suite -- macOS's
+# system `gcc` is really Clang under a compatibility shim with different sanitizer
+# runtime behavior, and MinGW gcc on Windows doesn't ship the sanitizer runtime at
+# all. Restricting to Linux avoids flaky, platform-dependent compiler probing.
+def ubsan_available?
+  return false unless RUBY_PLATFORM.downcase.include?('linux')
+
+  Dir.mktmpdir do |dir|
+    source = File.join(dir, 'ubsan_check.c')
+    binary = File.join(dir, 'ubsan_check')
+    File.write(source, "int main(void) { return 0; }\n")
+    tool_available?(%(gcc -fsanitize=undefined -o "#{binary}" "#{source}" 2>&1))
+  end
+end
+
 RSpec.shared_context "requires gdb" do
   before :all do
     @gdb_available = gdb_available?
@@ -222,5 +237,15 @@ RSpec.shared_context "requires bullseye" do
 
   before do
     skip "Bullseye (covc) is not installed, licensed, or not in PATH" unless @bullseye_available
+  end
+end
+
+RSpec.shared_context "requires gcc with UBSan" do
+  before :all do
+    @ubsan_available = ubsan_available?
+  end
+
+  before do
+    skip "gcc UBSan support not available (Linux + gcc -fsanitize=undefined required)" unless @ubsan_available
   end
 end

--- a/spec/system/deployment_as_gem_spec.rb
+++ b/spec/system/deployment_as_gem_spec.rb
@@ -92,6 +92,13 @@ ceedling_system_tests do
       test_case :crash_simple_sigsegv_all_test_cases
       test_case :crash_simple_sigabrt_assert_failure
       test_case :crash_simple_sigsegv_with_parameterized_test
+      test_case :crash_simple_diagnostic_retry_disagrees_with_main_fixture
+    end
+
+    describe "Crash handling with real UBSan" do
+      include_context "requires gcc with UBSan"
+
+      test_case :crash_simple_ubsan_diagnostic_retry_disagrees_with_main_fixture
     end
 
     describe "Backtrace with GDB" do

--- a/spec/system/deployment_as_vendor_spec.rb
+++ b/spec/system/deployment_as_vendor_spec.rb
@@ -95,6 +95,13 @@ ceedling_system_tests do
       test_case :crash_simple_sigsegv_all_test_cases
       test_case :crash_simple_sigabrt_assert_failure
       test_case :crash_simple_sigsegv_with_parameterized_test
+      test_case :crash_simple_diagnostic_retry_disagrees_with_main_fixture
+    end
+
+    describe "Crash handling with real UBSan" do
+      include_context "requires gcc with UBSan"
+
+      test_case :crash_simple_ubsan_diagnostic_retry_disagrees_with_main_fixture
     end
 
     describe "Backtrace with GDB" do

--- a/spec/system/support/common_test_cases.rb
+++ b/spec/system/support/common_test_cases.rb
@@ -5,6 +5,8 @@
 #   SPDX-License-Identifier: MIT
 # =========================================================================
 
+require 'rbconfig'
+
 module CommonSystemTestCases
   def can_report_version_no_git_commit_sha
     @c.with_context do
@@ -978,6 +980,78 @@ module CommonSystemTestCases
         log_path = './build/logs/test/test_example_file_crash_sigsegv_with_param/test_add_numbers_will_fail.gdb.log'
         expect(File.exist?(log_path)).to be(true)
         expect(File.read(log_path)).to match(/SIGSEGV|Segmentation fault/i)
+      end
+    end
+  end
+
+  # Regression test for issue #1198: a custom :test_fixture tool (e.g. a wrapper
+  # enabling a sanitizer's halt-on-error) can correctly detect a crash on the main run,
+  # only for that crash to be silently overwritten by a :simple backtrace diagnostic
+  # retry that runs through a *different*, independently-configured tool
+  # (test_fixture_simple_backtrace) and behaves differently there -- legitimately
+  # passing in that other environment. fake_crash_test_fixture.rb reproduces the
+  # mismatch without needing a real sanitizer: it always exits nonzero without ever
+  # running the real, bug-free test executable it's given, while the unmodified default
+  # backtrace retry tool runs that same executable directly and passes.
+  def crash_simple_diagnostic_retry_disagrees_with_main_fixture
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        FileUtils.cp test_asset_path("fake_crash_test_fixture.rb"), 'test/'
+
+        @c.merge_project_yml_for_test({
+          :project => { :use_backtrace => :simple },
+          :tools   => {
+            :test_fixture => {
+              :executable => RbConfig.ruby,
+              :arguments  => ['test/fake_crash_test_fixture.rb']
+            }
+          }
+        })
+
+        output = @c.ceedling_build_exec("test:all")
+        expect(@c.last_exit_status).not_to eq(0)
+        expect(output).to match(/Unit test failures/)
+        expect(output).not_to match(/PASSED:\s+1/)
+      end
+    end
+  end
+
+  # Same regression coverage as crash_simple_diagnostic_retry_disagrees_with_main_fixture
+  # above, but with a real UBSan-triggered crash (matching issue #1198's own
+  # reproduction exactly) instead of the portable simulated fixture. UBSan doesn't
+  # produce an OS-level crash signal the way a segfault does -- run_with_ubsan.rb's
+  # halt_on_error setting is what turns the undefined behavior into a hard stop, and
+  # only the main :test_fixture invocation goes through that wrapper. Requires a Linux
+  # gcc toolchain with -fsanitize=undefined support -- see "requires gcc with UBSan".
+  def crash_simple_ubsan_diagnostic_retry_disagrees_with_main_fixture
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("test_example_file_ub_shift_overflow.c"), 'test/'
+        FileUtils.cp test_asset_path("run_with_ubsan.rb"), 'test/'
+
+        @c.merge_project_yml_for_test({
+          :project => { :use_backtrace => :simple },
+          :flags   => {
+            :test => {
+              :compile => { '*' => ['-fsanitize=undefined'] },
+              :link    => { '*' => ['-fsanitize=undefined'] }
+            }
+          },
+          :tools => {
+            :test_fixture => {
+              :executable => RbConfig.ruby,
+              :arguments  => ['test/run_with_ubsan.rb', '${1}']
+            }
+          }
+        })
+
+        output = @c.ceedling_build_exec("test:all")
+        expect(@c.last_exit_status).not_to eq(0)
+        expect(output).to match(/Unit test failures/)
+        expect(output).not_to match(/PASSED:\s+1/)
       end
     end
   end

--- a/spec/units/generators/generator_helper_spec.rb
+++ b/spec/units/generators/generator_helper_spec.rb
@@ -21,30 +21,57 @@ describe GeneratorHelper do
     @helper = described_class.new({ :loginator => @loginator })
 
     # A minimal status double for shell_result[:status].
-    @ok_status = double('status', termsig: nil)
+    @ok_status = double('status', termsig: nil, signaled?: false, exitstatus: 0, success?: true)
   end
 
 
   # ---------------------------------------------------------------------------
   # Helper: build a shell_result hash
   # ---------------------------------------------------------------------------
-  def shell_result(output: VALID_STATS_OUTPUT, stderr: '', termsig: nil)
-    status = double('status', termsig: termsig)
+  # `success` left unspecified derives from `termsig`/`exitstatus` the way a real
+  # Process::Status would -- signaled or nonzero-exit is never success. Callers that
+  # need an inconsistent combination (a status that looks successful despite a nonzero
+  # exit, exercised nowhere here) can still pass `success:` explicitly.
+  def shell_result(output: VALID_STATS_OUTPUT, stderr: '', termsig: nil, exitstatus: 0, success: nil)
+    success = (termsig.nil? && exitstatus == 0) if success.nil?
+    status = double(
+      'status', termsig: termsig, signaled?: !termsig.nil?, exitstatus: exitstatus, success?: success
+    )
     { :output => output, :stderr => stderr, :status => status }
   end
 
 
   describe '#test_crash?' do
 
-    context 'SIGSEGV detection (termsig == 11)' do
-      it 'returns true when the process was terminated by signal 11' do
+    context 'signal death (any signal, not just SIGSEGV)' do
+      it 'returns true when the process was terminated by signal 11 (SIGSEGV)' do
         result = shell_result(termsig: 11)
         expect( @helper.test_crash?('test_foo.c', 'test_foo.out', result) ).to be true
       end
 
-      it 'does not flag SIGSEGV for other signal numbers' do
-        result = shell_result(termsig: 6)   # SIGABRT
+      it 'returns true when the process was terminated by signal 6 (SIGABRT) -- e.g. UBSan/ASan halt_on_error' do
+        result = shell_result(termsig: 6)
         # output still has stats, stderr is empty → only the signal check matters here
+        expect( @helper.test_crash?('test_foo.c', 'test_foo.out', result) ).to be true
+      end
+    end
+
+    context 'a clean summary contradicted by the real exit status' do
+      it 'returns true when 0 failures are reported but the real process exited nonzero and unsignaled' do
+        # e.g. LeakSanitizer detecting a leak during teardown, after every test case
+        # already printed and Unity's own summary already looked clean.
+        result = shell_result(output: VALID_STATS_OUTPUT, exitstatus: 1, success: false)
+        expect( @helper.test_crash?('test_foo.c', 'test_foo.out', result) ).to be true
+      end
+
+      it 'returns false when a nonzero real exit is consistent with Unity reporting real failures' do
+        failing_output = "\n---------\n2 Tests 1 Failures 0 Ignored\nFAIL\n"
+        result = shell_result(output: failing_output, exitstatus: 1, success: false)
+        expect( @helper.test_crash?('test_foo.c', 'test_foo.out', result) ).to be false
+      end
+
+      it 'returns false when 0 failures are reported and the real process exited successfully' do
+        result = shell_result(output: VALID_STATS_OUTPUT, exitstatus: 0, success: true)
         expect( @helper.test_crash?('test_foo.c', 'test_foo.out', result) ).to be false
       end
     end

--- a/spec/units/generators/generator_test_results_backtrace_spec.rb
+++ b/spec/units/generators/generator_test_results_backtrace_spec.rb
@@ -7,7 +7,9 @@
 
 require 'spec_helper'
 require 'ceedling/generators/generator_test_results_backtrace'
+require 'ceedling/generators/generator_helper'
 require 'ceedling/constants'
+require 'ceedling/exceptions'
 
 # ── Representative gdb output constants ──────────────────────────────────────
 
@@ -125,9 +127,9 @@ SIMPLE_ASSERT_CRASH_OUTPUT =
   "test_lib.out: src/lib.c:5: asserting: Assertion `0' failed.\n" \
   "Aborted (core dumped)\n"
 
-SIMPLE_PASS_OUTPUT   = "test_lib.c:3:test_empty:PASS\n"
-SIMPLE_FAIL_OUTPUT   = "test_lib.c:8:test_bad:FAIL: Expected 1 Was 2\n"
-SIMPLE_IGNORE_OUTPUT = "test_lib.c:12:test_skip:IGNORE\n"
+SIMPLE_PASS_OUTPUT   = "test_lib.c:3:test_empty:PASS\n---------\n1 Tests 0 Failures 0 Ignored\nOK\n"
+SIMPLE_FAIL_OUTPUT   = "test_lib.c:8:test_bad:FAIL: Expected 1 Was 2\n---------\n1 Tests 1 Failures 0 Ignored\nFAIL\n"
+SIMPLE_IGNORE_OUTPUT = "test_lib.c:12:test_skip:IGNORE\n---------\n1 Tests 0 Failures 1 Ignored\nOK\n"
 
 
 describe GeneratorTestResultsBacktrace do
@@ -140,15 +142,27 @@ describe GeneratorTestResultsBacktrace do
     @generator_test_results  = instance_double('GeneratorTestResults')
     @file_path_utils         = instance_double('FilePathUtils')
     @file_wrapper            = instance_double('FileWrapper')
+    @loginator               = double('loginator').as_null_object
+    # A real GeneratorHelper, not a double -- these tests exercise the actual crash
+    # detection logic a retry's status is checked against, not a stubbed stand-in for it.
+    @generator_helper        = GeneratorHelper.new({ :loginator => @loginator })
 
     @backtrace = described_class.new({
       :configurator           => @configurator,
       :tool_executor          => @tool_executor,
       :generator_test_results => @generator_test_results,
+      :generator_helper       => @generator_helper,
       :file_path_utils        => @file_path_utils,
-      :file_wrapper           => @file_wrapper
+      :file_wrapper           => @file_wrapper,
+      :loginator              => @loginator
     })
     @backtrace.setup()
+
+    # A healthy retry sub-process status -- the common case for most stubs below. Crash
+    # scenarios that already resolve via a missing result-line match (the pre-existing
+    # "unresolved" path) don't depend on this value at all; it's included on every stub
+    # anyway so `crash_result[:status]` is never unexpectedly missing.
+    @ok_status = double('status', signaled?: false, success?: true, exitstatus: 0, termsig: nil)
 
     # Standard stubs used by most tests
     allow(@tool_executor).to receive(:build_command_line).and_return({ options: {} })
@@ -173,37 +187,113 @@ describe GeneratorTestResultsBacktrace do
       allow(@configurator).to receive(:tools_test_backtrace_gdb).and_return({})
     end
 
+    # Companion helper: a genuinely-crashing group paired alongside the group under
+    # test, matching realistic multi-test-case usage -- do_gdb only ever runs because
+    # the main run already crashed, so an isolated group with nothing but a clean match
+    # is indistinguishable from the #1198 bug pattern (every retry legitimately clean,
+    # contradicting the crash that triggered this method) and correctly falls back on
+    # its own, tested separately below.
+    let(:companion_case) { { test: 'test_crashes_elsewhere', symbol: 'test_crashes_elsewhere', line_number: 20 } }
+
     it 'handles a PASS test case and does not write a log' do
-      allow(@tool_executor).to receive(:exec)
-        .and_return({ output: "test_lib.c:9:test_asserting:PASS\n", time: 0.1, exit_code: 0 })
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: GDB_NO_SIGNAL_OUTPUT, time: 0.1, exit_code: 1, stderr: '', status: @ok_status },
+        { output: "test_lib.c:9:test_asserting:PASS\n---------\n1 Tests 0 Failures 0 Ignored\nOK\n",
+          time: 0.1, exit_code: 0, stderr: '', status: @ok_status }
+      )
 
-      expect(@file_wrapper).not_to receive(:write)
+      expect(@file_wrapper).to receive(:write).once.with(%r{test_crashes_elsewhere}, anything, anything)
 
-      result = @backtrace.do_gdb( filename, executable, shell_result, test_cases, context: :test )
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
 
-      expect(result[:exit_code]).to eq(0)
+      @backtrace.do_gdb( filename, executable, shell_result, [companion_case] + test_cases, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:9:test_asserting:PASS')
     end
 
     it 'handles an IGNORE test case and does not write a log' do
-      allow(@tool_executor).to receive(:exec)
-        .and_return({ output: "test_lib.c:9:test_asserting:IGNORE\n", time: 0.1, exit_code: 0 })
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: GDB_NO_SIGNAL_OUTPUT, time: 0.1, exit_code: 1, stderr: '', status: @ok_status },
+        { output: "test_lib.c:9:test_asserting:IGNORE\n---------\n1 Tests 0 Failures 1 Ignored\nOK\n",
+          time: 0.1, exit_code: 0, stderr: '', status: @ok_status }
+      )
 
-      expect(@file_wrapper).not_to receive(:write)
+      expect(@file_wrapper).to receive(:write).once.with(%r{test_crashes_elsewhere}, anything, anything)
 
-      result = @backtrace.do_gdb( filename, executable, shell_result, test_cases, context: :test )
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
 
-      expect(result[:exit_code]).to eq(0)
+      @backtrace.do_gdb( filename, executable, shell_result, [companion_case] + test_cases, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:9:test_asserting:IGNORE')
     end
 
     it 'handles a FAIL test case and does not write a log' do
-      allow(@tool_executor).to receive(:exec)
-        .and_return({ output: "test_lib.c:9:test_asserting:FAIL: Expected 1 Was 2\n", time: 0.1, exit_code: 1 })
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: GDB_NO_SIGNAL_OUTPUT, time: 0.1, exit_code: 1, stderr: '', status: @ok_status },
+        { output: "test_lib.c:9:test_asserting:FAIL: Expected 1 Was 2\n---------\n1 Tests 1 Failures 0 Ignored\nFAIL\n",
+          time: 0.1, exit_code: 1, stderr: '', status: @ok_status }
+      )
 
-      expect(@file_wrapper).not_to receive(:write)
+      expect(@file_wrapper).to receive(:write).once.with(%r{test_crashes_elsewhere}, anything, anything)
+
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
+
+      @backtrace.do_gdb( filename, executable, shell_result, [companion_case] + test_cases, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:9:test_asserting:FAIL: Expected 1 Was 2')
+    end
+
+    it "does not trust a matched PASS line when the retry's own real status contradicts it" do
+      # Regression test for issue #1198: a diagnostic retry can print a clean Unity
+      # result line while its own real process outcome says otherwise.
+      bad_status = double('status', signaled?: false, success?: false, exitstatus: 1, termsig: nil)
+
+      allow(@tool_executor).to receive(:exec).and_return({
+        output: "test_lib.c:9:test_asserting:PASS\n---------\n1 Tests 0 Failures 0 Ignored\nOK\n",
+        time: 0.1, exit_code: 0, stderr: '', status: bad_status
+      })
+
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
 
       result = @backtrace.do_gdb( filename, executable, shell_result, test_cases, context: :test )
 
       expect(result[:exit_code]).to eq(1)
+      expect(expected_output_lines.first).to include(':FAIL:')
+    end
+
+    it 'falls back to a whole-file crash failure when no retry ever reproduces the crash the main run detected' do
+      # Regression test for issue #1198: every retry can legitimately pass in its own,
+      # differently-configured environment even though the main run genuinely crashed.
+      # An all-clean diagnostic must not be allowed to overrule that.
+      allow(@tool_executor).to receive(:exec).and_return({
+        output: "test_lib.c:9:test_asserting:PASS\n---------\n1 Tests 0 Failures 0 Ignored\nOK\n",
+        time: 0.1, exit_code: 0, stderr: '', status: @ok_status
+      })
+
+      fallback_result = { output: 'crash-failure-output', exit_code: 1 }
+      expect(@generator_test_results).to receive(:create_crash_failure)
+        .with(filename, shell_result, test_cases)
+        .and_return(fallback_result)
+
+      result = @backtrace.do_gdb( filename, executable, shell_result, test_cases, context: :test )
+
+      expect(result).to eq(fallback_result)
     end
 
     it 'handles a SIGSEGV crash — writes log, includes signal label, backtick source line, and log path' do
@@ -211,7 +301,7 @@ describe GeneratorTestResultsBacktrace do
       filename_sigsegv   = 'TestUsartModel.c'
 
       allow(@tool_executor).to receive(:exec)
-        .and_return({ output: GDB_SIGSEGV_OUTPUT, time: 0.5, exit_code: 139 })
+        .and_return({ output: GDB_SIGSEGV_OUTPUT, time: 0.5, exit_code: 139, stderr: '', status: @ok_status })
 
       expected_output_lines = []
       allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
@@ -241,7 +331,7 @@ describe GeneratorTestResultsBacktrace do
       filename_param = 'test_module_d.c'
 
       allow(@tool_executor).to receive(:exec)
-        .and_return({ output: GDB_SIGSEGV_PARAM_OUTPUT, time: 0.5, exit_code: 139 })
+        .and_return({ output: GDB_SIGSEGV_PARAM_OUTPUT, time: 0.5, exit_code: 139, stderr: '', status: @ok_status })
 
       expected_output_lines = []
       allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
@@ -267,7 +357,7 @@ describe GeneratorTestResultsBacktrace do
       test_cases_assert = [{ test: 'test_asserting', symbol: 'test_asserting', line_number: 8 }]
 
       allow(@tool_executor).to receive(:exec)
-        .and_return({ output: GDB_SIGABRT_ASSERT_OUTPUT, time: 0.3, exit_code: 134 })
+        .and_return({ output: GDB_SIGABRT_ASSERT_OUTPUT, time: 0.3, exit_code: 134, stderr: '', status: @ok_status })
 
       expected_output_lines = []
       allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
@@ -288,7 +378,7 @@ describe GeneratorTestResultsBacktrace do
 
     it 'handles a crash with no identifiable signal — fallback message, log path without "log: " prefix' do
       allow(@tool_executor).to receive(:exec)
-        .and_return({ output: GDB_NO_SIGNAL_OUTPUT, time: 0.1, exit_code: 1 })
+        .and_return({ output: GDB_NO_SIGNAL_OUTPUT, time: 0.1, exit_code: 1, stderr: '', status: @ok_status })
 
       expected_output_lines = []
       allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
@@ -317,42 +407,115 @@ describe GeneratorTestResultsBacktrace do
       allow(@configurator).to receive(:tools_test_fixture_simple_backtrace).and_return({})
     end
 
+    # Each of the three cases below is paired with a companion group that genuinely
+    # crashes -- a realistic multi-test-case file, where the group under test is only
+    # one of several. Without a companion, an isolated group with nothing but a clean
+    # match is indistinguishable from the #1198 bug pattern (every retry legitimately
+    # clean, contradicting the crash do_simple only ever runs because of) and correctly
+    # triggers the whole-file fallback tested below in its own right.
+
     it 'handles a PASS test case' do
-      allow(@tool_executor).to receive(:exec)
-        .and_return({ output: SIMPLE_PASS_OUTPUT, time: 0.05, exit_code: 0 })
+      test_cases_multi = [{ test: 'test_crashes_elsewhere', line_number: 20 }] + test_cases
 
-      result = @backtrace.do_simple( filename, executable, shell_result, test_cases, context: :test )
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: SIMPLE_ASSERT_CRASH_OUTPUT, time: 0.1, exit_code: 134, stderr: '', status: @ok_status },
+        { output: SIMPLE_PASS_OUTPUT, time: 0.05, exit_code: 0, stderr: '', status: @ok_status }
+      )
 
-      expect(result[:exit_code]).to eq(0)
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
+
+      @backtrace.do_simple( filename, executable, shell_result, test_cases_multi, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:3:test_empty:PASS')
     end
 
     it 'handles a FAIL test case with a message' do
-      test_cases_fail = [{ test: 'test_bad', line_number: 8 }]
+      test_cases_fail = [{ test: 'test_crashes_elsewhere', line_number: 20 }, { test: 'test_bad', line_number: 8 }]
 
-      allow(@tool_executor).to receive(:exec)
-        .and_return({ output: SIMPLE_FAIL_OUTPUT, time: 0.05, exit_code: 1 })
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: SIMPLE_ASSERT_CRASH_OUTPUT, time: 0.1, exit_code: 134, stderr: '', status: @ok_status },
+        { output: SIMPLE_FAIL_OUTPUT, time: 0.05, exit_code: 1, stderr: '', status: @ok_status }
+      )
 
-      result = @backtrace.do_simple( filename, executable, shell_result, test_cases_fail, context: :test )
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
 
-      expect(result[:exit_code]).to eq(1)
+      @backtrace.do_simple( filename, executable, shell_result, test_cases_fail, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:8:test_bad:FAIL: Expected 1 Was 2')
     end
 
     it 'handles an IGNORE test case' do
-      test_cases_ignore = [{ test: 'test_skip', line_number: 12 }]
+      test_cases_ignore = [{ test: 'test_crashes_elsewhere', line_number: 20 }, { test: 'test_skip', line_number: 12 }]
+
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: SIMPLE_ASSERT_CRASH_OUTPUT, time: 0.1, exit_code: 134, stderr: '', status: @ok_status },
+        { output: SIMPLE_IGNORE_OUTPUT, time: 0.02, exit_code: 0, stderr: '', status: @ok_status }
+      )
+
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
+
+      @backtrace.do_simple( filename, executable, shell_result, test_cases_ignore, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:12:test_skip:IGNORE')
+    end
+
+    it "does not trust a matched PASS line when the retry's own real status contradicts it" do
+      # Regression test for issue #1198: a diagnostic retry can print a clean Unity
+      # result line while its own real process outcome says otherwise.
+      bad_status = double('status', signaled?: false, success?: false, exitstatus: 1, termsig: nil)
 
       allow(@tool_executor).to receive(:exec)
-        .and_return({ output: SIMPLE_IGNORE_OUTPUT, time: 0.02, exit_code: 0 })
+        .and_return({ output: SIMPLE_PASS_OUTPUT, time: 0.05, exit_code: 0, stderr: '', status: bad_status })
 
-      result = @backtrace.do_simple( filename, executable, shell_result, test_cases_ignore, context: :test )
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
 
-      expect(result[:exit_code]).to eq(0)
+      result = @backtrace.do_simple( filename, executable, shell_result, test_cases, context: :test )
+
+      expect(result[:exit_code]).to eq(1)
+      expect(expected_output_lines.first).to include(':FAIL:')
+    end
+
+    it 'falls back to a whole-file crash failure when no retry ever reproduces the crash the main run detected' do
+      # Regression test for issue #1198: the exact reported scenario -- a custom
+      # :test_fixture wrapper enables sanitizer halt-on-error and the main run crashes,
+      # but the unrelated, independently-configured test_fixture_simple_backtrace tool
+      # runs the same executable directly, without the wrapper, and it legitimately
+      # passes. Every retry can be entirely clean and still must not overrule a crash
+      # Ceedling already established.
+      allow(@tool_executor).to receive(:exec)
+        .and_return({ output: SIMPLE_PASS_OUTPUT, time: 0.05, exit_code: 0, stderr: '', status: @ok_status })
+
+      fallback_result = { output: 'crash-failure-output', exit_code: 1 }
+      expect(@generator_test_results).to receive(:create_crash_failure)
+        .with(filename, shell_result, test_cases)
+        .and_return(fallback_result)
+
+      result = @backtrace.do_simple( filename, executable, shell_result, test_cases, context: :test )
+
+      expect(result).to eq(fallback_result)
     end
 
     it 'handles a crash and includes extra executable output in the failure message' do
       test_cases_crash = [{ test: 'test_asserting', line_number: 8 }]
 
       allow(@tool_executor).to receive(:exec)
-        .and_return({ output: SIMPLE_ASSERT_CRASH_OUTPUT, time: 0.1, exit_code: 134 })
+        .and_return({ output: SIMPLE_ASSERT_CRASH_OUTPUT, time: 0.1, exit_code: 134, stderr: '', status: @ok_status })
 
       expected_output_lines = []
       allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
@@ -372,7 +535,7 @@ describe GeneratorTestResultsBacktrace do
       test_cases_crash = [{ test: 'test_asserting', line_number: 8 }]
 
       allow(@tool_executor).to receive(:exec)
-        .and_return({ output: "\n\n\n", time: 0.1, exit_code: 134 })
+        .and_return({ output: "\n\n\n", time: 0.1, exit_code: 134, stderr: '', status: @ok_status })
 
       expected_output_lines = []
       allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
@@ -515,7 +678,7 @@ describe GeneratorTestResultsBacktrace do
 
     it 'uses assertion label and metadata line number when no crash location frame is found' do
       allow(@tool_executor).to receive(:exec)
-        .and_return({ output: GDB_WINDOWS_ASSERT_BRIEF_OUTPUT, time: 0.1, exit_code: 3 })
+        .and_return({ output: GDB_WINDOWS_ASSERT_BRIEF_OUTPUT, time: 0.1, exit_code: 3, stderr: '', status: @ok_status })
 
       expected_output_lines = []
       allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|

--- a/spec/units/system_wrapper_spec.rb
+++ b/spec/units/system_wrapper_spec.rb
@@ -1,0 +1,72 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/system_wrapper'
+
+describe SystemWrapper do
+  before(:each) do
+    @sys_wrapper = described_class.new
+  end
+
+  # Portable, real subprocess invocations -- no shell scripting, no signals (those are
+  # covered where they're actually consumed, via doubles, in generator_helper_spec.rb).
+  # This spec exists to characterize shell_capture3's own contract: it is the sole place
+  # a subprocess's real Process::Status is captured, and the one thing downstream crash
+  # detection depends on entirely.
+  def ruby_command(code)
+    "#{RbConfig.ruby} -e #{code.inspect}"
+  end
+
+  describe '#shell_capture3' do
+    context 'boom: false (the default, and how test-fixture execution always runs)' do
+      it 'forces exit_code to 0 even though the real subprocess exited nonzero' do
+        result = @sys_wrapper.shell_capture3( command: ruby_command('exit 3'), boom: false )
+        expect(result[:exit_code]).to eq(0)
+      end
+
+      it 'still relays the real, un-neutered Process::Status' do
+        result = @sys_wrapper.shell_capture3( command: ruby_command('exit 3'), boom: false )
+        expect(result[:status]).not_to be_nil
+        expect(result[:status].exitstatus).to eq(3)
+        expect(result[:status].success?).to be false
+      end
+
+      it 'forces exit_code to 0 for a genuinely successful subprocess too' do
+        result = @sys_wrapper.shell_capture3( command: ruby_command('exit 0'), boom: false )
+        expect(result[:exit_code]).to eq(0)
+        expect(result[:status].success?).to be true
+      end
+    end
+
+    context 'boom: true' do
+      it 'surfaces the real nonzero exit code' do
+        result = @sys_wrapper.shell_capture3( command: ruby_command('exit 3'), boom: true )
+        expect(result[:exit_code]).to eq(3)
+      end
+
+      it 'reports 0 for a genuinely successful subprocess' do
+        result = @sys_wrapper.shell_capture3( command: ruby_command('exit 0'), boom: true )
+        expect(result[:exit_code]).to eq(0)
+      end
+
+      it 'still relays the same real Process::Status as boom: false does' do
+        result = @sys_wrapper.shell_capture3( command: ruby_command('exit 3'), boom: true )
+        expect(result[:status].exitstatus).to eq(3)
+      end
+    end
+
+    it 'combines stdout and stderr into :output while keeping each stream separately available' do
+      result = @sys_wrapper.shell_capture3(
+        command: ruby_command('STDOUT.print "out"; STDERR.print "err"'), boom: false
+      )
+      expect(result[:stdout]).to eq('out')
+      expect(result[:stderr]).to eq('err')
+      expect(result[:output]).to eq('outerr')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #1198 for `next_version`/1.2.0.

Ceedling could exit 0 after a test fixture genuinely crashed. `:use_backtrace` diagnostic retries (`:simple`, `:gdb`) run through a separate, independently-configured tool that doesn't inherit the main `:test_fixture`'s own configuration -- e.g. a custom wrapper enabling a sanitizer's halt-on-error. A retry that behaved differently in its own environment (recovering instead of halting) produced a clean `PASS` that silently overwrote the crash already detected on the main run.

This is a direct cherry-pick of #1200 (the `master`/1.1.4 fix) -- `generator_helper.rb`, `generator_test_results_backtrace.rb`, and `system_wrapper.rb` are identical between the two branches in this area, so the same patch applies unchanged aside from one path convention conflict (`assets/` vs. `assets/fixtures/`) and an additive conflict in `spec_system_helper.rb` against `next_version`'s own new Bullseye-gating helper, both resolved directly.

- `GeneratorHelper#test_crash?` broadened from a `SIGSEGV`-only signal check to any signal death, plus a new check: a clean summary (0 failures) is not trustworthy if the real process still exited nonzero afterward.
- The same check is now reused per retry sub-run inside `do_simple`/`do_gdb`. If no retry group, across the whole file, ever shows real crash evidence, the diagnostic falls back to reporting the original crash rather than an all-clear result that contradicts it.
- New `spec/units/system_wrapper_spec.rb`: no prior coverage existed for `shell_capture3`'s exit-code-zeroing/status-preservation contract, which this fix depends on entirely.
- New system-spec regression coverage: a portable, sanitizer-free reproduction (`crash_simple_diagnostic_retry_disagrees_with_main_fixture`, both deployment modes) plus a real-UBSan counterpart matching the issue's exact reproduction (Linux-only, gated behind toolchain detection, skipped elsewhere).

## Test plan

- `bundle exec rspec spec/units/generators/generator_helper_spec.rb spec/units/generators/generator_test_results_backtrace_spec.rb spec/units/system_wrapper_spec.rb`
- `bundle exec rake specs:units`
- Reproduced issue #1198's own UBSan repro directly via `bin/ceedling` against this branch: exit code is now nonzero and the crash is correctly reported instead of a contradictory `PASS`.
