### PR TITLE
Test-build pipeline Phase B, PR 3: consolidate duplicate Partial header/source preprocessing

### DIFF
--- a/lib/ceedling/test_invoker/test_build_executor.rb
+++ b/lib/ceedling/test_invoker/test_build_executor.rb
@@ -37,245 +37,25 @@ class TestBuildExecutor
   end
 
   # Stage 6: Preprocess partial header files for extract-and-generate pass.
-  #
-  # A partial header's three preprocessing passes below (directives-only
-  # generation, preserve-macros preprocessing, full-expansion) all derive
-  # from the same antecedent file and the same preprocess flags/defines/
-  # search paths, so they're stale or fresh together as a single unit --
-  # one DependencyTracker target per header per test covers all three.
-  #
-  # Settling every target's staleness in its own sequential pass first
-  # (cheap, no subprocess work) is what lets the three parallel batches
-  # below each just check `details.stale` instead of duplicating the
-  # register/stale? call three times over. On a stale target, all three
-  # passes run and populate `config` as they do today. On a fresh target,
-  # the two preprocessed output filepaths are recomputed the same
-  # deterministic way the preprocessor methods themselves compute them, and
-  # `config.includes` is recalled from the on-disk list a prior stale run
-  # wrote -- so `config` ends up populated identically either way, and
-  # stage 8 (which reads only `config`) needs no knowledge of which path
-  # produced it.
   def stage_preprocess_partial_headers(state)
-    directives_only = @configurator.test_build_preprocess_directives_only_available
-    skipped = 0
-
-    state.partials_headers.each do |details|
-      config   = details.config
-      testable = details.testable
-      name     = testable.name
-
-      target = @file_path_utils.form_preprocessed_file_filepath( config.filepath, name )
-
-      @dependinator.register(
-        target,
-        files: [config.filepath],
-        meta:  dependency_meta( flags: testable.preprocess_flags, defines: testable.preprocess_defines, search_paths: testable.search_paths )
-      )
-
-      details.preprocessed_target = target
-      details.stale               = @dependinator.stale?( target )
-
-      if details.stale
-        msg = @reportinator.generate_module_progress(
-          operation:   'Preprocessing partial header for',
-          module_name: name,
-          filename:    File.basename( config.filepath )
-        )
-        @loginator.log( msg )
-      else
-        msg = @reportinator.generate_module_progress(
-          operation:   'Skipping partial header preprocessing for',
-          module_name: name,
-          filename:    File.basename( config.filepath )
-        )
-        @loginator.log( msg, Verbosity::OBNOXIOUS )
-        skipped += 1
-
-        config.directives_only_filepath = target
-        config.includes                 = @preprocessinator.load_includes_list( test: name, filepath: config.filepath )
-        config.full_expansion_filepath  = @file_path_utils.form_preprocessed_file_full_expansion_filepath( config.filepath, name )
-      end
-    end
-
-    log_skip_summary( task: "partial header preprocessing", count: skipped, noun: "headers" )
-
-    # Generate directive-only preprocessor output if available
-    @batchinator.exec(workload: :compile, things: state.partials_headers) do |details|
-      next unless details.stale
-
-      config   = details.config
-      testable = details.testable
-      name     = testable.name
-
-      arg_hash = {
-        filepath:      config.filepath,
-        test:          name,
-        flags:         testable.preprocess_flags,
-        include_paths: testable.search_paths,
-        vendor_paths:  vendor_search_paths(),
-        defines:       testable.preprocess_defines
-      }
-
-      details.directives_only_filepath = @preprocessinator.generate_directives_only_output( **arg_hash )
-    end if directives_only
-
-    # Preprocess and assemble header files
-    @batchinator.exec(workload: :compile, things: state.partials_headers) do |details|
-      next unless details.stale
-
-      config                   = details.config
-      testable                 = details.testable
-      name                     = testable.name
-      directives_only_filepath = details.directives_only_filepath
-
-      arg_hash = {
-        test:                     name,
-        filepath:                 config.filepath,
-        directives_only_filepath: directives_only_filepath,
-        fallback:                 directives_only_fallback?( directives_only, directives_only_filepath ),
-        flags:                    testable.preprocess_flags,
-        include_paths:            testable.search_paths,
-        vendor_paths:             vendor_search_paths(),
-        defines:                  testable.preprocess_defines
-      }
-
-      config.directives_only_filepath, config.includes = @preprocessinator.preprocess_partial_header_file_preserve_macros( **arg_hash )
-    end
-
-    # Full-preprocess partial header files for expanded signature extraction.
-    @batchinator.exec(workload: :compile, things: state.partials_headers) do |details|
-      next unless details.stale
-
-      config   = details.config
-      testable = details.testable
-      name     = testable.name
-
-      arg_hash = {
-        filepath:      config.filepath,
-        test:          name,
-        flags:         testable.preprocess_flags,
-        include_paths: testable.search_paths,
-        vendor_paths:  vendor_search_paths(),
-        defines:       testable.preprocess_defines
-      }
-
-      config.full_expansion_filepath = @preprocessinator.preprocess_partial_header_expand_macros( **arg_hash )
-
-      @dependinator.mark_fresh( details.preprocessed_target )
-    end
+    preprocess_partials(
+      items:                  state.partials_headers,
+      kind:                   'header',
+      noun:                   'headers',
+      preserve_macros_method: :preprocess_partial_header_file_preserve_macros,
+      expand_macros_method:   :preprocess_partial_header_expand_macros
+    )
   end
 
   # Stage 7: Preprocess partial source files for extract-and-generate pass.
-  # Mirrors stage 6 exactly, against `state.partials_sources` and each
-  # partial's source file rather than its header.
   def stage_preprocess_partial_sources(state)
-    directives_only = @configurator.test_build_preprocess_directives_only_available
-    skipped = 0
-
-    state.partials_sources.each do |details|
-      config   = details.config
-      testable = details.testable
-      name     = testable.name
-
-      target = @file_path_utils.form_preprocessed_file_filepath( config.filepath, name )
-
-      @dependinator.register(
-        target,
-        files: [config.filepath],
-        meta:  dependency_meta( flags: testable.preprocess_flags, defines: testable.preprocess_defines, search_paths: testable.search_paths )
-      )
-
-      details.preprocessed_target = target
-      details.stale               = @dependinator.stale?( target )
-
-      if details.stale
-        msg = @reportinator.generate_module_progress(
-          operation:   'Preprocessing partial source for',
-          module_name: name,
-          filename:    File.basename( config.filepath )
-        )
-        @loginator.log( msg )
-      else
-        msg = @reportinator.generate_module_progress(
-          operation:   'Skipping partial source preprocessing for',
-          module_name: name,
-          filename:    File.basename( config.filepath )
-        )
-        @loginator.log( msg, Verbosity::OBNOXIOUS )
-        skipped += 1
-
-        config.directives_only_filepath = target
-        config.includes                 = @preprocessinator.load_includes_list( test: name, filepath: config.filepath )
-        config.full_expansion_filepath  = @file_path_utils.form_preprocessed_file_full_expansion_filepath( config.filepath, name )
-      end
-    end
-
-    log_skip_summary( task: "partial source preprocessing", count: skipped, noun: "sources" )
-
-    # Generate directive-only preprocessor output if available
-    @batchinator.exec(workload: :compile, things: state.partials_sources) do |details|
-      next unless details.stale
-
-      config   = details.config
-      testable = details.testable
-      name     = testable.name
-
-      arg_hash = {
-        filepath:      config.filepath,
-        test:          name,
-        flags:         testable.preprocess_flags,
-        include_paths: testable.search_paths,
-        vendor_paths:  vendor_search_paths(),
-        defines:       testable.preprocess_defines
-      }
-
-      details.directives_only_filepath = @preprocessinator.generate_directives_only_output( **arg_hash )
-    end if directives_only
-
-    # Preprocess and assemble source files
-    @batchinator.exec(workload: :compile, things: state.partials_sources) do |details|
-      next unless details.stale
-
-      config                   = details.config
-      testable                 = details.testable
-      name                     = testable.name
-      directives_only_filepath = details.directives_only_filepath
-
-      arg_hash = {
-        test:                     name,
-        filepath:                 config.filepath,
-        directives_only_filepath: directives_only_filepath,
-        fallback:                 directives_only_fallback?( directives_only, directives_only_filepath ),
-        flags:                    testable.preprocess_flags,
-        include_paths:            testable.search_paths,
-        vendor_paths:             vendor_search_paths(),
-        defines:                  testable.preprocess_defines
-      }
-
-      config.directives_only_filepath, config.includes = @preprocessinator.preprocess_partial_source_file_preserve_macros( **arg_hash )
-    end
-
-    # Full-preprocess partial source files for expanded signature extraction.
-    @batchinator.exec(workload: :compile, things: state.partials_sources) do |details|
-      next unless details.stale
-
-      config   = details.config
-      testable = details.testable
-      name     = testable.name
-
-      arg_hash = {
-        filepath:      config.filepath,
-        test:          name,
-        flags:         testable.preprocess_flags,
-        include_paths: testable.search_paths,
-        vendor_paths:  vendor_search_paths(),
-        defines:       testable.preprocess_defines
-      }
-
-      config.full_expansion_filepath = @preprocessinator.preprocess_partial_source_expand_macros( **arg_hash )
-
-      @dependinator.mark_fresh( details.preprocessed_target )
-    end
+    preprocess_partials(
+      items:                  state.partials_sources,
+      kind:                   'source',
+      noun:                   'sources',
+      preserve_macros_method: :preprocess_partial_source_file_preserve_macros,
+      expand_macros_method:   :preprocess_partial_source_expand_macros
+    )
   end
 
   # Stage 8: Extract and generate partial implementation and interface files.
@@ -1059,6 +839,136 @@ class TestBuildExecutor
   # generate_directives_only_output) despite support existing project-wide.
   def directives_only_fallback?(directives_only, directives_only_filepath)
     !directives_only or directives_only_filepath.nil?
+  end
+
+  # Shared body for stages 6 and 7 -- a partial's header and source files go through
+  # identical preprocessing, differing only in which of `state.partials_headers`/
+  # `state.partials_sources` supplies the work and which Preprocessinator methods
+  # `kind` (a header or a source) is actually preprocessed by.
+  #
+  # A partial file's three preprocessing passes below (directives-only generation,
+  # preserve-macros preprocessing, full-expansion) all derive from the same
+  # antecedent file and the same preprocess flags/defines/search paths, so they're
+  # stale or fresh together as a single unit -- one DependencyTracker target per
+  # file per test covers all three.
+  #
+  # Settling every target's staleness in its own sequential pass first (cheap, no
+  # subprocess work) is what lets the three parallel batches below each just check
+  # `details.stale` instead of duplicating the register/stale? call three times
+  # over. On a stale target, all three passes run and populate `config` as they do
+  # today. On a fresh target, the two preprocessed output filepaths are recomputed
+  # the same deterministic way the preprocessor methods themselves compute them,
+  # and `config.includes` is recalled from the on-disk list a prior stale run wrote
+  # -- so `config` ends up populated identically either way, and stage 8 (which
+  # reads only `config`) needs no knowledge of which path produced it.
+  def preprocess_partials(items:, kind:, noun:, preserve_macros_method:, expand_macros_method:)
+    directives_only = @configurator.test_build_preprocess_directives_only_available
+    skipped = 0
+
+    items.each do |details|
+      config   = details.config
+      testable = details.testable
+      name     = testable.name
+
+      target = @file_path_utils.form_preprocessed_file_filepath( config.filepath, name )
+
+      @dependinator.register(
+        target,
+        files: [config.filepath],
+        meta:  dependency_meta( flags: testable.preprocess_flags, defines: testable.preprocess_defines, search_paths: testable.search_paths )
+      )
+
+      details.preprocessed_target = target
+      details.stale               = @dependinator.stale?( target )
+
+      if details.stale
+        msg = @reportinator.generate_module_progress(
+          operation:   "Preprocessing partial #{kind} for",
+          module_name: name,
+          filename:    File.basename( config.filepath )
+        )
+        @loginator.log( msg )
+      else
+        msg = @reportinator.generate_module_progress(
+          operation:   "Skipping partial #{kind} preprocessing for",
+          module_name: name,
+          filename:    File.basename( config.filepath )
+        )
+        @loginator.log( msg, Verbosity::OBNOXIOUS )
+        skipped += 1
+
+        config.directives_only_filepath = target
+        config.includes                 = @preprocessinator.load_includes_list( test: name, filepath: config.filepath )
+        config.full_expansion_filepath  = @file_path_utils.form_preprocessed_file_full_expansion_filepath( config.filepath, name )
+      end
+    end
+
+    log_skip_summary( task: "partial #{kind} preprocessing", count: skipped, noun: noun )
+
+    # Generate directive-only preprocessor output if available
+    @batchinator.exec(workload: :compile, things: items) do |details|
+      next unless details.stale
+
+      config   = details.config
+      testable = details.testable
+      name     = testable.name
+
+      arg_hash = {
+        filepath:      config.filepath,
+        test:          name,
+        flags:         testable.preprocess_flags,
+        include_paths: testable.search_paths,
+        vendor_paths:  vendor_search_paths(),
+        defines:       testable.preprocess_defines
+      }
+
+      details.directives_only_filepath = @preprocessinator.generate_directives_only_output( **arg_hash )
+    end if directives_only
+
+    # Preprocess and assemble files
+    @batchinator.exec(workload: :compile, things: items) do |details|
+      next unless details.stale
+
+      config                   = details.config
+      testable                 = details.testable
+      name                     = testable.name
+      directives_only_filepath = details.directives_only_filepath
+
+      arg_hash = {
+        test:                     name,
+        filepath:                 config.filepath,
+        directives_only_filepath: directives_only_filepath,
+        fallback:                 directives_only_fallback?( directives_only, directives_only_filepath ),
+        flags:                    testable.preprocess_flags,
+        include_paths:            testable.search_paths,
+        vendor_paths:             vendor_search_paths(),
+        defines:                  testable.preprocess_defines
+      }
+
+      config.directives_only_filepath, config.includes = @preprocessinator.public_send( preserve_macros_method, **arg_hash )
+    end
+
+    # Full-preprocess files for expanded signature extraction.
+    @batchinator.exec(workload: :compile, things: items) do |details|
+      next unless details.stale
+
+      config   = details.config
+      testable = details.testable
+      name     = testable.name
+
+      arg_hash = {
+        filepath:      config.filepath,
+        test:          name,
+        flags:         testable.preprocess_flags,
+        include_paths: testable.search_paths,
+        vendor_paths:  vendor_search_paths(),
+        defines:       testable.preprocess_defines
+      }
+
+      config.full_expansion_filepath = @preprocessinator.public_send( expand_macros_method, **arg_hash )
+
+      @dependinator.mark_fresh( details.preprocessed_target )
+    end
   end
 
   # Compile a single C or assembly source file into an object file. Returns

--- a/spec/units/test_build_executor_spec.rb
+++ b/spec/units/test_build_executor_spec.rb
@@ -979,6 +979,17 @@ describe TestBuildExecutor do
       expect( @config.full_expansion_filepath ).to eq( 'build/preprocess/full_expansion/Foo.c' )
     end
 
+    it "does nothing for the directives-only pass when directives-only preprocessing is unavailable for this toolchain, but still runs preserve-macros and full-expansion" do
+      allow(@configurator).to receive(:test_build_preprocess_directives_only_available).and_return( false )
+      allow(@dependinator).to receive(:stale?).and_return( true )
+
+      expect(@preprocessinator).to_not receive(:generate_directives_only_output)
+      expect(@preprocessinator).to receive(:preprocess_partial_source_file_preserve_macros)
+      expect(@preprocessinator).to receive(:preprocess_partial_source_expand_macros)
+
+      @executor.stage_preprocess_partial_sources( @state )
+    end
+
     it "logs a NORMAL progress line for a source that needs preprocessing, and no OBNOXIOUS skip line" do
       allow(@configurator).to receive(:test_build_preprocess_directives_only_available).and_return( true )
       allow(@dependinator).to receive(:stale?).and_return( true )


### PR DESCRIPTION
## Summary

Third of four PRs implementing Phase B of the test-build pipeline (`lib/ceedling/test_invoker/`) architecture review, following [PR #1217](https://github.com/ThrowTheSwitch/Ceedling/pull/1217) (Phase A), [PR #1218](https://github.com/ThrowTheSwitch/Ceedling/pull/1218) (Phase B, PR 1), and [PR #1219](https://github.com/ThrowTheSwitch/Ceedling/pull/1219) (Phase B, PR 2).

`TestBuildExecutor#stage_preprocess_partial_headers` and `#stage_preprocess_partial_sources` (stages 6 and 7) were two ~110-line methods, structurally identical -- three preprocessing passes over a Partial's file, one `DependencyTracker` target per file per test -- differing only in which of `state.partials_headers`/`state.partials_sources` supplies the work and which `Preprocessinator` methods a header vs. a source is actually preprocessed by. The sources method's own doc comment already said "Mirrors stage 6 exactly."

- Added the one real coverage asymmetry the two near-duplicate spec contexts had: the headers context tested the "directives-only preprocessing unavailable for this toolchain" branch; the sources context didn't. Added that test to the sources context first, against the *unconsolidated* code, to lock in current behavior.
- Consolidated both methods into one shared private `preprocess_partials` body, parameterized on the input list, a `kind`/`noun` pair for log text, and the two `Preprocessinator` method names to call. Both `stage_preprocess_partial_headers` and `stage_preprocess_partial_sources` keep their own names and stay the pipeline's two public entry points -- `TestPipelineManager` calls them exactly as before, no change to stage ordering or conditions.
- Every existing unit example in both spec contexts passed unmodified against the new shared body -- the public input/output contract didn't change, only the internal duplication.

## Test plan

- [x] `bundle exec rspec spec/units` -- 2589 examples, 0 failures
- [x] Docker (`throwtheswitch/madsciencelab-plugins:v1.1.4`) `spec/system/delta_builds_spec.rb` (wondrous_forest Partials cases -- the real end-to-end safety net for staleness/skip behavior across both stages) -- 16 examples, 0 failures
- [x] Docker `spec/system/gcov_deployment_spec.rb`'s Partials/coverage cases -- 16 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)