### PR TITLE
Fix #1215: Partial mocks fail to redirect DEDUCT/ACCUMULATE-mocked static inline functions

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -18,6 +18,7 @@ This changelog is complemented by three other documents:
 
 - Fixed shared generated Partial types header filename being derived from the test's name rather than partialized module's own name. Two modules Partialized in the same test could silently overwrite each other's content.
 - [#1210](https://github.com/ThrowTheSwitch/Ceedling/issues/1210) Fixed macros missing from shared Partial types header file emitted when two Partials both depend on the same types and related in common.
+- [#1215](https://github.com/ThrowTheSwitch/Ceedling/issues/1215) Fixed `MOCK_PARTIAL_ALL_MODULE()`/`MOCK_PARTIAL_MODULE()` silently failing to partialize `inline` functions in some circumstances leading to duplicated symbols breaking compilation.
 
 ---
 

--- a/examples/wondrous_forest/src/SensorHal.h
+++ b/examples/wondrous_forest/src/SensorHal.h
@@ -16,4 +16,17 @@ bool   SensorHal_IsChannelReady(SensorChannel_t channel);
 void   SensorHal_StartConversion(SensorChannel_t channel);
 uint32 SensorHal_GetTimestampMs(void);
 
+/* Vendor-header-style static inline register accessor -- the same pattern that
+ * makes a real hardware header need Partial mocking instead of ordinary mocking,
+ * since there is no separate .c file to exclude from a test build and swap for a
+ * mock's .o at link time. The real body here stands in for what would otherwise
+ * be a direct, unsafe-off-target memory-mapped register read: it always returns
+ * the same obviously-wrong sentinel, so a test can tell whether this real body
+ * ran (Partial mocking failed to intercept the call) instead of its mock. */
+static inline uint16 SensorHal_RawStatusRegister(SensorChannel_t channel)
+{
+    (void)channel;
+    return 0xDEADu;
+}
+
 #endif /* SENSOR_HAL_H */

--- a/examples/wondrous_forest/src/TemperatureSensor.c
+++ b/examples/wondrous_forest/src/TemperatureSensor.c
@@ -9,9 +9,10 @@
 #include "TemperatureSensor.h"
 #include "SensorHal.h"
 
-static float s_calibration_offset;
-static int32 s_last_milli_celsius;
-static bool  s_reading_valid;
+static float  s_calibration_offset;
+static int32  s_last_milli_celsius;
+static bool   s_reading_valid;
+static uint16 s_last_status_register;
 
 /* Linearized approximation: full-scale 4095 counts maps 0 C to 85 C. */
 static int32 TemperatureSensor__RawToMilliCelsius(uint16 raw_counts)
@@ -45,8 +46,9 @@ bool TemperatureSensor_Sample(void)
 
     if (!SensorHal_IsChannelReady(SENSOR_CHANNEL_TEMP)) { return false; }
 
-    raw     = SensorHal_ReadChannel(SENSOR_CHANNEL_TEMP);
-    milli_c = TemperatureSensor__RawToMilliCelsius(raw);
+    raw                    = SensorHal_ReadChannel(SENSOR_CHANNEL_TEMP);
+    s_last_status_register = SensorHal_RawStatusRegister(SENSOR_CHANNEL_TEMP);
+    milli_c                = TemperatureSensor__RawToMilliCelsius(raw);
     milli_c += (int32)(s_calibration_offset * 1000.0f);
 
     s_reading_valid      = TemperatureSensor__IsInRange(milli_c);
@@ -64,4 +66,9 @@ int32 TemperatureSensor_GetMilliCelsius(void)
 bool TemperatureSensor_IsValid(void)
 {
     return s_reading_valid;
+}
+
+uint16 TemperatureSensor_GetStatusRegister(void)
+{
+    return s_last_status_register;
 }

--- a/examples/wondrous_forest/src/TemperatureSensor.h
+++ b/examples/wondrous_forest/src/TemperatureSensor.h
@@ -10,9 +10,10 @@
 
 #include "Types.h"
 
-void  TemperatureSensor_Init(float calibration_offset_celsius);
-bool  TemperatureSensor_Sample(void);
-int32 TemperatureSensor_GetMilliCelsius(void);
-bool  TemperatureSensor_IsValid(void);
+void   TemperatureSensor_Init(float calibration_offset_celsius);
+bool   TemperatureSensor_Sample(void);
+int32  TemperatureSensor_GetMilliCelsius(void);
+bool   TemperatureSensor_IsValid(void);
+uint16 TemperatureSensor_GetStatusRegister(void);
 
 #endif /* TEMPERATURE_SENSOR_H */

--- a/examples/wondrous_forest/test/TestTemperatureSensor.c
+++ b/examples/wondrous_forest/test/TestTemperatureSensor.c
@@ -5,17 +5,25 @@
     SPDX-License-Identifier: MIT
 ========================================================================= */
 
-/* Partials pattern: TEST_PARTIAL_ALL_MODULE
+/* Partials pattern: TEST_PARTIAL_ALL_MODULE + MOCK_PARTIAL_ALL_MODULE
  * Tests both public functions AND the private static helpers
  * TemperatureSensor__RawToMilliCelsius() and TemperatureSensor__IsInRange().
  * Also accesses the file-scoped static s_calibration_offset directly.
- * SensorHal is mocked traditionally since it has no private statics. */
+ * SensorHal is mocked via Partials (MOCK_PARTIAL_ALL_MODULE) rather than
+ * traditionally: SensorHal_RawStatusRegister() is a static inline function,
+ * which only Partial mocking (not ordinary CMock header mocking) can
+ * intercept -- there is no separate SensorHal.c definition for a static
+ * inline function to exclude from this test build and replace with a mock
+ * .o at link time, so the call must be redirected to the mock before that,
+ * at the #include level. Every existing SensorHal_*_Expect* call below
+ * keeps working unchanged either way, since Partial-mocked functions use
+ * the identical CMock expectation API as a traditionally mocked module. */
 
 #include "unity.h"
 #include "ceedling.h"
-#include "MockSensorHal.h"
 
 #include TEST_PARTIAL_ALL_MODULE(TemperatureSensor)
+#include MOCK_PARTIAL_ALL_MODULE(SensorHal)
 
 #include "Types.h"
 
@@ -78,6 +86,7 @@ void test_Sample_ReturnsTrueAndStoresReadingWhenReady(void)
     /* 1638 counts: (1638 * 85000) / 4095 ~= 34000 milli-C (34 C), in range */
     SensorHal_IsChannelReady_ExpectAndReturn(SENSOR_CHANNEL_TEMP, true);
     SensorHal_ReadChannel_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 1638u);
+    SensorHal_RawStatusRegister_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 0x1234u);
     SensorHal_StartConversion_Expect(SENSOR_CHANNEL_TEMP);
 
     TEST_ASSERT_TRUE(TemperatureSensor_Sample());
@@ -93,8 +102,28 @@ void test_CalibrationOffsetShiftsReading(void)
     /* 2048 counts ~= 42502 milli-C; with +1.0 C offset -> ~= 43502 */
     SensorHal_IsChannelReady_ExpectAndReturn(SENSOR_CHANNEL_TEMP, true);
     SensorHal_ReadChannel_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 2048u);
+    SensorHal_RawStatusRegister_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 0x1234u);
     SensorHal_StartConversion_Expect(SENSOR_CHANNEL_TEMP);
 
     TemperatureSensor_Sample();
     TEST_ASSERT_INT32_WITHIN(200, 43502, TemperatureSensor_GetMilliCelsius());
+}
+
+/* Regression test for #1215: a module partial-mocked via MOCK_PARTIAL_ALL_MODULE
+ * (as SensorHal is above) must have its calling module's real #include swapped for
+ * the generated mock interface header. Without that swap, SensorHal_RawStatusRegister()'s
+ * real static inline body -- unreachable through ordinary link-time mock substitution,
+ * since a static inline function has no separate object file to exclude -- compiles
+ * straight into this test build and always returns its 0xDEAD sentinel regardless of
+ * what's expected here, no matter what the mock is told to return. */
+void test_StatusRegisterReflectsMockedValueNotRealSentinel(void)
+{
+    SensorHal_IsChannelReady_ExpectAndReturn(SENSOR_CHANNEL_TEMP, true);
+    SensorHal_ReadChannel_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 1638u);
+    SensorHal_RawStatusRegister_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 0x1234u);
+    SensorHal_StartConversion_Expect(SENSOR_CHANNEL_TEMP);
+
+    TemperatureSensor_Sample();
+
+    TEST_ASSERT_EQUAL_HEX16(0x1234u, TemperatureSensor_GetStatusRegister());
 }

--- a/lib/ceedling/partials/partializer.rb
+++ b/lib/ceedling/partials/partializer.rb
@@ -125,8 +125,15 @@ class Partializer
 
     partials.each do |_module, config|
       # Remap mockable interface headers that will be injected into generated partial implementation
+      #
+      # Any real (non-nil) mock mode means this module has a generated mock interface header
+      # to redirect to -- PUBLIC/PRIVATE alone once covered every mode that existed, but DEDUCT
+      # (MOCK_PARTIAL_ALL_MODULE) and ACCUMULATE (MOCK_PARTIAL_MODULE) were added later without
+      # updating this check, so a module mocked via either of those was silently never
+      # redirected: its real header (and any static inline/static function bodies in it) stayed
+      # #include'd verbatim, compiling straight past the mock instead of being replaced by it.
       if includes.any? { |include| include.filename.ext().downcase() == _module.downcase() }
-        if [PUBLIC, PRIVATE].include?( config.mocks.type )
+        if !config.mocks.type.nil?
           # Insert mockable interface header from remapping of module name
           _includes << UserInclude.new(
             @file_path_utils.form_partial_interface_header_filename(_module)

--- a/spec/support/system/system_context.rb
+++ b/spec/support/system/system_context.rb
@@ -6,6 +6,7 @@
 # =========================================================================
 
 require 'fileutils'
+require 'bundler'
 require 'ceedling/encodinator'
 require_relative 'gem_dir_layout'
 
@@ -44,16 +45,26 @@ class SystemContext
     )
 
     Dir.chdir(shared_dir) do
-      saved = ENV.to_hash
       begin
-        %w{BUNDLE_GEMFILE BUNDLE_BIN_PATH RUBYOPT}.each { |k| ENV.delete(k) }
-        deploy_output  = `bundle config set --local path '#{shared_gem.install_dir}' 2>&1`
-        # --prefer-local: Without it, Bundler resolves gems (e.g. `erb`) fresh from
-        # rubygems repository even when Ruby's default-gem copy satisfies the Gemfile constraint.
-        deploy_output += `bundle install --prefer-local 2>&1`
+        # Bundler.with_unbundled_env restores the pre-`bundle exec` environment for this
+        # block -- clearing not just BUNDLE_GEMFILE/BUNDLE_BIN_PATH/RUBYOPT (the previous,
+        # incomplete hand-rolled list here) but also GEM_HOME/GEM_PATH/RUBYLIB/PATH and every
+        # other var Bundler sets when this spec suite itself runs under `bundle exec` against
+        # a non-default GEM_HOME (e.g. `bundle install --path vendor/bundle`). Any one of
+        # those left in place is enough on its own for the `bundle exec ruby -S ceedling
+        # version` verification below to load the *outer* project's bundler/gems instead of
+        # this shared gem's own `--local path` install, and fail to find this Gemfile's exact
+        # pinned versions there.
+        deploy_output = Bundler.with_unbundled_env do
+          output  = `bundle config set --local path '#{shared_gem.install_dir}' 2>&1`
+          # --prefer-local: Without it, Bundler resolves gems (e.g. `erb`) fresh from
+          # rubygems repository even when Ruby's default-gem copy satisfies the Gemfile constraint.
+          output += `bundle install --prefer-local 2>&1`
+          output
+        end
         raise VerificationFailed, "bundle install failed:\n#{deploy_output}" unless $?.success?
 
-        verify = `bundle exec ruby -S ceedling version 2>&1`
+        verify = Bundler.with_unbundled_env { `bundle exec ruby -S ceedling version 2>&1` }
         unless $?.success?
           raise VerificationFailed,
             "Ceedling does not appear to be installed or ready for use.\n" \
@@ -62,8 +73,6 @@ class SystemContext
       rescue
         FileUtils.rm_rf(shared_dir)
         raise
-      ensure
-        ENV.replace(saved)
       end
     end
 

--- a/spec/system/encoding_stress_spec.rb
+++ b/spec/system/encoding_stress_spec.rb
@@ -131,8 +131,8 @@ ceedling_system_tests do
           @c.merge_project_yml_for_test({ :test_build => { :preprocess_force_fallback => false } })
           output = @c.ceedling_build_exec("test:all")
           expect(@c.last_exit_status).to eq(0)
-          expect(output).to match(/TESTED:\s+67/)
-          expect(output).to match(/PASSED:\s+67/)
+          expect(output).to match(/TESTED:\s+68/)
+          expect(output).to match(/PASSED:\s+68/)
         end
       end
     end
@@ -144,8 +144,8 @@ ceedling_system_tests do
           @c.merge_project_yml_for_test({ :test_build => { :preprocess_force_fallback => true } })
           output = @c.ceedling_build_exec("test:all")
           expect(@c.last_exit_status).to eq(0)
-          expect(output).to match(/TESTED:\s+67/)
-          expect(output).to match(/PASSED:\s+67/)
+          expect(output).to match(/TESTED:\s+68/)
+          expect(output).to match(/PASSED:\s+68/)
         end
       end
     end

--- a/spec/system/example_wondrous_forest_spec.rb
+++ b/spec/system/example_wondrous_forest_spec.rb
@@ -46,8 +46,8 @@ ceedling_system_tests do
         @c.with_context do
           Dir.chdir "wondrous_forest" do
             @output = @c.ceedling_build_exec("test:all")
-            expect(@output).to match(/TESTED:\s+67/)
-            expect(@output).to match(/PASSED:\s+67/)
+            expect(@output).to match(/TESTED:\s+68/)
+            expect(@output).to match(/PASSED:\s+68/)
             expect(@output).to match(/FAILED:\s+0/)
           end
         end

--- a/spec/units/partials/partializer_spec.rb
+++ b/spec/units/partials/partializer_spec.rb
@@ -871,6 +871,75 @@ describe Partializer do
       expect(result).not_to include(UserInclude.new('partial_module.h'))
     end
 
+    # Regression test for #1215: PUBLIC/PRIVATE were once the only mock modes that existed,
+    # so this method's own "does this module have a mock to redirect to" check only ever
+    # listed those two. DEDUCT (MOCK_PARTIAL_ALL_MODULE) was added later without updating
+    # this check, so a module mocked via MOCK_PARTIAL_ALL_MODULE -- e.g. a vendor header
+    # whose only mockable functions are static inline, which requires DEDUCT to select at
+    # all -- was silently never redirected to its mock interface header.
+    it "remaps mockable deduct (ALL_MODULE) partial to interface header" do
+      includes = [UserInclude.new('header1.h'), UserInclude.new('partial_module.h'), UserInclude.new('header2.h')]
+      partials = {
+        'partial_module' => make_partial_config(mocks_type: Partials::DEDUCT)
+      }
+      impl_filename = 'module_impl.h'
+      interface_filename = 'partial_module_interface.h'
+      impl_header = UserInclude.new(impl_filename)
+      interface_header = UserInclude.new(interface_filename)
+
+      allow(@file_path_utils).to receive(:form_partial_implementation_header_filename)
+        .with('module')
+        .and_return(impl_filename)
+
+      allow(@file_path_utils).to receive(:form_partial_interface_header_filename)
+        .with('partial_module')
+        .and_return(interface_filename)
+
+      result = @partializer.remap_implementation_source_includes(
+        name: 'module',
+        includes: includes,
+        partials: partials
+      )
+
+      expect(result).to include(impl_header)
+      expect(result).to include(interface_header)
+      expect(result).to include(UserInclude.new('header1.h'))
+      expect(result).to include(UserInclude.new('header2.h'))
+      expect(result).not_to include(UserInclude.new('partial_module.h'))
+    end
+
+    # Same regression as the DEDUCT case above, for ACCUMULATE (MOCK_PARTIAL_MODULE).
+    it "remaps mockable accumulate partial to interface header" do
+      includes = [UserInclude.new('header1.h'), UserInclude.new('partial_module.h'), UserInclude.new('header2.h')]
+      partials = {
+        'partial_module' => make_partial_config(mocks_type: Partials::ACCUMULATE)
+      }
+      impl_filename = 'module_impl.h'
+      interface_filename = 'partial_module_interface.h'
+      impl_header = UserInclude.new(impl_filename)
+      interface_header = UserInclude.new(interface_filename)
+
+      allow(@file_path_utils).to receive(:form_partial_implementation_header_filename)
+        .with('module')
+        .and_return(impl_filename)
+
+      allow(@file_path_utils).to receive(:form_partial_interface_header_filename)
+        .with('partial_module')
+        .and_return(interface_filename)
+
+      result = @partializer.remap_implementation_source_includes(
+        name: 'module',
+        includes: includes,
+        partials: partials
+      )
+
+      expect(result).to include(impl_header)
+      expect(result).to include(interface_header)
+      expect(result).to include(UserInclude.new('header1.h'))
+      expect(result).to include(UserInclude.new('header2.h'))
+      expect(result).not_to include(UserInclude.new('partial_module.h'))
+    end
+
     it "remaps multiple mockable partials to interface headers" do
       includes = [
         UserInclude.new('header1.h'),


### PR DESCRIPTION
## Summary
- `MOCK_PARTIAL_ALL_MODULE()`/`MOCK_PARTIAL_MODULE()` (`DEDUCT`/`ACCUMULATE` mock modes) never redirected a calling module's `#include` of a Partial-mocked header to the generated mock interface header — only `PUBLIC`/`PRIVATE` modes did. A `static inline` function has no separate object file to exclude from a test build and swap for a mock's `.o` at link time, so it stayed compiled straight into the calling module, bypassing its mock entirely and running the real body instead (segfault in the original report, where the real body touched invalid hardware register memory).
- Fixes [#1215](https://github.com/ThrowTheSwitch/Ceedling/issues/1215).
- Added `DEDUCT`/`ACCUMULATE` unit test coverage for the affected method (`spec/units/partials/partializer_spec.rb`), which only ever exercised `PUBLIC`/`PRIVATE` before.
- Added a real end-to-end regression scenario to the `wondrous_forest` example project (a new `static inline` function in `SensorHal`, mocked via `MOCK_PARTIAL_ALL_MODULE` from `TemperatureSensor`'s test) so this class of bug fails a real build, not just a unit assertion, if it recurs.
- Also fixes an unrelated, pre-existing bug in `SystemContext.setup_shared_gem!` discovered while verifying the above: it only cleared 3 of the env vars `bundle exec` sets before shelling out to its own throwaway test-gem install, letting this repo's own Bundler environment leak into it. Replaced the hand-rolled list with `Bundler.with_unbundled_env`, matching `next_version`'s already-correct approach.

## Test plan
- [x] `bundle exec rspec spec/units/partials/partializer_spec.rb` — new `DEDUCT`/`ACCUMULATE` cases pass; confirmed they fail without the fix.
- [x] `bundle exec rspec spec/units` — 1961 examples, 0 failures, 1 pending (pre-existing).
- [x] `bundle exec rspec spec/system/example_wondrous_forest_spec.rb` (via `throwtheswitch/madsciencelab-plugins` Docker image) — 7/7 pass, 68/68/0 tested/passed/failed.
- [x] Same spec with only the `partializer.rb` fix reverted — 3 real CMock failures (`Called earlier than expected`), confirming the new system coverage would have caught #1215 outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)