### PR TITLE
Fix #1203: Partial mocks silently drop declaration-only functions

### DIFF
--- a/assets/partial_all_module.h
+++ b/assets/partial_all_module.h
@@ -1,0 +1,11 @@
+#ifndef PARTIAL_ALL_MODULE_H
+#define PARTIAL_ALL_MODULE_H
+
+void PartialAllModule_Init(int value);
+
+static inline int PartialAllModule_DoubleValue(int value)
+{
+  return value * 2;
+}
+
+#endif

--- a/assets/test_partial_all_module.c
+++ b/assets/test_partial_all_module.c
@@ -1,0 +1,16 @@
+#include "unity.h"
+#include "ceedling.h"
+
+#include MOCK_PARTIAL_ALL_MODULE(partial_all_module)
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_all_module_should_mock_both_a_plain_prototype_and_a_static_inline_function(void)
+{
+  PartialAllModule_Init_Expect(3);
+  PartialAllModule_Init(3);
+
+  PartialAllModule_DoubleValue_ExpectAndReturn(3, 6);
+  TEST_ASSERT_EQUAL_INT(6, PartialAllModule_DoubleValue(3));
+}

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -19,6 +19,7 @@ This changelog is complemented by three other documents:
 
 ### Partials
 
+- [#1203](https://github.com/ThrowTheSwitch/Ceedling/issues/1203) Fixed `MOCK_PARTIAL_ALL_MODULE()` (and `MOCK_PARTIAL_PUBLIC_MODULE()`/`MOCK_PARTIAL_PRIVATE_MODULE()`) silently omitting a function from the mock interface in certain cases where no function body could be found in the module.
 - [#1189](https://github.com/ThrowTheSwitch/Ceedling/issues/1189)/[#1187](https://github.com/ThrowTheSwitch/Ceedling/issues/1187) Fixed `const`/`volatile`/`restrict` qualifiers stripped from a Partial's generated `extern` declaration and definition for a promoted variable.
 - Fixed C variable extraction discarding a pointer's own qualifier (e.g. the second `const` in `const uint8_t* const ptr;`) whenever the same qualifier keyword also led the declaration.
 - [#1190](https://github.com/ThrowTheSwitch/Ceedling/issues/1190)/[#1187](https://github.com/ThrowTheSwitch/Ceedling/issues/1187) Fixed a module's typedefs and aggregate (struct/enum/union) definitions being generated into both its Test Partial and Mock Partial headers, causing a redefinition error when a test file uses both for the same module. Such content is now generated once into a shared header with unique include guard that both Partial headers, in turn, include.

--- a/lib/ceedling/partials/partializer.rb
+++ b/lib/ceedling/partials/partializer.rb
@@ -349,8 +349,15 @@ class Partializer
       Verbosity::DEBUG
     )
 
+    # A mock interface only ever needs a signature, never a body, so a declaration-only
+    # function (no body found anywhere in this module's merged content) is just as valid a
+    # candidate as one with a definition -- unlike extract_implementation_functions, which
+    # needs real code to inject and so stays definitions-only. A function named in both
+    # (declared in the header, defined in the paired source) is only counted once.
+    candidates = definitions + declarations.reject { |d| definitions.any? { |f| f.name == d.name } }
+
     # Build initial list by visibility; ACCUMULATE yields []
-    funcs = @helper.filter_and_transform_funcs(definitions, pf.type, :interface)
+    funcs = @helper.filter_and_transform_funcs(candidates, pf.type, :interface)
 
     # Additions: search definitions first, then declarations
     pf.additions.each do |name|

--- a/lib/ceedling/partials/partializer_utils.rb
+++ b/lib/ceedling/partials/partializer_utils.rb
@@ -47,9 +47,14 @@ class PartializerUtils
         code_block:      new_code_block
       )
     when :interface
+      # A signature sourced from a CFunctionDefinition never carries a trailing semicolon
+      # (it's followed by a body, not one), but a signature sourced from a
+      # CFunctionDeclaration always does (it's a bare prototype). Strip it here so
+      # callers can render "#{signature};" uniformly regardless of which kind of
+      # function this interface entry came from.
       Partials.manufacture_function_declaration(
         name: func.name,
-        signature: signature
+        signature: signature.sub(/;\s*\z/, '')
       )
     else
       PartializerRuntime.raise_on_option(output_type)

--- a/spec/system/deployment_as_gem_spec.rb
+++ b/spec/system/deployment_as_gem_spec.rb
@@ -65,6 +65,10 @@ ceedling_system_tests do
       test_case :test_project_preprocessing_same_dir_mock_pairing
     end
 
+    describe "Partials" do
+      test_case :test_project_partial_all_module_mocks_declaration_only_function
+    end
+
     describe "Defines and configuration" do
       test_case :test_project_with_per_file_defines
       test_case :test_project_with_test_and_vendor_defines

--- a/spec/system/deployment_as_vendor_spec.rb
+++ b/spec/system/deployment_as_vendor_spec.rb
@@ -68,6 +68,10 @@ ceedling_system_tests do
       test_case :test_project_preprocessing_same_dir_mock_pairing
     end
 
+    describe "Partials" do
+      test_case :test_project_partial_all_module_mocks_declaration_only_function
+    end
+
     describe "Defines and configuration" do
       test_case :test_project_with_per_file_defines
       test_case :test_project_with_test_and_vendor_defines
@@ -181,6 +185,10 @@ ceedling_system_tests do
       test_case :test_project_with_preprocessing_for_missing_mock
       test_case :test_project_with_preprocessing_all
       test_case :test_project_preprocessing_same_dir_mock_pairing
+    end
+
+    describe "Partials" do
+      test_case :test_project_partial_all_module_mocks_declaration_only_function
     end
 
     describe "Defines and configuration" do

--- a/spec/system/support/common_test_cases.rb
+++ b/spec/system/support/common_test_cases.rb
@@ -475,6 +475,33 @@ module CommonSystemTestCases
     end
   end
 
+  # A module header with both a plain (non-inline) function prototype and a `static
+  # inline` function, with no paired .c source providing a body for the plain prototype
+  # (so it exists only as a bare declaration, never a definition). MOCK_PARTIAL_ALL_MODULE()
+  # must mock both functions, not just the one with a body.
+  def test_project_partial_all_module_mocks_declaration_only_function
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("partial_all_module.h"), 'src/'
+        FileUtils.cp test_asset_path("test_partial_all_module.c"), 'test/'
+
+        settings = {
+          :project => {
+            :use_partials          => true,
+            :use_test_preprocessor => :all
+          }
+        }
+        @c.merge_project_yml_for_test(settings)
+
+        output = @c.ceedling_build_exec("test:partial_all_module")
+        expect(@c.last_exit_status).to eq(0) # Successful build and tests
+        expect(output).to match(/TESTED:\s+1/)
+        expect(output).to match(/PASSED:\s+1/)
+        expect(output).to match(/FAILED:\s+0/)
+      end
+    end
+  end
+
   def test_project_fail
     @c.with_context do
       Dir.chdir @proj_name do

--- a/spec/units/partials/partializer_spec.rb
+++ b/spec/units/partials/partializer_spec.rb
@@ -1571,6 +1571,66 @@ describe Partializer do
       expect(result).to eq(filtered)
     end
 
+    it "merges declaration-only functions into the DEDUCT candidate pool" do
+      defn     = double('inline_func', name: 'inline_fn')
+      decl     = double('proto_func', name: 'proto_fn')
+      defs     = [defn]
+      decls    = [decl]
+      filtered = [double('iface_inline'), double('iface_proto')]
+      pf       = make_pf(type: Partials::DEDUCT)
+
+      expect(@partializer_helper).to receive(:filter_and_transform_funcs)
+        .with([defn, decl], Partials::DEDUCT, :interface).and_return(filtered)
+      allow(@partializer_helper).to receive(:subtract_funcs)
+        .with(funcs: filtered, names: []).and_return(filtered)
+
+      result = @partializer.extract_interface_functions(
+        test: 'test_mod', partial: 'mod',
+        definitions: defs, declarations: decls, config: make_config(mocks: pf)
+      )
+      expect(result).to eq(filtered)
+    end
+
+    it "merges declaration-only functions into the PUBLIC candidate pool too" do
+      defn     = double('def_func', name: 'pub_def')
+      decl     = double('decl_func', name: 'pub_decl')
+      defs     = [defn]
+      decls    = [decl]
+      filtered = [double('iface_func')]
+      pf       = make_pf(type: Partials::PUBLIC)
+
+      expect(@partializer_helper).to receive(:filter_and_transform_funcs)
+        .with([defn, decl], Partials::PUBLIC, :interface).and_return(filtered)
+      allow(@partializer_helper).to receive(:subtract_funcs)
+        .with(funcs: filtered, names: []).and_return(filtered)
+
+      result = @partializer.extract_interface_functions(
+        test: 'test_mod', partial: 'mod',
+        definitions: defs, declarations: decls, config: make_config(mocks: pf)
+      )
+      expect(result).to eq(filtered)
+    end
+
+    it "excludes a declaration already present as a definition with the same name (dedup)" do
+      defn     = double('def_func', name: 'shared')
+      decl     = double('decl_func', name: 'shared') # e.g. header prototype for the same function
+      defs     = [defn]
+      decls    = [decl]
+      filtered = [double('iface_func')]
+      pf       = make_pf(type: Partials::DEDUCT)
+
+      expect(@partializer_helper).to receive(:filter_and_transform_funcs)
+        .with([defn], Partials::DEDUCT, :interface).and_return(filtered)
+      allow(@partializer_helper).to receive(:subtract_funcs)
+        .with(funcs: filtered, names: []).and_return(filtered)
+
+      result = @partializer.extract_interface_functions(
+        test: 'test_mod', partial: 'mod',
+        definitions: defs, declarations: decls, config: make_config(mocks: pf)
+      )
+      expect(result).to eq(filtered)
+    end
+
     it "fills list from additions only for ACCUMULATE type" do
       defs   = [double('def', name: 'named')]
       decls  = []
@@ -1598,8 +1658,10 @@ describe Partializer do
       found = double('iface_func', name: 'decl_only')
       pf    = make_pf(type: Partials::ACCUMULATE, additions: ['decl_only'])
 
+      # candidates = definitions + declarations (ACCUMULATE ignores this list regardless --
+      # it always starts empty -- but it's still built before the type check discards it).
       allow(@partializer_helper).to receive(:filter_and_transform_funcs)
-        .with(defs, Partials::ACCUMULATE, :interface).and_return([])
+        .with(decls, Partials::ACCUMULATE, :interface).and_return([])
       expect(@partializer_helper).to receive(:find_and_transform_func)
         .with(name: 'decl_only', primary_funcs: defs, secondary_funcs: decls, output_type: :interface)
         .and_return(found)

--- a/spec/units/partials/partializer_utils_spec.rb
+++ b/spec/units/partials/partializer_utils_spec.rb
@@ -166,6 +166,17 @@ describe PartializerUtils do
         expect(result.signature).to eq(signature)
         expect(result).not_to respond_to(:code_block)
       end
+
+      it "strips a trailing semicolon from a declaration-sourced signature" do
+        # CFunctionDeclaration#signature_stripped always carries its own trailing
+        # semicolon (it's a bare prototype); CFunctionDefinition#signature_stripped never
+        # does. Callers render "#{signature};" uniformly, so this must not double up.
+        signature = 'void testFunc(int x);'
+
+        result = @utils.transform_function(mock_func, signature, :interface)
+
+        expect(result.signature).to eq('void testFunc(int x)')
+      end
     end
 
     context "when output_type is invalid" do


### PR DESCRIPTION
## Summary

- Fixes #1203: `MOCK_PARTIAL_ALL_MODULE()` (and `MOCK_PARTIAL_PUBLIC_MODULE()`/`MOCK_PARTIAL_PRIVATE_MODULE()`) silently dropped any function that only ever appears as a bare prototype — no `static`/`inline` body in the header, and no definition merged in from a paired `.c` source (e.g. a vendor SDK header mocked without its own `.c` implementation being part of the project).
- Root cause: `Partializer#extract_interface_functions` built its base candidate list from function *definitions* only, for every visibility type. `declarations` (bare prototypes) were only ever consulted as a fallback for explicit `MOCK_PARTIAL_CONFIG()` additions — and additions are forbidden entirely for `ALL_MODULE`. A plain prototype had no path into the mock interface at all.
- Fix: fold declaration-only functions into the candidate pool before visibility filtering — a mock interface only ever needs a signature, never a body, so a bare prototype is just as valid a candidate as a defined function. A function present in both lists (declared in the header, defined in its paired source) is only counted once. `extract_implementation_functions` is intentionally left untouched — a Partial's real, testable implementation needs actual code to inject, which a declaration-only function structurally cannot provide.
- Also fixes an incidental double-semicolon in generated interface headers (`void Foo(void);;`) exposed by this same code path.

## Test plan

- [x] New unit coverage in `spec/units/partials/partializer_spec.rb` (DEDUCT/PUBLIC candidate-pool merging, dedup case) and `spec/units/partials/partializer_utils_spec.rb` (semicolon fix).
- [x] Full unit suite: 1955 examples, 0 failures.
- [x] New system-spec regression case with fixtures reproducing the reported shape (plain prototype + `static inline` function, no paired `.c` source, `MOCK_PARTIAL_ALL_MODULE()`'d).
- [x] Manually verified end-to-end via `bin/ceedling` against a hand-built reproduction mirroring the issue's own `fsl_gpio.h` scenario (`GPIO_PinInit` + a `static inline` `GPIO_PinWrite`): both functions are now correctly mocked. Confirmed the same fixtures/settings fail against unfixed source and pass after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)