### PR TITLE
Test-build pipeline Phase B, PR 2: consolidate scattered validation logic

### DIFF
--- a/lib/ceedling/test_invoker/test_build_planner.rb
+++ b/lib/ceedling/test_invoker/test_build_planner.rb
@@ -75,7 +75,7 @@ class TestBuildPlanner
         )
       end
 
-      validate_header_includes( filepath, testable )
+      validate_header_includes( test_filepath: filepath, testable: testable )
 
       partials_configs = {}
       if @configurator.project_use_partials
@@ -290,7 +290,7 @@ class TestBuildPlanner
   # and Ceedling's own headers live in the build's vendor directories, outside every configured
   # :test/:source/:support/:include root a test's search_paths is built from, so neither could
   # ever resolve there.
-  def validate_header_includes(test_filepath, testable)
+  def validate_header_includes(test_filepath:, testable:)
     includes = @context_extractor.lookup_nonmock_header_includes_list( test_filepath )
 
     collection = @include_pathinator.ordered_header_files( testable.search_paths )

--- a/lib/ceedling/test_invoker/test_build_planner.rb
+++ b/lib/ceedling/test_invoker/test_build_planner.rb
@@ -8,12 +8,14 @@
 require 'ceedling/constants'
 require 'ceedling/test_invoker/test_invoker_types'
 require 'ceedling/test_invoker/test_pipeline_helpers'
+require 'ceedling/test_invoker/test_build_validations'
 require 'ceedling/includes/includes'
 
 class TestBuildPlanner
 
   include TestInvokerTypes
   include TestPipelineHelpers
+  include TestBuildValidations
 
   constructor(
     :configurator,
@@ -276,33 +278,6 @@ class TestBuildPlanner
   # one mock.
   def ordered_mock_header_collection(testable)
     @include_pathinator.ordered_header_files( testable.search_paths - testable.mock_search_paths )
-  end
-
-  # Every #include naming a real project header -- other than a mock (validated separately,
-  # as part of resolving it via FileFinder#resolve_mock), a system header, Unity's or
-  # Ceedling's own header, or a Partial (Ceedling's own generated content, not a project file
-  # to validate) -- must resolve to exactly one file, existence-wise, among this test's own
-  # search_paths (the same directory priority the compiler itself consults): ambiguity among
-  # same-named candidates resolves quietly to the first by that order, exactly as the real
-  # compile would find it; only a genuinely unresolvable name still halts the build here. A
-  # bogus or merely-unmatched path is otherwise never actually checked against real project
-  # headers -- only its potential corresponding source file is, tolerantly, elsewhere. Unity's
-  # and Ceedling's own headers live in the build's vendor directories, outside every configured
-  # :test/:source/:support/:include root a test's search_paths is built from, so neither could
-  # ever resolve there.
-  def validate_header_includes(test_filepath:, testable:)
-    includes = @context_extractor.lookup_nonmock_header_includes_list( test_filepath )
-
-    collection = @include_pathinator.ordered_header_files( testable.search_paths )
-
-    includes.each do |include|
-      next if include.is_a?( SystemInclude )
-      next if include.filename == UNITY_H_FILE
-      next if include.filename == CEEDLING_HEADER_FILENAME
-      next if include.filename.start_with?( PARTIAL_FILENAME_PREFIX )
-
-      @file_finder.find_header_file( include.filepath, :error, collection: collection )
-    end
   end
 
   def generate_header_input_for_mock_partial(mock, test)

--- a/lib/ceedling/test_invoker/test_build_setup.rb
+++ b/lib/ceedling/test_invoker/test_build_setup.rb
@@ -12,12 +12,14 @@ require 'ceedling/includes/includes'
 require 'ceedling/partials/partials'
 require 'ceedling/test_invoker/test_invoker_types'
 require 'ceedling/test_invoker/test_pipeline_helpers'
+require 'ceedling/test_invoker/test_build_validations'
 require 'ceedling/path_mirror'
 
 class TestBuildSetup
 
   include TestInvokerTypes
   include TestPipelineHelpers
+  include TestBuildValidations
 
   constructor(
     :configurator,
@@ -524,35 +526,6 @@ class TestBuildSetup
       dirs << (subdir.empty? ? testable.paths[:mocks] : File.join( testable.paths[:mocks], subdir ))
     end
     return dirs.uniq
-  end
-
-  def validate_mocks_in_use(filename:, mocks:)
-    if !@configurator.project_use_mocks and !mocks.empty?
-      _mocks = mocks.map { |include| include.filename }
-
-      if _mocks.length > 1
-        _mocks = "[#{_mocks.join(', ')}]"
-      else
-        _mocks = _mocks[0]
-      end
-
-      msg = "Your project is not configured for mocking, but #{filename} #includes #{_mocks}"
-      raise CeedlingException.new( msg )
-    end
-  end
-
-  def validate_partials_in_use(filename:, partials_in_use:, includes:)
-    partials_header_in_use = Includes.contains?( includes, CEEDLING_HEADER_FILENAME )
-
-    if partials_in_use && !@configurator.project_use_partials
-      msg = "Your project is not configured for Partials, but #{filename} is attempting to use Partial features"
-      raise CeedlingException.new( msg )
-    end
-
-    if partials_in_use && !partials_header_in_use
-      msg = "Your test file #{filename} is attempting to use Partial features without #including #{CEEDLING_HEADER_FILENAME}"
-      raise CeedlingException.new( msg )
-    end
   end
 
   def search_paths(filepath, paths, mock_search_paths = [])

--- a/lib/ceedling/test_invoker/test_build_validations.rb
+++ b/lib/ceedling/test_invoker/test_build_validations.rb
@@ -1,0 +1,102 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# Test-build configuration validators shared by more than one test pipeline stage
+# class -- each raises CeedlingException on a real, user-facing mistake it's
+# positioned to catch (a project using mocking, Partials, or a build-directive
+# source without configuring for it, or a header that doesn't actually resolve).
+# Relies on whichever including class's own constructor DI already provides the
+# collaborators a given validator needs, the same way TestPipelineHelpers is
+# mixed in without any DI wiring of its own.
+module TestBuildValidations
+
+  def validate_mocks_in_use(filename:, mocks:)
+    if !@configurator.project_use_mocks and !mocks.empty?
+      _mocks = mocks.map { |include| include.filename }
+
+      if _mocks.length > 1
+        _mocks = "[#{_mocks.join(', ')}]"
+      else
+        _mocks = _mocks[0]
+      end
+
+      msg = "Your project is not configured for mocking, but #{filename} #includes #{_mocks}"
+      raise CeedlingException.new( msg )
+    end
+  end
+
+  def validate_partials_in_use(filename:, partials_in_use:, includes:)
+    partials_header_in_use = Includes.contains?( includes, CEEDLING_HEADER_FILENAME )
+
+    if partials_in_use && !@configurator.project_use_partials
+      msg = "Your project is not configured for Partials, but #{filename} is attempting to use Partial features"
+      raise CeedlingException.new( msg )
+    end
+
+    if partials_in_use && !partials_header_in_use
+      msg = "Your test file #{filename} is attempting to use Partial features without #including #{CEEDLING_HEADER_FILENAME}"
+      raise CeedlingException.new( msg )
+    end
+  end
+
+  # Every #include naming a real project header -- other than a mock (validated separately,
+  # as part of resolving it via FileFinder#resolve_mock), a system header, Unity's or
+  # Ceedling's own header, or a Partial (Ceedling's own generated content, not a project file
+  # to validate) -- must resolve to exactly one file, existence-wise, among this test's own
+  # search_paths (the same directory priority the compiler itself consults): ambiguity among
+  # same-named candidates resolves quietly to the first by that order, exactly as the real
+  # compile would find it; only a genuinely unresolvable name still halts the build here. A
+  # bogus or merely-unmatched path is otherwise never actually checked against real project
+  # headers -- only its potential corresponding source file is, tolerantly, elsewhere. Unity's
+  # and Ceedling's own headers live in the build's vendor directories, outside every configured
+  # :test/:source/:support/:include root a test's search_paths is built from, so neither could
+  # ever resolve there.
+  def validate_header_includes(test_filepath:, testable:)
+    includes = @context_extractor.lookup_nonmock_header_includes_list( test_filepath )
+
+    collection = @include_pathinator.ordered_header_files( testable.search_paths )
+
+    includes.each do |include|
+      next if include.is_a?( SystemInclude )
+      next if include.filename == UNITY_H_FILE
+      next if include.filename == CEEDLING_HEADER_FILENAME
+      next if include.filename.start_with?( PARTIAL_FILENAME_PREFIX )
+
+      @file_finder.find_header_file( include.filepath, :error, collection: collection )
+    end
+  end
+
+  # A TEST_SOURCE_FILE() entry must name a real, recognized file whether it
+  # adds or removes -- a typo or a nonexistent path is worth failing loudly
+  # on either side of the +:/-: convention, the same way a missing file has
+  # always been treated for a plain, additive entry.
+  def validate!(test:, filepath:)
+    sources = @test_context_extractor.lookup_build_directive_sources_list( filepath )
+
+    ext_message = @configurator.extension_source.to_s
+    ext_message += " or #{@configurator.extension_assembly}" if @configurator.test_build_use_assembly
+
+    sources.each do |raw_source|
+      source = FilePathUtils.no_aggregation_decorators( raw_source )
+      valid_extension =
+        if @configurator.test_build_use_assembly
+          @configurator.extension_assembly.match?( source ) || @configurator.extension_source.match?( source )
+        else
+          @configurator.extension_source.match?( source )
+        end
+
+      unless valid_extension
+        raise CeedlingException.new( "File '#{source}' specified with TEST_SOURCE_FILE() in #{test} is not a #{ext_message} source file" )
+      end
+
+      if @file_finder.find_build_input_file( filepath: source, complain: :ignore, context: TEST_SYM ).nil?
+        raise CeedlingException.new( "File '#{source}' specified with TEST_SOURCE_FILE() in #{test} cannot be found in the source file collection" )
+      end
+    end
+  end
+
+end

--- a/lib/ceedling/test_invoker/test_source_file_directive_resolver.rb
+++ b/lib/ceedling/test_invoker/test_source_file_directive_resolver.rb
@@ -8,6 +8,7 @@
 require 'ceedling/constants'
 require 'ceedling/exceptions'
 require 'ceedling/file_path_utils'
+require 'ceedling/test_invoker/test_build_validations'
 
 # Owns everything about the TEST_SOURCE_FILE() build directive's own path
 # content: collecting a test's raw directive strings, telling additive
@@ -17,6 +18,8 @@ require 'ceedling/file_path_utils'
 # valid; they don't need to know the +:/-: convention or how a raw string
 # becomes a real filepath.
 class TestSourceFileDirectiveResolver
+
+  include TestBuildValidations
 
   constructor :test_context_extractor, :file_finder, :configurator, :loginator
 
@@ -46,35 +49,6 @@ class TestSourceFileDirectiveResolver
     end
 
     return [additive_sources, subtractive_sources]
-  end
-
-  # A TEST_SOURCE_FILE() entry must name a real, recognized file whether it
-  # adds or removes -- a typo or a nonexistent path is worth failing loudly
-  # on either side of the +:/-: convention, the same way a missing file has
-  # always been treated for a plain, additive entry.
-  def validate!(test:, filepath:)
-    sources = @test_context_extractor.lookup_build_directive_sources_list( filepath )
-
-    ext_message = @configurator.extension_source.to_s
-    ext_message += " or #{@configurator.extension_assembly}" if @configurator.test_build_use_assembly
-
-    sources.each do |raw_source|
-      source = FilePathUtils.no_aggregation_decorators( raw_source )
-      valid_extension =
-        if @configurator.test_build_use_assembly
-          @configurator.extension_assembly.match?( source ) || @configurator.extension_source.match?( source )
-        else
-          @configurator.extension_source.match?( source )
-        end
-
-      unless valid_extension
-        raise CeedlingException.new( "File '#{source}' specified with TEST_SOURCE_FILE() in #{test} is not a #{ext_message} source file" )
-      end
-
-      if @file_finder.find_build_input_file( filepath: source, complain: :ignore, context: TEST_SYM ).nil?
-        raise CeedlingException.new( "File '#{source}' specified with TEST_SOURCE_FILE() in #{test} cannot be found in the source file collection" )
-      end
-    end
   end
 
   # Applies this test's TEST_SOURCE_FILE("-:...") entries against the fully

--- a/spec/system/mocks_partials_configuration_validation_spec.rb
+++ b/spec/system/mocks_partials_configuration_validation_spec.rb
@@ -1,0 +1,113 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+
+##
+## Mocks/Partials Configuration Validation
+## ==========================================
+##
+## A test file's own #includes are scanned for the mock and Partials naming
+## conventions regardless of whether either feature is actually configured
+## on for the project -- a test #including a Mock*.h header, or using a
+## TEST_PARTIAL_*_MODULE()/MOCK_PARTIAL_*_MODULE() macro, with the
+## corresponding project feature turned off is a real, loud configuration
+## mistake (the test author almost certainly meant to enable the feature),
+## not something to silently ignore or fail at some much later, harder to
+## diagnose compile/link stage.
+##
+
+MOCK_WITHOUT_CONFIG_C = <<~C
+  #include "unity.h"
+  #include "mock_foo.h"
+
+  void setUp(void) {}
+  void tearDown(void) {}
+
+  void test_dummy(void) { TEST_ASSERT_TRUE(1); }
+C
+
+PARTIAL_WITHOUT_CONFIG_C = <<~C
+  #include "unity.h"
+  #include "ceedling.h"
+  #include TEST_PARTIAL_PUBLIC_MODULE(Foo)
+
+  void setUp(void) {}
+  void tearDown(void) {}
+
+  void test_dummy(void) { TEST_ASSERT_TRUE(1); }
+C
+
+ceedling_system_tests do
+
+  before :all do
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  before { @proj_name = unique_proj_name("mocks_partials_config") }
+
+  describe "Deployed as a gem" do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new #{@proj_name}")
+      end
+    end
+
+    describe "a test #including a mock while mocking is disabled" do
+      before do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            @c.merge_project_yml_for_test({ :project => { :use_mocks => false } })
+            File.write('test/test_mock_without_config.c', MOCK_WITHOUT_CONFIG_C)
+          end
+        end
+      end
+
+      it "fails the build naming the offending test file and mock" do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            output = @c.ceedling_build_exec("test:all")
+            expect(@c.last_exit_status).not_to eq(0)
+            expect(output).to match(/not configured for mocking/)
+            expect(output).to match(/test_mock_without_config\.c/)
+            expect(output).to match(/mock_foo\.h/)
+          end
+        end
+      end
+    end
+
+    describe "a test using a Partial while Partials are disabled (the project default)" do
+      before do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            # Partials configuration macros are only scanned for when test
+            # preprocessing is on -- off (:none) is this project's own default.
+            @c.merge_project_yml_for_test({ :project => { :use_test_preprocessor => :all } })
+            File.write('test/test_partial_without_config.c', PARTIAL_WITHOUT_CONFIG_C)
+          end
+        end
+      end
+
+      it "fails the build naming the offending test file" do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            output = @c.ceedling_build_exec("test:all")
+            expect(@c.last_exit_status).not_to eq(0)
+            expect(output).to match(/not configured for Partials/)
+            expect(output).to match(/test_partial_without_config\.c/)
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/spec/units/test_build_planner_spec.rb
+++ b/spec/units/test_build_planner_spec.rb
@@ -401,7 +401,7 @@ describe TestBuildPlanner do
         .with( 'test/TestFoo.c' ).and_return( [SystemInclude.new('stdio.h')] )
       expect(@file_finder).to_not receive(:find_header_file)
 
-      @planner.validate_header_includes( 'test/TestFoo.c', @testable )
+      @planner.validate_header_includes( test_filepath: 'test/TestFoo.c', testable: @testable )
     end
 
     it "skips Unity's own header" do
@@ -409,7 +409,7 @@ describe TestBuildPlanner do
         .with( 'test/TestFoo.c' ).and_return( [UserInclude.new('unity.h')] )
       expect(@file_finder).to_not receive(:find_header_file)
 
-      @planner.validate_header_includes( 'test/TestFoo.c', @testable )
+      @planner.validate_header_includes( test_filepath: 'test/TestFoo.c', testable: @testable )
     end
 
     it "skips Ceedling's own Partials support header" do
@@ -417,7 +417,7 @@ describe TestBuildPlanner do
         .with( 'test/TestFoo.c' ).and_return( [UserInclude.new('ceedling.h')] )
       expect(@file_finder).to_not receive(:find_header_file)
 
-      @planner.validate_header_includes( 'test/TestFoo.c', @testable )
+      @planner.validate_header_includes( test_filepath: 'test/TestFoo.c', testable: @testable )
     end
 
     it "skips a Partial's own generated header" do
@@ -425,7 +425,7 @@ describe TestBuildPlanner do
         .with( 'test/TestFoo.c' ).and_return( [UserInclude.new('ceedling_partial_foo_interface.h')] )
       expect(@file_finder).to_not receive(:find_header_file)
 
-      @planner.validate_header_includes( 'test/TestFoo.c', @testable )
+      @planner.validate_header_includes( test_filepath: 'test/TestFoo.c', testable: @testable )
     end
 
     it "resolves an ordinary header against this test's own ordered search-path header collection, hard-erroring only on no match" do
@@ -437,7 +437,7 @@ describe TestBuildPlanner do
 
       expect(@file_finder).to receive(:find_header_file).with( 'drivers/foo.h', :error, collection: ['inc/drivers/foo.h'] )
 
-      @planner.validate_header_includes( 'test/TestFoo.c', @testable )
+      @planner.validate_header_includes( test_filepath: 'test/TestFoo.c', testable: @testable )
     end
   end
 


### PR DESCRIPTION
## Summary

Second of four PRs implementing Phase B of the test-build pipeline (`lib/ceedling/test_invoker/`) architecture review, following [PR #1217](https://github.com/ThrowTheSwitch/Ceedling/pull/1217) (Phase A) and [PR #1218](https://github.com/ThrowTheSwitch/Ceedling/pull/1218) (Phase B, PR 1).

Four independent validators -- `TestBuildSetup#validate_mocks_in_use`/`#validate_partials_in_use`, `TestBuildPlanner#validate_header_includes`, and `TestSourceFileDirectiveResolver#validate!` -- each raise `CeedlingException` on a real, user-facing configuration mistake, but had no shared home and no consistent calling convention.

- Filled a real, pre-existing coverage gap first: neither `validate_mocks_in_use`'s nor `validate_partials_in_use`'s raise path had any system-level coverage, only unit tests. New system spec (`spec/system/mocks_partials_configuration_validation_spec.rb`) confirms both against the real CLI, run against the *unrefactored* code first to lock in current behavior before touching anything.
- Standardized `validate_header_includes`'s two positional params to keyword args, matching the other three validators' existing convention.
- Moved all four into a new `TestBuildValidations` module (`lib/ceedling/test_invoker/test_build_validations.rb`), mixed into `TestBuildSetup`, `TestBuildPlanner`, and `TestSourceFileDirectiveResolver` -- same pattern `TestPipelineHelpers` already established for non-validation shared helpers in this same directory.

Two things the new system spec surfaced along the way, worth knowing for future work here: CMock's real default mock-file prefix is `mock_` (lowercase), not the `Mock` naming unit-test doubles in this codebase happen to stub; and Partials-configuration-macro scanning (`TEST_PARTIAL_*_MODULE()`, etc.) only happens when test preprocessing is enabled (`:project ↳ :use_test_preprocessor` other than `:none`, this project's own default) -- so `validate_partials_in_use`'s "used without configuring" check can only ever fire under that setting.

## Test plan

- [x] `bundle exec rspec spec/units` -- 2588 examples, 0 failures
- [x] Docker (`throwtheswitch/madsciencelab-plugins:v1.1.4`) targeted run: `spec/system/mocks_partials_configuration_validation_spec.rb` (new), `spec/system/header_include_path_validation_spec.rb`, `spec/system/test_source_file_directive_spec.rb` -- 14 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)