### PR TITLE
Log a diagnostic when a filepath approaches or exceeds its platform's practical length limit

### DIFF
--- a/bin/objects.yml
+++ b/bin/objects.yml
@@ -11,8 +11,13 @@
 #
 
 file_wrapper:
+  compose:
+    - loginator
+    - verbosinator
 
 yaml_wrapper:
+  compose:
+    - file_wrapper
 
 ruby_expandinator:
 
@@ -29,7 +34,6 @@ rake_task_registry:
 loginator:
   compose:
     - verbosinator
-    - file_wrapper
     - system_wrapper
 
 #

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -30,7 +30,7 @@ In Ceedling’s early history simplicity won out with the assumption that every 
 Added support for multiple [file extensions](https://throwtheswitch.github.io/Ceedling/latest/configuration/reference/extension/) per type (e.g. `:extension` ↳ `:source` ⇒ `['.c', '.C']`) such as requested in [#947](https://github.com/ThrowTheSwitch/Ceedling/issues/947).
 
 ### Filepath limit checks
-Platform filepath limits (especially Windows) can lead to mysterious build failures, especially in CI where deep project subdirectories can occur. Filepaths are intercepted and their lengths logged if they are nearing or exceed the platform limit to help track down funny business.
+Platform filepath limits (especially Windows) can lead to mysterious build failures, especially in CI where deep project subdirectories can occur. To help track down funny business, filepaths are intercepted and their lengths logged if they are nearing or exceed the platform limit.
 
 ## ⚠️ Changed
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -29,6 +29,9 @@ In Ceedling’s early history simplicity won out with the assumption that every 
 ### Multiple file extensions per file type
 Added support for multiple [file extensions](https://throwtheswitch.github.io/Ceedling/latest/configuration/reference/extension/) per type (e.g. `:extension` ↳ `:source` ⇒ `['.c', '.C']`) such as requested in [#947](https://github.com/ThrowTheSwitch/Ceedling/issues/947).
 
+### Filepath limit checks
+Platform filepath limits (especially Windows) can lead to mysterious build failures, especially in CI where deep project subdirectories can occur. Filepaths are intercepted and their lengths logged if they are nearing or exceed the platform limit to help track down funny business.
+
 ## ⚠️ Changed
 
 ### `#include` relative paths & duplicate filename disambiguation
@@ -39,7 +42,7 @@ Because of the support added for handling paths and distinguishing duplicated fi
 
 ---
 
-# [1.1.4] — Prerelease
+# [1.1.4] — 2026-08-13
 
 ## 💪 Fixed
 

--- a/lib/ceedling/c_extractor/c_extractor.rb
+++ b/lib/ceedling/c_extractor/c_extractor.rb
@@ -18,7 +18,7 @@ class CExtractor
   include CExtractorConstants
   include CExtractorTypes
 
-  constructor :c_extractor_code_text, :c_extractor_functions, :c_extractor_declarations, :c_extractor_preprocessing, :c_extractor_definitions, :configurator, :loginator
+  constructor :c_extractor_code_text, :c_extractor_functions, :c_extractor_declarations, :c_extractor_preprocessing, :c_extractor_definitions, :configurator, :loginator, :file_wrapper
 
   attr_writer :chunk_size, :max_buffer_length
 
@@ -45,7 +45,7 @@ class CExtractor
   #   CeedlingException: If file cannot be opened (permissions, doesn't exist, etc.)
   def from_file(filepath)
     begin
-      File.open(filepath, 'r') do |file|
+      @file_wrapper.open(filepath, 'r') do |file|
         return extract_contents( file, filepath )
       end
     rescue => ex

--- a/lib/ceedling/erb_wrapper.rb
+++ b/lib/ceedling/erb_wrapper.rb
@@ -8,8 +8,11 @@
 require 'erb'
 
 class ErbWrapper
+
+  constructor :file_wrapper
+
   def generate_file(template, data, output_file)
-    File.open(output_file, "w") do |f|
+    @file_wrapper.open(output_file, "w") do |f|
       f << ERB.new(template, trim_mode: "<>").result(binding)
     end
   end

--- a/lib/ceedling/file_path_utils.rb
+++ b/lib/ceedling/file_path_utils.rb
@@ -406,13 +406,16 @@ class FilePathUtils
     parts << context.to_s if context
     parts << subdir
     parts << name if name
-    File.join( *parts )
+    path = File.join( *parts )
+    @file_wrapper.check_path_length( path, origin: 'FilePathUtils#form_build_context_path' )
+    return path
   end
 
   # Forms base/name[/subdir]
   def form_named_path(base, name, subdir: nil)
-    return File.join( base, name, subdir ) if subdir
-    File.join( base, name )
+    path = subdir ? File.join( base, name, subdir ) : File.join( base, name )
+    @file_wrapper.check_path_length( path, origin: 'FilePathUtils#form_named_path' )
+    return path
   end
 
   # The mirrored-subdirectory portion of a test's own identity, excluding its own basename

--- a/lib/ceedling/file_wrapper.rb
+++ b/lib/ceedling/file_wrapper.rb
@@ -11,9 +11,28 @@ require 'fileutils'
 require 'pathname'
 require 'tmpdir'
 require 'ceedling/constants'
+require 'ceedling/system_wrapper'
 
 
 class FileWrapper
+
+  constructor :loginator, :verbosinator
+
+  # Platform practical filepath length ceilings, used only as a diagnostic heuristic --
+  # neither Ruby nor the host OS exposes a portable, runtime-queryable API for this.
+  # POSIX pathconf(2) is the real mechanism (PATH_MAX can vary by filesystem/mount
+  # point, so it's a per-path query, not a system-wide sysconf() value), but Ruby's Etc
+  # module defines the PC_PATH_MAX/PC_NAME_MAX pathconf constants without exposing a
+  # pathconf method to use them. Windows has no Ruby-accessible equivalent at all
+  # without an FFI dependency. These are the stable, documented OS/libc defaults
+  # instead: Windows' legacy MAX_PATH, and macOS/Linux's PATH_MAX from their own libc
+  # headers (a project can opt into longer paths on some platforms, but that's not
+  # safely assumable here, so these stay conservative).
+  PATH_LENGTH_LIMITS = {
+    windows: 260,
+    macos:   1024,
+    linux:   4096,
+  }.freeze
 
   def self.generate_include_guard(name)
     # abc-XYZ.h --> _ABC_XYZ_H_
@@ -72,6 +91,7 @@ class FileWrapper
   end
 
   def cp(source, destination, options={})
+    check_path_length(destination, origin: 'FileWrapper#cp')
     FileUtils.cp(source, destination, **options)
   end
 
@@ -96,6 +116,9 @@ class FileWrapper
   end
 
   def open(filepath, flags)
+    # Only writing/creating/appending can run into a platform's filepath length ceiling --
+    # a read-mode open is against a path that (if it exists) already fit on disk.
+    check_path_length(filepath, origin: 'FileWrapper#open') if flags.to_s =~ /[wa+]/
     File.open(filepath, flags) do |file|
       yield(file)
     end
@@ -120,12 +143,14 @@ class FileWrapper
   end
 
   def write_blank_file(filepath)
+    check_path_length(filepath, origin: 'FileWrapper#write_blank_file')
     File.open(filepath, 'w') do |file|
       file.write("// Ceedling intentionally blank file\n\n")
     end
   end
 
   def write(filepath, contents, flags='w')
+    check_path_length(filepath, origin: 'FileWrapper#write')
     File.open(filepath, flags) do |file|
       file.write(contents)
     end
@@ -140,6 +165,7 @@ class FileWrapper
   end
 
   def mkdir(folder)
+    check_path_length(folder, origin: 'FileWrapper#mkdir')
     return FileUtils.mkdir_p(folder)
   end
 
@@ -147,7 +173,42 @@ class FileWrapper
   # `parent` must already exist. Collision-free even across concurrent callers targeting
   # the same `parent` -- Dir.mktmpdir retries internally on name clash.
   def mkdir_tmp(prefix, parent)
-    return Dir.mktmpdir(prefix, parent)
+    path = Dir.mktmpdir(prefix, parent)
+    check_path_length(path, origin: 'FileWrapper#mkdir_tmp')
+    return path
+  end
+
+  # Warn as a path's length approaches its platform's practical ceiling, and flag if it
+  # reaches or exceeds it. Logging only -- never raises or blocks the caller's own
+  # operation, which will surface its own real failure on its own if the OS actually
+  # rejects the path. The calling context (`origin:`) is only included at DEBUG
+  # verbosity -- otherwise the message stays plain, since the path itself is normally
+  # enough and repeated origin labels add noise at everyday verbosity levels.
+  def check_path_length(path, origin:)
+    limit  = path_length_limit
+    length = File.expand_path(path).length
+
+    prefix = @verbosinator.should_output?(Verbosity::DEBUG) ? "#{origin} ⏩️ " : ''
+
+    if length >= limit
+      @loginator.log(
+        "#{prefix}Path length (#{length}) reaches or exceeds this platform's practical limit (#{limit}): #{path}",
+        Verbosity::ERRORS
+      )
+    elsif length >= (limit * 0.95)
+      @loginator.log(
+        "#{prefix}Path length (#{length}) is approaching this platform's practical limit (#{limit}): #{path}",
+        Verbosity::COMPLAIN
+      )
+    end
+  end
+
+  private
+
+  def path_length_limit
+    return PATH_LENGTH_LIMITS[:windows] if SystemWrapper.windows?
+    return PATH_LENGTH_LIMITS[:macos] if SystemWrapper.macos?
+    return PATH_LENGTH_LIMITS[:linux]
   end
 
 end

--- a/lib/ceedling/loginator.rb
+++ b/lib/ceedling/loginator.rb
@@ -14,7 +14,7 @@ class Loginator
   attr_reader :project_logging
   attr_writer :decorators
 
-  constructor :verbosinator, :file_wrapper, :system_wrapper
+  constructor :verbosinator, :system_wrapper
 
   def setup()
     $loginator = self
@@ -419,7 +419,9 @@ class Loginator
     # <IO:$stdout> May  1 22:20:40 2024 | Compiling TestUsartModel::unity.c...
     # <IO:$stdout> May  1 22:20:40 2024 | Compiling TestUsartModel::cmock.c...
 
-    @file_wrapper.write( @log_filepath, output, 'a' )
+    # Raw File I/O, not FileWrapper#write -- FileWrapper's own path-length diagnostics log
+    # through this class, so depending on FileWrapper here would be circular.
+    File.open( @log_filepath, 'a' ) { |file| file.write( output ) }
   end
 
 end

--- a/lib/ceedling/objects.yml
+++ b/lib/ceedling/objects.yml
@@ -10,12 +10,17 @@ application:
     - system_wrapper
 
 file_wrapper:
+  compose:
+    - loginator
+    - verbosinator
 
 file_system_wrapper:
 
 rake_wrapper:
 
 yaml_wrapper:
+  compose:
+    - file_wrapper
 
 ruby_expandinator:
 
@@ -113,7 +118,6 @@ configurator_builder:
 loginator:
   compose:
     - verbosinator
-    - file_wrapper
     - system_wrapper
 
 setupinator:
@@ -265,12 +269,14 @@ dependinator:
 preprocessinator_line_marker_includes_extractor:
   compose:
     - include_factory
+    - file_wrapper
 
 c_comment_scanner:
 
 preprocessinator_comment_stripper:
   compose:
     - c_comment_scanner
+    - file_wrapper
 
 preprocessinator_reconstructor:
   compose:
@@ -315,6 +321,8 @@ preprocessinator_file_assembler:
     - reportinator
 
 preprocessinator_code_finder:
+  compose:
+    - file_wrapper
 
 c_extractor_code_text:
 
@@ -343,6 +351,7 @@ c_extractor:
     - c_extractor_definitions
     - configurator
     - loginator
+    - file_wrapper
 
 partializer_config:
   compose:
@@ -507,3 +516,5 @@ dependency_tracker:
     - dependency_differ
 
 erb_wrapper:
+  compose:
+    - file_wrapper

--- a/lib/ceedling/preprocess/preprocessinator_code_finder.rb
+++ b/lib/ceedling/preprocess/preprocessinator_code_finder.rb
@@ -9,6 +9,8 @@ require 'stringio'
 
 class PreprocessinatorCodeFinder
 
+  constructor :file_wrapper
+
   LINE_MARKER_REGEX = /^#\s+(\d+)\s+"[^"]+"[^\n]*\n/ unless const_defined?(:LINE_MARKER_REGEX)
 
   # Regex-special-character-immune string
@@ -18,7 +20,7 @@ class PreprocessinatorCodeFinder
   # Returns the 1-indexed source line number of the match, or nil if not found.
   # Intended for production use where preprocessor output resides on disk.
   def find_in_preprpocessed_file(filepath, code)
-    File.open( filepath, 'r' ) do |file|
+    @file_wrapper.open( filepath, 'r' ) do |file|
       return find_in_preprocessed_content( io: file, search: code )
     end
   end
@@ -36,7 +38,7 @@ class PreprocessinatorCodeFinder
   # Returns the 1-indexed source line number of the match, or nil if not found.
   # Intended for production use where C file resides on disk.
   def find_in_c_file(filepath, code)
-    File.open( filepath, 'r' ) do |file|
+    @file_wrapper.open( filepath, 'r' ) do |file|
       return find_in_c_code( io: file, search: code )
     end
   end

--- a/lib/ceedling/preprocess/preprocessinator_comment_stripper.rb
+++ b/lib/ceedling/preprocess/preprocessinator_comment_stripper.rb
@@ -10,7 +10,7 @@ require 'ceedling/exceptions'
 
 class PreprocessinatorCommentStripper
 
-  constructor :c_comment_scanner
+  constructor :c_comment_scanner, :file_wrapper
 
 
   # Strip all C comments from a file. The file is unchanged if no comments 
@@ -25,7 +25,7 @@ class PreprocessinatorCommentStripper
       # Open in binary mode to avoid locale-dependent encoding failures.
       # GCC preprocessor output may contain localized strings (e.g. <組み込み> under ja_JP locale).
       # CCommentScanner already operates byte-accurately internally.
-      File.open(filepath, 'rb') do |buffer|
+      @file_wrapper.open(filepath, 'rb') do |buffer|
         stripped = strip(buffer)
       end
     rescue => e
@@ -37,7 +37,7 @@ class PreprocessinatorCommentStripper
 
     begin
       # Write in binary mode to match binary read — preserves original line endings exactly
-      File.write(filepath, stripped, mode: 'wb')
+      @file_wrapper.write(filepath, stripped, 'wb')
     rescue => e
       raise CeedlingException.new("Failed to rewrite '#{filepath}' after comment stripping ⏩️ #{e}")
     end

--- a/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
@@ -87,7 +87,7 @@ class PreprocessinatorLineMarkerIncludesExtractor
   SYSTEM = :system  unless const_defined?(:SYSTEM)
   USER   = :user    unless const_defined?(:USER)
 
-  constructor :include_factory
+  constructor :include_factory, :file_wrapper
 
   # Parse preprocessor output from a file (production use)
   # @param filepath [String] Path to the preprocessor output file
@@ -107,7 +107,7 @@ class PreprocessinatorLineMarkerIncludesExtractor
       # their first byte is 0x3C — ASCII '<' — regardless of the surrounding encoding.
       # NOTE: binary mode means \r\n line endings are NOT translated on Windows; the
       # extract_includes method calls line.chomp! before regex matching to handle this.
-      File.open(filepath, 'rb') do |file|
+      @file_wrapper.open(filepath, 'rb') do |file|
         includes = extract_includes(io: file, filepath: filepath, type: type, max_depth: max_depth, test: test)
       end
     rescue StandardError => e

--- a/lib/ceedling/system_wrapper.rb
+++ b/lib/ceedling/system_wrapper.rb
@@ -17,6 +17,13 @@ class SystemWrapper
     @windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|msys|ucrt/i) ? true : false
   end
 
+  # Memoized: host_os is fixed for the process lifetime.
+  # Guard against nil? rather than ||= so false (non-macOS) is cached correctly.
+  def self.macos?
+    return @macos unless @macos.nil?
+    @macos = (RbConfig::CONFIG['host_os'] =~ /darwin/i) ? true : false
+  end
+
   def self.time_stopwatch_s
     # Wall clock time that can be adjusted for a variety of reasons and lead to
     # unexpected negative durations -- only option on Windows.
@@ -34,6 +41,11 @@ class SystemWrapper
   # class method so as to be mockable for tests
   def windows?
     return SystemWrapper.windows?
+  end
+
+  # class method so as to be mockable for tests
+  def macos?
+    return SystemWrapper.macos?
   end
 
   def eval(string)

--- a/lib/ceedling/yaml_wrapper.rb
+++ b/lib/ceedling/yaml_wrapper.rb
@@ -10,6 +10,8 @@ require 'ceedling/exceptions'
 
 class YamlWrapper
 
+  constructor :file_wrapper
+
   # Ceedling loads YAML from project config files, cache files, and generated test-result
   # files. `YAML.load` can instantiate arbitrary Ruby objects from that content, which is
   # unnecessary and unsafe -- `YAML.safe_load` restricts deserialization to plain data types
@@ -36,7 +38,7 @@ class YamlWrapper
 
   def load(filepath)
     begin
-      source = File.read(filepath)
+      source = @file_wrapper.read(filepath)
     rescue Errno::ENOENT
       raise YamlLoadException.new(
         reason: :not_found, source: filepath, original_error: nil,
@@ -89,7 +91,7 @@ class YamlWrapper
   end
 
   def dump(filepath, structure)
-    File.open(filepath, 'w') do |output|
+    @file_wrapper.open(filepath, 'w') do |output|
       YAML.dump(structure, output)
     end
   end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -15,7 +15,7 @@
 module Ceedling
   module Version
     # Convenience constants for gem building, etc.
-    GEM = '1.1.0'
+    GEM = '1.2.0'
     TAG = GEM
 
     # If run as a script print Ceedling's version to $stdout

--- a/spec/support/system/dependency_tracker_system_helper.rb
+++ b/spec/support/system/dependency_tracker_system_helper.rb
@@ -32,9 +32,12 @@ module DependencyTrackerSystemHelper
   # particular -- `store_path` is the caller's responsibility, typically
   # somewhere under a per-example temp directory (see `in_temp_dir`).
   def build_dependency_tracker(store_path:, debug_tier: nil)
-    file_wrapper = FileWrapper.new
-    system_wrapper = SystemWrapper.new
     loginator = double('loginator').as_null_object
+    file_wrapper = FileWrapper.new({
+      :loginator    => loginator,
+      :verbosinator => double('verbosinator').as_null_object
+    })
+    system_wrapper = SystemWrapper.new
 
     hasher = DependencyHasher.new( { :file_wrapper => file_wrapper } )
     normalizer = DependencyPathNormalizer.new( { :file_wrapper => file_wrapper } )
@@ -89,7 +92,11 @@ module DependencyTrackerSystemHelper
   end
 
   def debug_tree_for_specs
-    DependencyDebugTree.new( { :file_wrapper => FileWrapper.new, :yaml_wrapper => YamlWrapper.new } )
+    file_wrapper = FileWrapper.new({
+      :loginator    => double('loginator').as_null_object,
+      :verbosinator => double('verbosinator').as_null_object
+    })
+    DependencyDebugTree.new( { :file_wrapper => file_wrapper, :yaml_wrapper => YamlWrapper.new } )
   end
 
   # Runs `block` with a fresh, real temp directory, cleaned up afterward

--- a/spec/support/system/dependency_tracker_system_helper.rb
+++ b/spec/support/system/dependency_tracker_system_helper.rb
@@ -44,7 +44,7 @@ module DependencyTrackerSystemHelper
     normalizer.setup()
     cache_store = DependencyCacheStore.new( { :file_wrapper => file_wrapper, :loginator => loginator } )
     gcc_parser = GccDependencyParser.new
-    debug_tree = DependencyDebugTree.new( { :file_wrapper => file_wrapper, :yaml_wrapper => YamlWrapper.new } )
+    debug_tree = DependencyDebugTree.new( { :file_wrapper => file_wrapper, :yaml_wrapper => YamlWrapper.new({ file_wrapper: file_wrapper }) } )
     differ = DependencyDiffer.new
 
     tracker = DependencyTracker.new(
@@ -96,7 +96,7 @@ module DependencyTrackerSystemHelper
       :loginator    => double('loginator').as_null_object,
       :verbosinator => double('verbosinator').as_null_object
     })
-    DependencyDebugTree.new( { :file_wrapper => file_wrapper, :yaml_wrapper => YamlWrapper.new } )
+    DependencyDebugTree.new( { :file_wrapper => file_wrapper, :yaml_wrapper => YamlWrapper.new({ file_wrapper: file_wrapper }) } )
   end
 
   # Runs `block` with a fresh, real temp directory, cleaned up afterward

--- a/spec/support/system/spec_system_helper.rb
+++ b/spec/support/system/spec_system_helper.rb
@@ -8,8 +8,10 @@
 require 'fileutils'
 require 'tmpdir'
 require 'open3'
-require 'ceedling/yaml_wrapper'
+# spec_helper pulls in the 'constructor' gem -- must load before any Ceedling
+# class using the `constructor` class macro, e.g. ceedling/yaml_wrapper below.
 require 'spec_helper'
+require 'ceedling/yaml_wrapper'
 require 'deep_merge'
 
 require_relative 'system_test_output'

--- a/spec/support/system/system_context.rb
+++ b/spec/support/system/system_context.rb
@@ -8,6 +8,9 @@
 require 'fileutils'
 require 'bundler'
 require 'ceedling/encodinator'
+require 'ceedling/file_wrapper'
+require 'ceedling/verbosinator'
+require 'ceedling/yaml_wrapper'
 require_relative 'gem_dir_layout'
 
 class SystemContext
@@ -170,8 +173,19 @@ class SystemContext
 
   ############################################################
   # Functions for manipulating project.yml files during tests:
+
+  # `self` here is a plain SystemContext instance, not an RSpec example, so
+  # RSpec::Mocks' `double` isn't reachable -- a trivial no-op stands in for it.
+  class NullLoginator
+    def log(*); end
+  end
+
   def merge_project_yml_for_test(settings, show_final=false)
-    yaml_wrapper = YamlWrapper.new
+    file_wrapper = FileWrapper.new({
+      :loginator    => NullLoginator.new,
+      :verbosinator => Verbosinator.new
+    })
+    yaml_wrapper = YamlWrapper.new({ file_wrapper: file_wrapper })
     project_hash = yaml_wrapper.load('project.yml')
     project_hash.deep_merge!(settings)
     puts "\n\n#{project_hash.to_yaml}\n\n" if show_final

--- a/spec/system/support/common_test_cases.rb
+++ b/spec/system/support/common_test_cases.rb
@@ -6,8 +6,18 @@
 # =========================================================================
 
 require 'rbconfig'
+require 'ceedling/file_wrapper'
+require 'ceedling/yaml_wrapper'
 
 module CommonSystemTestCases
+  def yaml_wrapper_for_test
+    file_wrapper = FileWrapper.new({
+      :loginator    => double('loginator').as_null_object,
+      :verbosinator => double('verbosinator').as_null_object
+    })
+    YamlWrapper.new({ file_wrapper: file_wrapper })
+  end
+
   def can_report_version_no_git_commit_sha
     @c.with_context do
       # Version without Git commit short SHA file in project
@@ -984,7 +994,7 @@ module CommonSystemTestCases
 
         result_file = './build/test/results/test_example_file_crash_sigsegv_with_param.fail'
         expect(File.exist?(result_file)).to be(true)
-        results = YamlWrapper.new.load(result_file)
+        results = yaml_wrapper_for_test.load(result_file)
 
         # Only the truly crashing test is reported as a failure/crash
         expect(results[:failures].map { |f| f[:test] }).to eq(['test_add_numbers_will_fail'])
@@ -1026,7 +1036,7 @@ module CommonSystemTestCases
 
         result_file = './build/test/results/test_example_file_crash_sigsegv_with_param.fail'
         expect(File.exist?(result_file)).to be(true)
-        results = YamlWrapper.new.load(result_file)
+        results = yaml_wrapper_for_test.load(result_file)
 
         # Only the truly crashing test is reported as a failure/crash
         expect(results[:failures].map { |f| f[:test] }).to eq(['test_add_numbers_will_fail'])

--- a/spec/units/c_extractor/c_extractor_integration_spec.rb
+++ b/spec/units/c_extractor/c_extractor_integration_spec.rb
@@ -38,7 +38,8 @@ describe CExtractor do
         # Bare double (no :partials_max_extraction_length stub) so #respond_to? is
         # false and CExtractor falls back to its own built-in default buffer length.
         configurator:              double('Configurator'),
-        loginator:                 double('Loginator').as_null_object
+        loginator:                 double('Loginator').as_null_object,
+        file_wrapper:              double('FileWrapper').as_null_object
       }
     )
     extractor.setup()

--- a/spec/units/c_extractor/c_extractor_spec.rb
+++ b/spec/units/c_extractor/c_extractor_spec.rb
@@ -37,7 +37,8 @@ describe CExtractor do
             c_extractor_preprocessing: CExtractorPreprocessing.new({ c_extractor_code_text: CExtractorCodeText.new }),
             c_extractor_definitions:   CExtractorDefinitions.new({ c_extractor_code_text: CExtractorCodeText.new }),
             configurator:              configurator,
-            loginator:                 double('Loginator').as_null_object
+            loginator:                 double('Loginator').as_null_object,
+            file_wrapper:              double('FileWrapper').as_null_object
           }
         )
         extractor.setup()
@@ -111,7 +112,8 @@ describe CExtractor do
             # Bare double (no :partials_max_extraction_length stub) so #respond_to? is
             # false and CExtractor falls back to its own built-in default buffer length.
             configurator:             double('Configurator'),
-            loginator:                double('Loginator').as_null_object
+            loginator:                double('Loginator').as_null_object,
+            file_wrapper:             double('FileWrapper').as_null_object
           }
         )
         extractor.setup()

--- a/spec/units/dependencies/dependency_debug_tree_spec.rb
+++ b/spec/units/dependencies/dependency_debug_tree_spec.rb
@@ -15,7 +15,8 @@ describe DependencyDebugTree do
 
   before(:each) do
     @file_wrapper = instance_double('FileWrapper')
-    @yaml_wrapper = YamlWrapper.new # real: pure in-memory YAML (de)serialization, no FS of its own
+    # real: pure in-memory YAML (de)serialization via load_string only, no FS of its own
+    @yaml_wrapper = YamlWrapper.new({ file_wrapper: double('file_wrapper').as_null_object })
 
     # A tiny in-memory fake file store so writes and reads round-trip within
     # a single example, without ever touching a real disk.

--- a/spec/units/dependencies/dependency_tracker_spec.rb
+++ b/spec/units/dependencies/dependency_tracker_spec.rb
@@ -58,7 +58,7 @@ describe DependencyTracker do
     normalizer.setup()
     cache_store = DependencyCacheStore.new( { :file_wrapper => @file_wrapper, :loginator => @loginator } )
     gcc_parser = GccDependencyParser.new
-    debug_tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new } )
+    debug_tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new({ file_wrapper: double('file_wrapper').as_null_object }) } )
     differ = DependencyDiffer.new
 
     @tracker = described_class.new(
@@ -350,7 +350,7 @@ describe DependencyTracker do
       end
 
       def read_snapshot(path)
-        debug_tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new } )
+        debug_tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new({ file_wrapper: double('file_wrapper').as_null_object }) } )
         debug_tree.read_snapshot( @tracker.instance_variable_get(:@debug_root), path )
       end
 
@@ -570,7 +570,7 @@ describe DependencyTracker do
     # Reads back diagnosis.yml through the real DependencyDebugTree, proving
     # #diagnose actually persisted it (not just returned it in-memory).
     def read_diagnosis(target)
-      tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new } )
+      tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new({ file_wrapper: double('file_wrapper').as_null_object }) } )
       allow( @file_wrapper ).to receive(:read) { |path| @debug_files.fetch( path ) { raise "unstubbed read: #{path}" } }
       allow( @file_wrapper ).to receive(:read_binary) { |path| @debug_files.fetch( path ) { raise "unstubbed read_binary: #{path}" } }
       allow( @file_wrapper ).to receive(:exist?) { |path| @debug_files.key?( path ) }
@@ -720,12 +720,12 @@ describe DependencyTracker do
     end
 
     def seed_debug_snapshot(store_path, target)
-      debug_tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new } )
+      debug_tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new({ file_wrapper: double('file_wrapper').as_null_object }) } )
       debug_tree.write_snapshot( debug_root_for( store_path ), target, hash: 'a' * 64 )
     end
 
     def debug_snapshot_exists?(store_path, target)
-      debug_tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new } )
+      debug_tree = DependencyDebugTree.new( { :file_wrapper => @file_wrapper, :yaml_wrapper => YamlWrapper.new({ file_wrapper: double('file_wrapper').as_null_object }) } )
       !debug_tree.read_snapshot( debug_root_for( store_path ), target ).nil?
     end
 

--- a/spec/units/file_finder_helper_spec.rb
+++ b/spec/units/file_finder_helper_spec.rb
@@ -18,7 +18,7 @@ FILE_LIST = ['some/dir/a.c', 'some/dir/a.h', \
 describe FileFinderHelper do
   before(:each) do
     # this will always be mocked
-    @loginator = Loginator.new({:verbosinator => nil, :file_wrapper => nil, :system_wrapper => nil})
+    @loginator = Loginator.new({:verbosinator => nil, :system_wrapper => nil})
 
     @ff_helper = described_class.new({:loginator => @loginator})
   end

--- a/spec/units/file_path_utils_spec.rb
+++ b/spec/units/file_path_utils_spec.rb
@@ -230,6 +230,7 @@ describe FilePathUtils do
     before(:each) do
       @configurator = double('configurator')
       @file_wrapper = double('file_wrapper')
+      allow(@file_wrapper).to receive(:check_path_length)
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -277,6 +278,7 @@ describe FilePathUtils do
     before(:each) do
       @configurator = double('configurator')
       @file_wrapper = double('file_wrapper')
+      allow(@file_wrapper).to receive(:check_path_length)
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -317,6 +319,7 @@ describe FilePathUtils do
     before(:each) do
       @configurator = double('configurator')
       @file_wrapper = double('file_wrapper')
+      allow(@file_wrapper).to receive(:check_path_length)
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -348,6 +351,7 @@ describe FilePathUtils do
     before(:each) do
       @configurator = double('configurator')
       @file_wrapper = double('file_wrapper')
+      allow(@file_wrapper).to receive(:check_path_length)
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -383,6 +387,7 @@ describe FilePathUtils do
     before(:each) do
       @configurator = double('configurator')
       @file_wrapper = double('file_wrapper')
+      allow(@file_wrapper).to receive(:check_path_length)
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -410,7 +415,10 @@ describe FilePathUtils do
   describe '#form_release_build_objects_filelist' do
     before(:each) do
       @configurator = double('configurator')
-      @file_wrapper = FileWrapper.new
+      @file_wrapper = FileWrapper.new({
+        :loginator    => double('loginator').as_null_object,
+        :verbosinator => double('verbosinator').as_null_object
+      })
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -436,7 +444,10 @@ describe FilePathUtils do
   describe '#form_release_dependencies_filelist' do
     before(:each) do
       @configurator = double('configurator')
-      @file_wrapper = FileWrapper.new
+      @file_wrapper = FileWrapper.new({
+        :loginator    => double('loginator').as_null_object,
+        :verbosinator => double('verbosinator').as_null_object
+      })
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -457,7 +468,10 @@ describe FilePathUtils do
   describe '#form_test_build_objects_filelist' do
     before(:each) do
       @configurator = double('configurator')
-      @file_wrapper = FileWrapper.new
+      @file_wrapper = FileWrapper.new({
+        :loginator    => double('loginator').as_null_object,
+        :verbosinator => double('verbosinator').as_null_object
+      })
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -491,7 +505,10 @@ describe FilePathUtils do
   describe '#form_pass_results_filelist' do
     before(:each) do
       @configurator = double('configurator')
-      @file_wrapper = FileWrapper.new
+      @file_wrapper = FileWrapper.new({
+        :loginator    => double('loginator').as_null_object,
+        :verbosinator => double('verbosinator').as_null_object
+      })
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -519,6 +536,7 @@ describe FilePathUtils do
     before(:each) do
       @configurator = double('configurator')
       @file_wrapper = double('file_wrapper')
+      allow(@file_wrapper).to receive(:check_path_length)
       @fpu = described_class.new({
         :configurator => @configurator,
         :file_wrapper => @file_wrapper
@@ -548,6 +566,50 @@ describe FilePathUtils do
       # distinct from those two generated headers so all three can coexist.
       expect( @fpu.form_partial_types_header_filename('LightSensor') )
         .to eq('ceedling_partial_LightSensor_types.h')
+    end
+  end
+
+  describe '#form_named_path' do
+    before(:each) do
+      @file_wrapper = double('file_wrapper')
+      allow(@file_wrapper).to receive(:check_path_length)
+      @fpu = described_class.new({
+        :configurator => double('configurator'),
+        :file_wrapper => @file_wrapper
+      })
+    end
+
+    # form_named_path is private -- exercised via #send, same as its callers do internally.
+    it 'checks the constructed path length, identifying itself as the origin' do
+      @fpu.send(:form_named_path, 'build/test/preprocess/files', 'test_foo')
+      expect(@file_wrapper).to have_received(:check_path_length)
+        .with('build/test/preprocess/files/test_foo', origin: 'FilePathUtils#form_named_path')
+    end
+
+    it 'checks the constructed path length including an optional subdir' do
+      @fpu.send(:form_named_path, 'build/test/preprocess/files', 'test_foo', subdir: 'full_expansion')
+      expect(@file_wrapper).to have_received(:check_path_length)
+        .with('build/test/preprocess/files/test_foo/full_expansion', origin: 'FilePathUtils#form_named_path')
+    end
+  end
+
+  describe '#form_build_context_path' do
+    before(:each) do
+      @configurator = double('configurator')
+      @file_wrapper = double('file_wrapper')
+      allow(@file_wrapper).to receive(:check_path_length)
+      allow(@configurator).to receive(:project_build_root).and_return('build')
+      @fpu = described_class.new({
+        :configurator => @configurator,
+        :file_wrapper => @file_wrapper
+      })
+    end
+
+    # form_build_context_path is private -- exercised via #send, same as its callers do internally.
+    it 'checks the constructed path length, identifying itself as the origin' do
+      @fpu.send(:form_build_context_path, 'out', name: 'TestFoo')
+      expect(@file_wrapper).to have_received(:check_path_length)
+        .with('build/out/TestFoo', origin: 'FilePathUtils#form_build_context_path')
     end
   end
 

--- a/spec/units/file_wrapper_spec.rb
+++ b/spec/units/file_wrapper_spec.rb
@@ -32,9 +32,14 @@ describe FileWrapper do
 
   # Absolute paths throughout: check_path_length measures File.expand_path(path).length,
   # so a relative path would pick up the test-runner's own CWD and throw off the
-  # precise threshold arithmetic these examples depend on.
+  # precise threshold arithmetic these examples depend on. The padding is sized off
+  # File.expand_path('/')'s own actual length rather than assumed to be 1, since Windows
+  # expands a bare '/' by prepending a drive letter (e.g. "C:/") -- without probing that
+  # overhead first, expanded lengths on Windows would run a couple characters longer than
+  # intended and throw off the precise threshold boundaries these examples depend on.
   def path_of_length(n)
-    '/' + ('a' * (n - 1))
+    overhead = File.expand_path('/').length - 1
+    '/' + ('a' * (n - 1 - overhead))
   end
 
   describe '#check_path_length' do

--- a/spec/units/file_wrapper_spec.rb
+++ b/spec/units/file_wrapper_spec.rb
@@ -1,0 +1,122 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/file_wrapper'
+require 'ceedling/system_wrapper'
+
+describe FileWrapper do
+  before(:each) do
+    @loginator    = double('loginator')
+    @verbosinator = double('verbosinator')
+
+    @file_wrapper = described_class.new({
+      :loginator    => @loginator,
+      :verbosinator => @verbosinator
+    })
+
+    # Debug verbosity off by default in these examples -- explicitly enabled
+    # only in the origin-prefix examples below.
+    allow(@verbosinator).to receive(:should_output?).with(Verbosity::DEBUG).and_return(false)
+    allow(@loginator).to receive(:log)
+
+    # Pin the platform so limit-selection is deterministic regardless of the
+    # machine actually running this spec.
+    allow(SystemWrapper).to receive(:windows?).and_return(false)
+    allow(SystemWrapper).to receive(:macos?).and_return(false)
+  end
+
+  # Absolute paths throughout: check_path_length measures File.expand_path(path).length,
+  # so a relative path would pick up the test-runner's own CWD and throw off the
+  # precise threshold arithmetic these examples depend on.
+  def path_of_length(n)
+    '/' + ('a' * (n - 1))
+  end
+
+  describe '#check_path_length' do
+    # Linux limit (4096) is the default platform pinned in before(:each) above.
+
+    it 'logs nothing for a path well under the limit' do
+      @file_wrapper.check_path_length('/short/path.c', origin: 'Test')
+      expect(@loginator).not_to have_received(:log)
+    end
+
+    it 'logs a WARNING once length reaches 95% of the limit' do
+      # 4096 * 0.95 == 3891.2 -- 3892 is the first integer at/over threshold
+      @file_wrapper.check_path_length(path_of_length(3892), origin: 'Test')
+      expect(@loginator).to have_received(:log).with(any_args, Verbosity::COMPLAIN)
+    end
+
+    it 'does not yet log a WARNING one character under the 95% threshold' do
+      @file_wrapper.check_path_length(path_of_length(3891), origin: 'Test')
+      expect(@loginator).not_to have_received(:log)
+    end
+
+    it 'logs an ERROR once length reaches the limit' do
+      @file_wrapper.check_path_length(path_of_length(4096), origin: 'Test')
+      expect(@loginator).to have_received(:log).with(any_args, Verbosity::ERRORS)
+    end
+
+    it 'logs an ERROR for a length beyond the limit' do
+      @file_wrapper.check_path_length(path_of_length(5000), origin: 'Test')
+      expect(@loginator).to have_received(:log).with(any_args, Verbosity::ERRORS)
+    end
+
+    it 'never raises regardless of path length' do
+      expect { @file_wrapper.check_path_length(path_of_length(10_000), origin: 'Test') }.not_to raise_error
+    end
+
+    context 'origin prefix' do
+      it 'omits the origin from the message when verbosity is below DEBUG' do
+        allow(@verbosinator).to receive(:should_output?).with(Verbosity::DEBUG).and_return(false)
+        @file_wrapper.check_path_length(path_of_length(5000), origin: 'FileWrapper#mkdir_tmp')
+        expect(@loginator).to have_received(:log) do |message, _verbosity|
+          expect(message).not_to include('FileWrapper#mkdir_tmp')
+        end
+      end
+
+      it 'includes the origin in the message when verbosity is DEBUG' do
+        allow(@verbosinator).to receive(:should_output?).with(Verbosity::DEBUG).and_return(true)
+        @file_wrapper.check_path_length(path_of_length(5000), origin: 'FileWrapper#mkdir_tmp')
+        expect(@loginator).to have_received(:log) do |message, _verbosity|
+          expect(message).to include('FileWrapper#mkdir_tmp')
+        end
+      end
+    end
+
+    context 'platform limit selection' do
+      it 'uses the Windows limit (260) when SystemWrapper.windows? is true' do
+        allow(SystemWrapper).to receive(:windows?).and_return(true)
+        @file_wrapper.check_path_length(path_of_length(260), origin: 'Test')
+        expect(@loginator).to have_received(:log).with(any_args, Verbosity::ERRORS)
+      end
+
+      it 'does not yet flag a path under the Windows limit' do
+        allow(SystemWrapper).to receive(:windows?).and_return(true)
+        @file_wrapper.check_path_length(path_of_length(200), origin: 'Test')
+        expect(@loginator).not_to have_received(:log)
+      end
+
+      it 'uses the macOS limit (1024) when SystemWrapper.macos? is true' do
+        allow(SystemWrapper).to receive(:macos?).and_return(true)
+        @file_wrapper.check_path_length(path_of_length(1024), origin: 'Test')
+        expect(@loginator).to have_received(:log).with(any_args, Verbosity::ERRORS)
+      end
+
+      it 'does not yet flag a path under the macOS limit' do
+        allow(SystemWrapper).to receive(:macos?).and_return(true)
+        @file_wrapper.check_path_length(path_of_length(900), origin: 'Test')
+        expect(@loginator).not_to have_received(:log)
+      end
+
+      it 'falls back to the Linux limit (4096) when neither Windows nor macOS' do
+        @file_wrapper.check_path_length(path_of_length(4096), origin: 'Test')
+        expect(@loginator).to have_received(:log).with(any_args, Verbosity::ERRORS)
+      end
+    end
+  end
+end

--- a/spec/units/generators/generator_test_results_sanity_checker_spec.rb
+++ b/spec/units/generators/generator_test_results_sanity_checker_spec.rb
@@ -15,7 +15,7 @@ require 'ceedling/config/configurator'
 describe GeneratorTestResultsSanityChecker do
   before(:each) do
     # These will always be mocked
-    @loginator = Loginator.new({:verbosinator => nil, :file_wrapper => nil, :system_wrapper => nil})
+    @loginator = Loginator.new({:verbosinator => nil, :system_wrapper => nil})
     @configurator = Configurator.new({
       :configurator_setup => nil,
       :configurator_builder => nil,

--- a/spec/units/generators/generator_test_results_spec.rb
+++ b/spec/units/generators/generator_test_results_spec.rb
@@ -142,7 +142,11 @@ describe GeneratorTestResults do
       :ruby_expandinator    => nil
     })
 
-    @yaml_wrapper = YamlWrapper.new
+    @file_wrapper = FileWrapper.new({
+      :loginator    => @loginator,
+      :verbosinator => double('verbosinator').as_null_object
+    })
+    @yaml_wrapper = YamlWrapper.new({ :file_wrapper => @file_wrapper })
     @sanity_checker = GeneratorTestResultsSanityChecker.new({
       :configurator => @configurator,
       :loginator    => @loginator
@@ -154,7 +158,7 @@ describe GeneratorTestResults do
       :loginator                             => @loginator,
       :reportinator                          => @reportinator,
       :yaml_wrapper                          => @yaml_wrapper,
-      :file_wrapper                          => FileWrapper.new
+      :file_wrapper                          => @file_wrapper
     })
 
     @tmpdir = Dir.mktmpdir

--- a/spec/units/preprocess/preprocessinator_code_finder_spec.rb
+++ b/spec/units/preprocess/preprocessinator_code_finder_spec.rb
@@ -11,7 +11,8 @@ require 'ceedling/preprocess/preprocessinator_code_finder'
 describe PreprocessinatorCodeFinder do
 
   before(:each) do
-    @finder = described_class.new
+    @file_wrapper = double('file_wrapper')
+    @finder = described_class.new({ file_wrapper: @file_wrapper })
   end
 
   context "#find_in_preprpocessed_string" do
@@ -356,6 +357,24 @@ describe PreprocessinatorCodeFinder do
       expect( @finder.find_in_c_string( content, "void reset(void) { counter = 0; }" ) ).to eq 5
     end
 
+  end
+
+  context "#find_in_preprpocessed_file" do
+    it "opens the file through FileWrapper in read mode and delegates to the string search" do
+      content = "# 1 \"source.c\"\nint foo(void) { return 0; }\n"
+      allow(@file_wrapper).to receive(:open).with('source.c', 'r').and_yield(StringIO.new(content))
+
+      expect( @finder.find_in_preprpocessed_file( 'source.c', 'int foo(void) { return 0; }' ) ).to eq 1
+    end
+  end
+
+  context "#find_in_c_file" do
+    it "opens the file through FileWrapper in read mode and delegates to the string search" do
+      content = "#include <stdint.h>\nvoid foo(void) {}\n"
+      allow(@file_wrapper).to receive(:open).with('source.c', 'r').and_yield(StringIO.new(content))
+
+      expect( @finder.find_in_c_file( 'source.c', 'void foo(void) {}' ) ).to eq 2
+    end
   end
 
 end

--- a/spec/units/preprocess/preprocessinator_comment_stripper_spec.rb
+++ b/spec/units/preprocess/preprocessinator_comment_stripper_spec.rb
@@ -15,13 +15,16 @@ RSpec.describe PreprocessinatorCommentStripper do
   before(:each) do
     @stripper = PreprocessinatorCommentStripper.new(
       {
-        c_comment_scanner: CCommentScanner.new
+        c_comment_scanner: CCommentScanner.new,
+        file_wrapper:      double('file_wrapper').as_null_object
       }
     )
 
     # PreprocessinatorCodeFinder is used to verify that stripped output preserves
     # correct source-line mapping via the marker-relative arithmetic it implements.
-    @finder = PreprocessinatorCodeFinder.new
+    @finder = PreprocessinatorCodeFinder.new({
+      file_wrapper: double('file_wrapper').as_null_object
+    })
   end
 
 
@@ -573,6 +576,55 @@ RSpec.describe PreprocessinatorCommentStripper do
         expect(@finder.find_in_preprpocessed_string(result, 'int init(void);')).to eq(6)
       end
 
+    end
+
+  end
+
+
+  # ===========================================================================
+  describe '#strip_file' do
+  # ===========================================================================
+
+    before(:each) do
+      @file_wrapper = double('file_wrapper')
+      @stripper = PreprocessinatorCommentStripper.new(
+        {
+          c_comment_scanner: CCommentScanner.new,
+          file_wrapper:      @file_wrapper
+        }
+      )
+    end
+
+    it 'reads the file in binary mode and returns false without writing when there are no comments' do
+      content = "# 1 \"foo.c\"\nint x;\n"
+      allow(@file_wrapper).to receive(:open).with('foo.c', 'rb').and_yield(StringIO.new(content))
+
+      expect(@file_wrapper).not_to receive(:write)
+      expect(@stripper.strip_file('foo.c')).to be false
+    end
+
+    it 'writes stripped content back in binary mode and returns true when comments are found' do
+      content = "# 1 \"foo.c\"\n// comment\nint x;\n"
+      allow(@file_wrapper).to receive(:open).with('foo.c', 'rb').and_yield(StringIO.new(content))
+
+      expect(@file_wrapper).to receive(:write).with('foo.c', anything, 'wb')
+      expect(@stripper.strip_file('foo.c')).to be true
+    end
+
+    it 'wraps a read failure in a CeedlingException identifying the file' do
+      allow(@file_wrapper).to receive(:open).and_raise(Errno::ENOENT.new('no such file'))
+
+      expect { @stripper.strip_file('missing.c') }
+        .to raise_error(CeedlingException, /Failed to read 'missing\.c' for comment stripping/)
+    end
+
+    it 'wraps a write failure in a CeedlingException identifying the file' do
+      content = "# 1 \"foo.c\"\n// comment\nint x;\n"
+      allow(@file_wrapper).to receive(:open).with('foo.c', 'rb').and_yield(StringIO.new(content))
+      allow(@file_wrapper).to receive(:write).and_raise(Errno::EACCES.new('permission denied'))
+
+      expect { @stripper.strip_file('foo.c') }
+        .to raise_error(CeedlingException, /Failed to rewrite 'foo\.c' after comment stripping/)
     end
 
   end

--- a/spec/units/system_wrapper_spec.rb
+++ b/spec/units/system_wrapper_spec.rb
@@ -22,6 +22,22 @@ describe SystemWrapper do
     "#{RbConfig.ruby} -e #{code.inspect}"
   end
 
+  # Portable across the whole CI platform matrix: asserts the regex classifies whatever
+  # host this test actually happens to run on, rather than hardcoding an expected result.
+  describe '.windows?' do
+    it 'matches the actual host_os of the machine running this test' do
+      expected = !!(RbConfig::CONFIG['host_os'] =~ /mswin|mingw|msys|ucrt/i)
+      expect(SystemWrapper.windows?).to eq(expected)
+    end
+  end
+
+  describe '.macos?' do
+    it 'matches the actual host_os of the machine running this test' do
+      expected = !!(RbConfig::CONFIG['host_os'] =~ /darwin/i)
+      expect(SystemWrapper.macos?).to eq(expected)
+    end
+  end
+
   describe '#shell_capture3' do
     context 'boom: false (the default, and how test-fixture execution always runs)' do
       it 'forces exit_code to 0 even though the real subprocess exited nonzero' do

--- a/spec/units/tool_executor_helper_spec.rb
+++ b/spec/units/tool_executor_helper_spec.rb
@@ -19,7 +19,7 @@ describe ToolExecutorHelper do
     # these will always be mocked
     @sys_wrapper = SystemWrapper.new
     @sys_utils = SystemUtils.new({:system_wrapper => @sys_wrapper})
-    @loginator = Loginator.new({:verbosinator => nil, :file_wrapper => nil, :system_wrapper => nil})
+    @loginator = Loginator.new({:verbosinator => nil, :system_wrapper => nil})
     @verbosinator = Verbosinator.new()
     
     @tool_exe_helper = described_class.new(

--- a/spec/units/yaml_wrapper_spec.rb
+++ b/spec/units/yaml_wrapper_spec.rb
@@ -10,7 +10,8 @@ require 'ceedling/yaml_wrapper'
 
 describe YamlWrapper do
   before(:each) do
-    @yaml_wrapper = described_class.new
+    @file_wrapper = double('file_wrapper').as_null_object
+    @yaml_wrapper = described_class.new({ file_wrapper: @file_wrapper })
   end
 
   describe '#load_string' do
@@ -75,6 +76,8 @@ describe YamlWrapper do
 
   describe '#load' do
     it 'reports a missing file as :not_found' do
+      allow(@file_wrapper).to receive(:read).with('/no/such/file.yml').and_raise(Errno::ENOENT)
+
       expect { @yaml_wrapper.load('/no/such/file.yml') }.to raise_error(YamlLoadException) do |e|
         expect(e.reason).to eq(:not_found)
         expect(e.message).to match(/could not find yaml file/i)


### PR DESCRIPTION
## Summary
- `FileWrapper` now checks path length on every mutating file operation (`mkdir`, `mkdir_tmp`, `cp`, `write`, `write_blank_file`, write-mode `open`), logging a WARNING as a path approaches its platform's practical length ceiling and an ERROR once it reaches or exceeds it. Diagnostic only — never blocks the operation itself.
- `FilePathUtils#form_named_path`/`#form_build_context_path`, the two shared builders nearly all generated build paths funnel through, get the same check.
- Added `SystemWrapper.macos?`, mirroring the existing `windows?` pattern, so the platform-specific limit (Windows 260 / macOS 1024 / Linux 4096) can be selected.
- Routed the six remaining raw `File.open`/`File.read`/`File.write` call sites (`ErbWrapper`, `YamlWrapper`, `PreprocessinatorLineMarkerIncludesExtractor`, `PreprocessinatorCommentStripper`, `PreprocessinatorCodeFinder`, `CExtractor`) through `FileWrapper` so the check is genuinely singular rather than partial.
- Resolved the resulting `Loginator` ↔ `FileWrapper` circular dependency by moving `Loginator`'s own logfile write onto raw `File` I/O (it's the one place in the codebase that can't route through `FileWrapper`, since `FileWrapper`'s own diagnostics log through `Loginator`).

## Test plan
- [x] Full unit suite: 2470 examples, 0 failures, 1 pre-existing pending
- [x] New unit coverage for `FileWrapper#check_path_length` (threshold math, origin-prefix gating, platform-limit selection) and `SystemWrapper.macos?`
- [x] Manual end-to-end verification against a real hand-built project with a deliberately long build path: WARNING/ERROR fire correctly at both default and `--verbosity=debug` (origin prefix present only at DEBUG), normal-length paths produce no false positives, and the build/test run completes and passes throughout