### PR TITLE
Port #1215 fix to next_version: Partial mocks fail to redirect DEDUCT/ACCUMULATE-mocked static inline functions

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -61,6 +61,12 @@ Because of the support added for handling paths and distinguishing duplicated fi
 
 Historically, Ceedling automatically compiles and links into a test executable any C source file whose name matches an `#include`d header file. Sometimes this convention can select the wrong file among same-named files or compile and link an entirely unwanted source file whose name happens to match a header file.
 
+## 💪 Fixed
+
+### Partials
+
+- [#1215](https://github.com/ThrowTheSwitch/Ceedling/issues/1215) Fixed `MOCK_PARTIAL_ALL_MODULE()`/`MOCK_PARTIAL_MODULE()` silently failing to partialize `inline` functions in some circumstances leading to duplicated symbols breaking compilation.
+
 ---
 
 # [1.1.5] — Prerelease

--- a/examples/wondrous_forest/src/SensorHal.h
+++ b/examples/wondrous_forest/src/SensorHal.h
@@ -16,4 +16,17 @@ bool   SensorHal_IsChannelReady(SensorChannel_t channel);
 void   SensorHal_StartConversion(SensorChannel_t channel);
 uint32 SensorHal_GetTimestampMs(void);
 
+/* Vendor-header-style static inline register accessor -- the same pattern that
+ * makes a real hardware header need Partial mocking instead of ordinary mocking,
+ * since there is no separate .c file to exclude from a test build and swap for a
+ * mock's .o at link time. The real body here stands in for what would otherwise
+ * be a direct, unsafe-off-target memory-mapped register read: it always returns
+ * the same obviously-wrong sentinel, so a test can tell whether this real body
+ * ran (Partial mocking failed to intercept the call) instead of its mock. */
+static inline uint16 SensorHal_RawStatusRegister(SensorChannel_t channel)
+{
+    (void)channel;
+    return 0xDEADu;
+}
+
 #endif /* SENSOR_HAL_H */

--- a/examples/wondrous_forest/src/TemperatureSensor.c
+++ b/examples/wondrous_forest/src/TemperatureSensor.c
@@ -9,9 +9,10 @@
 #include "TemperatureSensor.h"
 #include "SensorHal.h"
 
-static float s_calibration_offset;
-static int32 s_last_milli_celsius;
-static bool  s_reading_valid;
+static float  s_calibration_offset;
+static int32  s_last_milli_celsius;
+static bool   s_reading_valid;
+static uint16 s_last_status_register;
 
 /* Linearized approximation: full-scale 4095 counts maps 0 C to 85 C. */
 static int32 TemperatureSensor__RawToMilliCelsius(uint16 raw_counts)
@@ -45,8 +46,9 @@ bool TemperatureSensor_Sample(void)
 
     if (!SensorHal_IsChannelReady(SENSOR_CHANNEL_TEMP)) { return false; }
 
-    raw     = SensorHal_ReadChannel(SENSOR_CHANNEL_TEMP);
-    milli_c = TemperatureSensor__RawToMilliCelsius(raw);
+    raw                    = SensorHal_ReadChannel(SENSOR_CHANNEL_TEMP);
+    s_last_status_register = SensorHal_RawStatusRegister(SENSOR_CHANNEL_TEMP);
+    milli_c                = TemperatureSensor__RawToMilliCelsius(raw);
     milli_c += (int32)(s_calibration_offset * 1000.0f);
 
     s_reading_valid      = TemperatureSensor__IsInRange(milli_c);
@@ -64,4 +66,9 @@ int32 TemperatureSensor_GetMilliCelsius(void)
 bool TemperatureSensor_IsValid(void)
 {
     return s_reading_valid;
+}
+
+uint16 TemperatureSensor_GetStatusRegister(void)
+{
+    return s_last_status_register;
 }

--- a/examples/wondrous_forest/src/TemperatureSensor.h
+++ b/examples/wondrous_forest/src/TemperatureSensor.h
@@ -10,9 +10,10 @@
 
 #include "Types.h"
 
-void  TemperatureSensor_Init(float calibration_offset_celsius);
-bool  TemperatureSensor_Sample(void);
-int32 TemperatureSensor_GetMilliCelsius(void);
-bool  TemperatureSensor_IsValid(void);
+void   TemperatureSensor_Init(float calibration_offset_celsius);
+bool   TemperatureSensor_Sample(void);
+int32  TemperatureSensor_GetMilliCelsius(void);
+bool   TemperatureSensor_IsValid(void);
+uint16 TemperatureSensor_GetStatusRegister(void);
 
 #endif /* TEMPERATURE_SENSOR_H */

--- a/examples/wondrous_forest/test/TestTemperatureSensor.c
+++ b/examples/wondrous_forest/test/TestTemperatureSensor.c
@@ -5,17 +5,25 @@
     SPDX-License-Identifier: MIT
 ========================================================================= */
 
-/* Partials pattern: TEST_PARTIAL_ALL_MODULE
+/* Partials pattern: TEST_PARTIAL_ALL_MODULE + MOCK_PARTIAL_ALL_MODULE
  * Tests both public functions AND the private static helpers
  * TemperatureSensor__RawToMilliCelsius() and TemperatureSensor__IsInRange().
  * Also accesses the file-scoped static s_calibration_offset directly.
- * SensorHal is mocked traditionally since it has no private statics. */
+ * SensorHal is mocked via Partials (MOCK_PARTIAL_ALL_MODULE) rather than
+ * traditionally: SensorHal_RawStatusRegister() is a static inline function,
+ * which only Partial mocking (not ordinary CMock header mocking) can
+ * intercept -- there is no separate SensorHal.c definition for a static
+ * inline function to exclude from this test build and replace with a mock
+ * .o at link time, so the call must be redirected to the mock before that,
+ * at the #include level. Every existing SensorHal_*_Expect* call below
+ * keeps working unchanged either way, since Partial-mocked functions use
+ * the identical CMock expectation API as a traditionally mocked module. */
 
 #include "unity.h"
 #include "ceedling.h"
-#include "MockSensorHal.h"
 
 #include TEST_PARTIAL_ALL_MODULE(TemperatureSensor)
+#include MOCK_PARTIAL_ALL_MODULE(SensorHal)
 
 #include "Types.h"
 
@@ -78,6 +86,7 @@ void test_Sample_ReturnsTrueAndStoresReadingWhenReady(void)
     /* 1638 counts: (1638 * 85000) / 4095 ~= 34000 milli-C (34 C), in range */
     SensorHal_IsChannelReady_ExpectAndReturn(SENSOR_CHANNEL_TEMP, true);
     SensorHal_ReadChannel_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 1638u);
+    SensorHal_RawStatusRegister_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 0x1234u);
     SensorHal_StartConversion_Expect(SENSOR_CHANNEL_TEMP);
 
     TEST_ASSERT_TRUE(TemperatureSensor_Sample());
@@ -93,8 +102,28 @@ void test_CalibrationOffsetShiftsReading(void)
     /* 2048 counts ~= 42502 milli-C; with +1.0 C offset -> ~= 43502 */
     SensorHal_IsChannelReady_ExpectAndReturn(SENSOR_CHANNEL_TEMP, true);
     SensorHal_ReadChannel_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 2048u);
+    SensorHal_RawStatusRegister_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 0x1234u);
     SensorHal_StartConversion_Expect(SENSOR_CHANNEL_TEMP);
 
     TemperatureSensor_Sample();
     TEST_ASSERT_INT32_WITHIN(200, 43502, TemperatureSensor_GetMilliCelsius());
+}
+
+/* Regression test for #1215: a module partial-mocked via MOCK_PARTIAL_ALL_MODULE
+ * (as SensorHal is above) must have its calling module's real #include swapped for
+ * the generated mock interface header. Without that swap, SensorHal_RawStatusRegister()'s
+ * real static inline body -- unreachable through ordinary link-time mock substitution,
+ * since a static inline function has no separate object file to exclude -- compiles
+ * straight into this test build and always returns its 0xDEAD sentinel regardless of
+ * what's expected here, no matter what the mock is told to return. */
+void test_StatusRegisterReflectsMockedValueNotRealSentinel(void)
+{
+    SensorHal_IsChannelReady_ExpectAndReturn(SENSOR_CHANNEL_TEMP, true);
+    SensorHal_ReadChannel_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 1638u);
+    SensorHal_RawStatusRegister_ExpectAndReturn(SENSOR_CHANNEL_TEMP, 0x1234u);
+    SensorHal_StartConversion_Expect(SENSOR_CHANNEL_TEMP);
+
+    TemperatureSensor_Sample();
+
+    TEST_ASSERT_EQUAL_HEX16(0x1234u, TemperatureSensor_GetStatusRegister());
 }

--- a/lib/ceedling/partials/partializer.rb
+++ b/lib/ceedling/partials/partializer.rb
@@ -125,8 +125,15 @@ class Partializer
 
     partials.each do |_module, config|
       # Remap mockable interface headers that will be injected into generated partial implementation
+      #
+      # Any real (non-nil) mock mode means this module has a generated mock interface header
+      # to redirect to -- PUBLIC/PRIVATE alone once covered every mode that existed, but DEDUCT
+      # (MOCK_PARTIAL_ALL_MODULE) and ACCUMULATE (MOCK_PARTIAL_MODULE) were added later without
+      # updating this check, so a module mocked via either of those was silently never
+      # redirected: its real header (and any static inline/static function bodies in it) stayed
+      # #include'd verbatim, compiling straight past the mock instead of being replaced by it.
       if includes.any? { |include| include.filename.ext().downcase() == _module.downcase() }
-        if [PUBLIC, PRIVATE].include?( config.mocks.type )
+        if !config.mocks.type.nil?
           # Insert mockable interface header from remapping of module name
           _includes << UserInclude.new(
             @file_path_utils.form_partial_interface_header_filename(_module)

--- a/spec/system/delta_builds_spec.rb
+++ b/spec/system/delta_builds_spec.rb
@@ -350,8 +350,8 @@ ceedling_system_tests do
       @c.with_context do
         Dir.chdir "wondrous_forest" do
           baseline = @c.ceedling_build_exec("test:all")
-          expect(baseline).to match(/TESTED:\s+67/)
-          expect(baseline).to match(/PASSED:\s+67/)
+          expect(baseline).to match(/TESTED:\s+68/)
+          expect(baseline).to match(/PASSED:\s+68/)
 
           rebuild = @c.ceedling_build_exec("test:all")
           expect(rebuild).to_not match(/^Compiling /)
@@ -362,8 +362,8 @@ ceedling_system_tests do
           expect(rebuild).to_not match(/Generating Partial implementation for/)
           expect(rebuild).to_not match(/Generating Partial mockable interface for/)
 
-          expect(rebuild).to match(/TESTED:\s+67/)
-          expect(rebuild).to match(/PASSED:\s+67/)
+          expect(rebuild).to match(/TESTED:\s+68/)
+          expect(rebuild).to match(/PASSED:\s+68/)
         end
       end
     end
@@ -388,8 +388,8 @@ ceedling_system_tests do
           expect(rebuild).to_not match(/^Linking TestEventQueue/)
           expect(rebuild).to_not match(/^Linking TestForestMonitor/)
 
-          expect(rebuild).to match(/TESTED:\s+67/)
-          expect(rebuild).to match(/PASSED:\s+67/)
+          expect(rebuild).to match(/TESTED:\s+68/)
+          expect(rebuild).to match(/PASSED:\s+68/)
         end
       end
     end
@@ -419,8 +419,8 @@ ceedling_system_tests do
           expect(rebuild).to_not match(/^Linking TestSoilMoisture/)
           expect(rebuild).to_not match(/^Linking TestTemperatureSensor/)
 
-          expect(rebuild).to match(/TESTED:\s+67/)
-          expect(rebuild).to match(/PASSED:\s+67/)
+          expect(rebuild).to match(/TESTED:\s+68/)
+          expect(rebuild).to match(/PASSED:\s+68/)
         end
       end
     end
@@ -460,8 +460,8 @@ ceedling_system_tests do
           expect(rebuild).to_not match(/^Linking /)
           expect(rebuild).to_not match(/^Running /)
 
-          expect(rebuild).to match(/TESTED:\s+67/)
-          expect(rebuild).to match(/PASSED:\s+67/)
+          expect(rebuild).to match(/TESTED:\s+68/)
+          expect(rebuild).to match(/PASSED:\s+68/)
         end
       end
     end

--- a/spec/system/encoding_stress_spec.rb
+++ b/spec/system/encoding_stress_spec.rb
@@ -131,8 +131,8 @@ ceedling_system_tests do
           @c.merge_project_yml_for_test({ :test_build => { :preprocess_force_fallback => false } })
           output = @c.ceedling_build_exec("test:all")
           expect(@c.last_exit_status).to eq(0)
-          expect(output).to match(/TESTED:\s+67/)
-          expect(output).to match(/PASSED:\s+67/)
+          expect(output).to match(/TESTED:\s+68/)
+          expect(output).to match(/PASSED:\s+68/)
         end
       end
     end
@@ -144,8 +144,8 @@ ceedling_system_tests do
           @c.merge_project_yml_for_test({ :test_build => { :preprocess_force_fallback => true } })
           output = @c.ceedling_build_exec("test:all")
           expect(@c.last_exit_status).to eq(0)
-          expect(output).to match(/TESTED:\s+67/)
-          expect(output).to match(/PASSED:\s+67/)
+          expect(output).to match(/TESTED:\s+68/)
+          expect(output).to match(/PASSED:\s+68/)
         end
       end
     end

--- a/spec/system/example_wondrous_forest_spec.rb
+++ b/spec/system/example_wondrous_forest_spec.rb
@@ -55,8 +55,8 @@ ceedling_system_tests do
         @c.with_context do
           Dir.chdir "wondrous_forest" do
             @output = @c.ceedling_build_exec("test:all")
-            expect(@output).to match(/TESTED:\s+67/)
-            expect(@output).to match(/PASSED:\s+67/)
+            expect(@output).to match(/TESTED:\s+68/)
+            expect(@output).to match(/PASSED:\s+68/)
             expect(@output).to match(/FAILED:\s+0/)
           end
         end

--- a/spec/units/partials/partializer_spec.rb
+++ b/spec/units/partials/partializer_spec.rb
@@ -871,6 +871,75 @@ describe Partializer do
       expect(result).not_to include(UserInclude.new('partial_module.h'))
     end
 
+    # Regression test for #1215: PUBLIC/PRIVATE were once the only mock modes that existed,
+    # so this method's own "does this module have a mock to redirect to" check only ever
+    # listed those two. DEDUCT (MOCK_PARTIAL_ALL_MODULE) was added later without updating
+    # this check, so a module mocked via MOCK_PARTIAL_ALL_MODULE -- e.g. a vendor header
+    # whose only mockable functions are static inline, which requires DEDUCT to select at
+    # all -- was silently never redirected to its mock interface header.
+    it "remaps mockable deduct (ALL_MODULE) partial to interface header" do
+      includes = [UserInclude.new('header1.h'), UserInclude.new('partial_module.h'), UserInclude.new('header2.h')]
+      partials = {
+        'partial_module' => make_partial_config(mocks_type: Partials::DEDUCT)
+      }
+      impl_filename = 'module_impl.h'
+      interface_filename = 'partial_module_interface.h'
+      impl_header = UserInclude.new(impl_filename)
+      interface_header = UserInclude.new(interface_filename)
+
+      allow(@file_path_utils).to receive(:form_partial_implementation_header_filename)
+        .with('module')
+        .and_return(impl_filename)
+
+      allow(@file_path_utils).to receive(:form_partial_interface_header_filename)
+        .with('partial_module')
+        .and_return(interface_filename)
+
+      result = @partializer.remap_implementation_source_includes(
+        name: 'module',
+        includes: includes,
+        partials: partials
+      )
+
+      expect(result).to include(impl_header)
+      expect(result).to include(interface_header)
+      expect(result).to include(UserInclude.new('header1.h'))
+      expect(result).to include(UserInclude.new('header2.h'))
+      expect(result).not_to include(UserInclude.new('partial_module.h'))
+    end
+
+    # Same regression as the DEDUCT case above, for ACCUMULATE (MOCK_PARTIAL_MODULE).
+    it "remaps mockable accumulate partial to interface header" do
+      includes = [UserInclude.new('header1.h'), UserInclude.new('partial_module.h'), UserInclude.new('header2.h')]
+      partials = {
+        'partial_module' => make_partial_config(mocks_type: Partials::ACCUMULATE)
+      }
+      impl_filename = 'module_impl.h'
+      interface_filename = 'partial_module_interface.h'
+      impl_header = UserInclude.new(impl_filename)
+      interface_header = UserInclude.new(interface_filename)
+
+      allow(@file_path_utils).to receive(:form_partial_implementation_header_filename)
+        .with('module')
+        .and_return(impl_filename)
+
+      allow(@file_path_utils).to receive(:form_partial_interface_header_filename)
+        .with('partial_module')
+        .and_return(interface_filename)
+
+      result = @partializer.remap_implementation_source_includes(
+        name: 'module',
+        includes: includes,
+        partials: partials
+      )
+
+      expect(result).to include(impl_header)
+      expect(result).to include(interface_header)
+      expect(result).to include(UserInclude.new('header1.h'))
+      expect(result).to include(UserInclude.new('header2.h'))
+      expect(result).not_to include(UserInclude.new('partial_module.h'))
+    end
+
     it "remaps multiple mockable partials to interface headers" do
       includes = [
         UserInclude.new('header1.h'),


### PR DESCRIPTION
## Summary
Port of PR #1224 (already merged to `master`) to `next_version`.

- `MOCK_PARTIAL_ALL_MODULE()`/`MOCK_PARTIAL_MODULE()` (`DEDUCT`/`ACCUMULATE` mock modes) never redirected a calling module's `#include` of a Partial-mocked header to the generated mock interface header — only `PUBLIC`/`PRIVATE` modes did. A `static inline` function has no separate object file to exclude from a test build and swap for a mock's `.o` at link time, so it stayed compiled straight into the calling module, bypassing its mock entirely.
- Fixes [#1215](https://github.com/ThrowTheSwitch/Ceedling/issues/1215).
- Same `DEDUCT`/`ACCUMULATE` unit test coverage added to `spec/units/partials/partializer_spec.rb`.
- Same real end-to-end regression scenario added to the `wondrous_forest` example project — including this branch's own `spec/system/delta_builds_spec.rb`, which doesn't exist on `master` and so needed its own `67` → `68` count update here.
- `next_version`'s `spec/support/system/system_context.rb` already used `Bundler.with_unbundled_env` correctly (the pattern master's port of this fix adopted from here), so no equivalent infra fix was needed on this branch.

## Test plan
- [x] `bundle exec rspec spec/units/partials/partializer_spec.rb` — 88/88 pass.
- [x] `bundle exec rspec spec/units` — 2591 examples, 0 failures.
- [x] `bundle exec rspec spec/system/example_wondrous_forest_spec.rb` (via `throwtheswitch/madsciencelab-plugins` Docker image) — 7/7 pass, 68/68/0 tested/passed/failed.
- [x] `bundle exec rspec spec/system/delta_builds_spec.rb -e wondrous_forest` (Docker image) — 4/4 pass with the updated count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)