### PR TITLE
Port #1223 fix to next_version: conditional #include silently dropped when its guard depends on a macro from an earlier #include

### DIFF
--- a/assets/fixtures/tests_with_conditional_includes/src/feature_config.h
+++ b/assets/fixtures/tests_with_conditional_includes/src/feature_config.h
@@ -1,0 +1,13 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#ifndef FEATURE_CONFIG_H
+#define FEATURE_CONFIG_H
+
+#define FEATURE_LEVEL (2)
+
+#endif // FEATURE_CONFIG_H

--- a/assets/fixtures/tests_with_conditional_includes/src/feature_extra.h
+++ b/assets/fixtures/tests_with_conditional_includes/src/feature_extra.h
@@ -1,0 +1,13 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#ifndef FEATURE_EXTRA_H
+#define FEATURE_EXTRA_H
+
+#define FEATURE_EXTRA_MACRO (7)
+
+#endif // FEATURE_EXTRA_H

--- a/assets/fixtures/tests_with_conditional_includes/src/local_flag_extra.h
+++ b/assets/fixtures/tests_with_conditional_includes/src/local_flag_extra.h
@@ -1,0 +1,13 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#ifndef LOCAL_FLAG_EXTRA_H
+#define LOCAL_FLAG_EXTRA_H
+
+#define LOCAL_FLAG_MACRO (11)
+
+#endif // LOCAL_FLAG_EXTRA_H

--- a/assets/fixtures/tests_with_conditional_includes/src/macro_target_extra.h
+++ b/assets/fixtures/tests_with_conditional_includes/src/macro_target_extra.h
@@ -1,0 +1,13 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#ifndef MACRO_TARGET_EXTRA_H
+#define MACRO_TARGET_EXTRA_H
+
+#define MACRO_TARGET_VALUE (19)
+
+#endif // MACRO_TARGET_EXTRA_H

--- a/assets/fixtures/tests_with_conditional_includes/src/nested_extra.h
+++ b/assets/fixtures/tests_with_conditional_includes/src/nested_extra.h
@@ -1,0 +1,13 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#ifndef NESTED_EXTRA_H
+#define NESTED_EXTRA_H
+
+#define NESTED_MACRO (17)
+
+#endif // NESTED_EXTRA_H

--- a/assets/fixtures/tests_with_conditional_includes/src/nested_wrapper.h
+++ b/assets/fixtures/tests_with_conditional_includes/src/nested_wrapper.h
@@ -1,0 +1,16 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+/* widget.c includes this wrapper directly; nested_extra.h is only ever
+ * reached transitively through it, never named directly by widget.c. */
+
+#ifndef NESTED_WRAPPER_H
+#define NESTED_WRAPPER_H
+
+#include "nested_extra.h"
+
+#endif // NESTED_WRAPPER_H

--- a/assets/fixtures/tests_with_conditional_includes/src/project_flag_extra.h
+++ b/assets/fixtures/tests_with_conditional_includes/src/project_flag_extra.h
@@ -1,0 +1,13 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#ifndef PROJECT_FLAG_EXTRA_H
+#define PROJECT_FLAG_EXTRA_H
+
+#define PROJECT_FLAG_MACRO (13)
+
+#endif // PROJECT_FLAG_EXTRA_H

--- a/assets/fixtures/tests_with_conditional_includes/src/widget.c
+++ b/assets/fixtures/tests_with_conditional_includes/src/widget.c
@@ -1,0 +1,64 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#include "widget.h"
+
+/* (a) Conditional include gated on a project-level :defines macro. */
+#ifdef PROJECT_FLAG
+#include "project_flag_extra.h"
+#endif
+
+#define LOCAL_FLAG (1)
+
+/* (b) Conditional include gated on a macro #define'd earlier in this same file. */
+#if LOCAL_FLAG
+#include "local_flag_extra.h"
+#endif
+
+/* (c) Reached only transitively, via nested_wrapper.h's own #include -- never
+ * itself named directly by this file. Must not appear as a duplicate,
+ * spuriously-promoted top-level #include in generated output. */
+#include "nested_wrapper.h"
+
+/* (e) An #include whose own target is a macro, not a literal filename -- there
+ * is no filename anywhere in this file's text until a real preprocessor
+ * expands WIDGET_COMPUTED_HEADER, so only the gcc-based bare pass can resolve
+ * this; the literal text-scan half of "bare" (added for issue #1223) cannot,
+ * by design. This is why that gcc pass is still run at all rather than
+ * replaced outright by the simpler text scan -- each half of "bare" covers a
+ * gap the other structurally can't. */
+#define WIDGET_COMPUTED_HEADER "macro_target_extra.h"
+#include WIDGET_COMPUTED_HEADER
+
+static int Widget__FromProjectFlag(void)
+{
+#ifdef PROJECT_FLAG
+    return PROJECT_FLAG_MACRO;
+#else
+    return 0;
+#endif
+}
+
+static int Widget__FromLocalFlag(void)
+{
+    return LOCAL_FLAG_MACRO;
+}
+
+static int Widget__FromNested(void)
+{
+    return NESTED_MACRO;
+}
+
+static int Widget__FromMacroInclude(void)
+{
+    return MACRO_TARGET_VALUE;
+}
+
+int Widget_FromProjectFlag(void)  { return Widget__FromProjectFlag(); }
+int Widget_FromLocalFlag(void)    { return Widget__FromLocalFlag(); }
+int Widget_FromNested(void)       { return Widget__FromNested(); }
+int Widget_FromMacroInclude(void) { return Widget__FromMacroInclude(); }

--- a/assets/fixtures/tests_with_conditional_includes/src/widget.h
+++ b/assets/fixtures/tests_with_conditional_includes/src/widget.h
@@ -1,0 +1,16 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#ifndef WIDGET_H
+#define WIDGET_H
+
+int Widget_FromProjectFlag(void);
+int Widget_FromLocalFlag(void);
+int Widget_FromNested(void);
+int Widget_FromMacroInclude(void);
+
+#endif // WIDGET_H

--- a/assets/fixtures/tests_with_conditional_includes/src/widget_feature.c
+++ b/assets/fixtures/tests_with_conditional_includes/src/widget_feature.c
@@ -1,0 +1,29 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+/* Reproduces issue #1223: a conditional #include guarded by a macro defined
+ * in an EARLIER #include in this same file (as opposed to a project :defines
+ * macro or a same-file #define, both of which already work correctly -- see
+ * widget.c). Ceedling's bare-includes extraction pass runs against an
+ * isolated, sibling-free copy of this file and so never actually opens
+ * feature_config.h to learn FEATURE_LEVEL's value, evaluating the #if below
+ * as false and silently dropping feature_extra.h from the generated Partial
+ * even though FEATURE_LEVEL is genuinely > 1. */
+
+#include "widget_feature.h"
+#include "feature_config.h"     /* defines FEATURE_LEVEL (2) */
+
+#if FEATURE_LEVEL > 1
+#include "feature_extra.h"      /* defines FEATURE_EXTRA_MACRO */
+#endif
+
+static int WidgetFeature__FromFeatureLevel(void)
+{
+    return FEATURE_EXTRA_MACRO;
+}
+
+int WidgetFeature_FromFeatureLevel(void) { return WidgetFeature__FromFeatureLevel(); }

--- a/assets/fixtures/tests_with_conditional_includes/src/widget_feature.h
+++ b/assets/fixtures/tests_with_conditional_includes/src/widget_feature.h
@@ -1,0 +1,13 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+#ifndef WIDGET_FEATURE_H
+#define WIDGET_FEATURE_H
+
+int WidgetFeature_FromFeatureLevel(void);
+
+#endif // WIDGET_FEATURE_H

--- a/assets/fixtures/tests_with_conditional_includes/test/test_widget.c
+++ b/assets/fixtures/tests_with_conditional_includes/test/test_widget.c
@@ -1,0 +1,52 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+/* Partials pattern: TEST_PARTIAL_ALL_MODULE
+ * Exercises #include-discovery scenarios that already work correctly without
+ * any source fix -- a regression guard locked in before touching the
+ * includes-discovery pipeline:
+ *   (a) conditional include gated on a project :defines macro
+ *   (b) conditional include gated on a same-file #define
+ *   (c) a header reached only transitively (never itself directly
+ *       #include'd by widget.c) correctly not duplicated in as a false
+ *       top-level entry
+ *   (e) an #include whose own target is a macro, not a literal filename --
+ *       only resolvable by real preprocessing (gcc's bare pass), never by
+ *       the literal text scan issue #1223's fix added */
+
+#include "unity.h"
+#include "ceedling.h"
+
+#include TEST_PARTIAL_ALL_MODULE(widget)
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_FromProjectFlag_ReturnsProjectFlagMacro(void)
+{
+    TEST_ASSERT_EQUAL_INT(13, Widget__FromProjectFlag());
+}
+
+void test_FromLocalFlag_ReturnsLocalFlagMacro(void)
+{
+    TEST_ASSERT_EQUAL_INT(11, Widget__FromLocalFlag());
+}
+
+void test_FromNested_ReturnsNestedMacro(void)
+{
+    TEST_ASSERT_EQUAL_INT(17, Widget__FromNested());
+}
+
+void test_FromMacroInclude_ReturnsMacroTargetValue(void)
+{
+    TEST_ASSERT_EQUAL_INT(19, Widget__FromMacroInclude());
+}

--- a/assets/fixtures/tests_with_conditional_includes/test/test_widget_feature.c
+++ b/assets/fixtures/tests_with_conditional_includes/test/test_widget_feature.c
@@ -1,0 +1,31 @@
+/* =========================================================================
+    Ceedling - Test-Centered Build System for C
+    ThrowTheSwitch.org
+    Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+    SPDX-License-Identifier: MIT
+========================================================================= */
+
+/* Partials pattern: TEST_PARTIAL_ALL_MODULE
+ * Regression test for #1223: without the fix, this fails to *compile* --
+ * FEATURE_EXTRA_MACRO is undeclared in the generated Partial implementation
+ * because feature_extra.h's conditional #include (guarded by a macro from
+ * an earlier #include in widget_feature.c) is silently dropped. See
+ * widget_feature.c for the full explanation. */
+
+#include "unity.h"
+#include "ceedling.h"
+
+#include TEST_PARTIAL_ALL_MODULE(widget_feature)
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_FromFeatureLevel_ReturnsFeatureExtraMacro(void)
+{
+    TEST_ASSERT_EQUAL_INT(7, WidgetFeature__FromFeatureLevel());
+}

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -63,6 +63,8 @@ Historically, Ceedling automatically compiles and links into a test executable a
 
 ## 💪 Fixed
 
+- [#1223](https://github.com/ThrowTheSwitch/Ceedling/issues/1223) Fixed a conditional `#include` silently dropping out of generated code derived from preprocessed code, breaking compilation with an undeclared identifier error. The specific case involves a macro defined by another header included earlier in the same file.
+
 ### Partials
 
 - [#1215](https://github.com/ThrowTheSwitch/Ceedling/issues/1215) Fixed `MOCK_PARTIAL_ALL_MODULE()`/`MOCK_PARTIAL_MODULE()` silently failing to partialize `inline` functions in some circumstances leading to duplicated symbols breaking compilation.

--- a/lib/ceedling/preprocess/README.md
+++ b/lib/ceedling/preprocess/README.md
@@ -6,7 +6,7 @@ A C preprocessor’s job is to resolve conditionals, expand macros, and pull in 
 
 Ceedling asks the preprocessor four different kinds of questions, and each one gets its own mode of invocation.
 
-- **Bare-includes mode** finds every header a file depends on, without opening a single one of them. It exists to produce a trustworthy, top-level include list.
+- **Bare-includes mode** finds every header a file depends on, without opening a single one of them. It exists to produce a trustworthy, top-level include list. It is actually two techniques working together: a real preprocessor pass, and a plain text scan that catches what the preprocessor pass alone cannot see.
 - **Directives-only mode** resolves conditionals and follows real includes, but leaves macro directives and comments in the output untouched. It exists to categorize includes as user or system headers, and to produce a version of a file with its macros still intact for later text extraction.
 - **Full-expansion mode** resolves everything a preprocessor can resolve, including every macro use in the body of a file. It exists for the case where a macro is hiding something a later step needs to see plainly, such as a function’s true signature or visibility.
 - **Text-scan fallback** does not invoke a preprocessor at all. It exists for the times a real preprocessor pass is unavailable or fails, scanning the original file’s text directly as a less certain but always-available substitute.
@@ -39,7 +39,7 @@ Knowing exactly which headers a file includes, and whether each one is a user he
 
 Ceedling solves this with two separate preprocessor passes that are then reconciled together. A class called `PreprocessinatorIncludesHandler` runs both passes and hands each one’s raw output to a small parser built just for it. `PreprocessinatorBareIncludesExtractor` reads the first pass’s output. `PreprocessinatorLineMarkerIncludesExtractor`, already named above, reads the second.
 
-The first pass runs the preprocessor in bare-includes mode, a mode meant only to report dependencies, deliberately pointed at no real project search paths at all. Because no real header can be found this way, none are ever opened, so no include guard can ever suppress anything. This pass is not troubled by nesting or guards, and it reliably reports the complete, accurate list of every file referenced in an `#include` directive within the preprocessed file, given its current macro definitions. What it cannot do is say whether any one of those includes is a user header or a system header.
+The first pass runs the preprocessor in bare-includes mode, a mode meant only to report dependencies, deliberately pointed at no real project search paths at all. Because no real header can be found this way, none are ever opened, so no include guard can ever suppress anything. This pass is not troubled by nesting or guards. What it cannot do is say whether any one of those includes is a user header or a system header.
 
 Restricting search paths is not by itself enough to guarantee that no real header is ever opened. A C preprocessor’s quoted `#include` resolution always additionally checks the directory of the file it is currently processing, independent of whatever search paths were given. A header sitting alongside the file being scanned, a same-directory sibling, gets opened and recursed into anyway, regardless of the restricted search paths above. Left unaddressed, this leaks past the pass’s own guarantee: a header reached only through this directory-relative side channel looks the same as a genuine top-level include, which can lead `Includes.reconcile` to keep a mocked header’s own real source in a test’s build when nothing about the test actually needed it there.
 
@@ -57,6 +57,16 @@ Its output is not C code at all. It is a make-style dependency rule, listing the
 test_module.o: test_module.c unity.h module.h \
   mock_dependency.h
 ```
+
+### The Gap a Real Preprocessor Pass Cannot Close Alone
+
+Bare-includes mode has one more limitation. It only keeps an `#include` if the preprocessor's own conditional evaluation resolves that way. But bare-includes mode never opens any header, so it cannot see a macro some other header defines. When a conditional depends on a macro like that, the preprocessor treats it as undefined. The conditional resolves the wrong way. A real, always-present `#include` silently disappears from this pass's own output.
+
+Ceedling closes this gap with a second, simpler technique: a plain scan of the file's own text for anything that looks like an `#include` line, no matter what conditional surrounds it. This scan runs no preprocessor and evaluates no conditionals. It only needs to notice that an `#include` line exists in the file's own text. `PreprocessinatorIncludesHandler#extract_bare_includes_from_text` does this scanning. Its result is unioned with the real bare-includes pass's own result before reconciliation runs.
+
+This union is safe. `Includes.reconcile` still checks every candidate against the accurate, second pass before keeping it. A line the text scan notices but the accurate pass never actually resolved is still discarded, exactly as before. The union only restores an entry both a literal reading of the file and a real preprocessor agree belongs there.
+
+Neither technique replaces the other. The real preprocessor pass can resolve an `#include` whose own target is a macro, something like `#include SOME_HEADER_NAME`, since that requires expanding a macro before any filename exists at all. The text scan has no filename to find in a case like that. The text scan, in turn, sees past a conditional the preprocessor pass cannot evaluate, since it never tries to evaluate conditionals in the first place. Each covers a gap the other cannot.
 
 The second pass runs the preprocessor in directives-only mode, with full search paths, and reads the resulting line markers, exactly as described above, to learn which included files are user headers and which are system headers. This pass sees real nesting and real include guards, so its own list cannot be fully trusted as a top-level list on its own.
 

--- a/lib/ceedling/preprocess/preprocessinator.rb
+++ b/lib/ceedling/preprocess/preprocessinator.rb
@@ -565,6 +565,28 @@ class Preprocessinator
       defines:       defines
     )
 
+    # Supplement with a literal text scan of the original file's own #include
+    # lines -- the gcc-based bare pass above runs against an isolated copy that
+    # can never open another header, so a conditional #include whose guard
+    # depends on a macro defined by an *earlier #include in this same file*
+    # evaluates false there and silently drops out. Unioning in this text-based
+    # pass's result only ever adds candidates for Includes.reconcile below to
+    # match against the accurate directives-only pass -- it can't introduce a
+    # spurious entry on its own, since reconcile still requires the accurate
+    # pass to also report it.
+    #
+    # This supplements the gcc-based pass rather than replacing it: gcc can
+    # resolve an #include whose target is itself a macro (e.g. the
+    # MOCK_PARTIAL_ALL_MODULE()-style directives this project's own generated
+    # test files use), since a command-line -D define is visible even to the
+    # isolated copy -- a literal text scan has no filename there to find at
+    # all, since none exists until a real preprocessor expands the macro. The
+    # two passes catch different, non-overlapping failure modes; keeping both
+    # covers both.
+    bare_includes = (
+      bare_includes + @includes_handler.extract_bare_includes_from_text( filepath: filepath )
+    ).uniq( &:filename )
+
     # Extract user includes
     user_includes = preprocess_user_includes(
       name:                     test,

--- a/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
@@ -115,6 +115,39 @@ class PreprocessinatorIncludesHandler
     return includes
   end
 
+  # Scan the original file's own text for every #include line, unconditionally --
+  # no #if/#ifdef tracking at all, just literal presence. Supplements the gcc-based
+  # bare pass (`extract_bare_includes`), which runs against an isolated, sibling-free
+  # copy of the file and so can never open another header to resolve a conditional
+  # that depends on a macro that header defines (e.g. `#if SOME_MACRO_FROM_ANOTHER_HEADER`)
+  # -- GCC treats the macro as undefined there and silently drops the #include line
+  # from that pass's output even though it's a perfectly ordinary, real, top-level
+  # #include once actually evaluated with the real file in place. This method's result
+  # is meant to be unioned with the gcc-based bare pass's own result (see
+  # Preprocessinator#preprocess_file_includes_common), not used on its own -- an
+  # `Includes.reconcile` call downstream still only keeps an entry here if the
+  # accurate directives-only pass also reports it, so unconditionally capturing every
+  # literal #include line (regardless of whether its own guard is really true) is
+  # safe: it can only ever let back in an entry the accurate pass already confirmed,
+  # never introduce a spurious one on its own. A supplement, not a replacement --
+  # the gcc pass can still do something this literal scan structurally can't: resolve
+  # an #include whose own target is a macro rather than a literal filename.
+  def extract_bare_includes_from_text(filepath:)
+    includes = []
+
+    # Open in binary mode: code_lines applies clean_encoding per-line, but each_line
+    # itself can raise on invalid byte sequences before clean_encoding is reached.
+    @file_wrapper.open(filepath, 'rb') do |input|
+      @parsing_parcels.code_lines( input ) do |line|
+        _include = @include_factory.user_include_from_directive( line ) ||
+                   @include_factory.system_include_from_directive( line )
+        includes << Include.new( _include.filepath ) if !_include.nil?
+      end
+    end
+
+    return clean_self_reference( filepath, includes )
+  end
+
   def extract_user_includes_preprocess(name:, filepath:, preprocessed_filepath:)
     includes = []
 

--- a/spec/system/conditional_include_macro_visibility_spec.rb
+++ b/spec/system/conditional_include_macro_visibility_spec.rb
@@ -1,0 +1,157 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+
+##
+## Conditional-#include Macro-Visibility Tests (directives-only preprocessing)
+## =============================================================================
+##
+## Ceedling discovers a file's #includes via two preprocessor passes reconciled
+## into one list: a "bare" pass and an accurate pass (gcc -E -fdirectives-only
+## against the real file with real search paths -- genuinely opens every
+## header). Reconciliation keeps an accurate-pass entry only if bare also found
+## it, to filter out headers reached only via a deeper, nested path.
+##
+## "Bare" is itself two things unioned together: a gcc -M -MG -MP pass against
+## an isolated, sibling-free copy of the file (so it never actually opens any
+## header the file #includes, but can still resolve an #include whose own
+## target is a macro, since command-line -D defines are visible even in
+## isolation), and a plain literal text scan of the file's own #include lines
+## (no conditional evaluation at all, so it sees past a guard the isolated gcc
+## pass can't evaluate -- but also can't resolve a macro-computed #include
+## target, since there's no literal filename in the source text to find).
+## Neither replaces the other; each catches what the other structurally can't.
+##
+## These tests characterize that reconciliation's behavior for #include
+## directives guarded by an #if/#ifdef, across the different places the
+## guarding macro can come from -- some already handled correctly, one
+## (issue #1223) fixed by adding the text-scan half of "bare" above.
+##
+## Test assets: assets/fixtures/tests_with_conditional_includes/
+##   - widget.c/.h: scenarios that already work correctly:
+##     (a) conditional include gated on a project :defines macro
+##     (b) conditional include gated on a same-file #define
+##     (c) a header reached only transitively (nested_wrapper.h's own
+##         #include, never itself directly #include'd by widget.c) --
+##         must not appear duplicated in as a false top-level entry
+##     (e) an #include whose own target is a macro (macro_target_extra.h via
+##         WIDGET_COMPUTED_HEADER) -- only the gcc-based half of "bare" can
+##         resolve this; confirms that half is still doing real work and
+##         wasn't made redundant by issue #1223's text-scan addition
+##   - widget_feature.c/.h + feature_config.h + feature_extra.h: issue #1223
+##     itself -- a conditional include gated on a macro defined by an
+##     *earlier #include in the same file* (feature_config.h's FEATURE_LEVEL),
+##     which the isolated bare pass can never see, silently dropping
+##     feature_extra.h and leaving FEATURE_EXTRA_MACRO undeclared.
+##
+
+ceedling_system_tests do
+
+  before :all do
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  before { @proj_name = unique_proj_name("cond_inc") }
+
+  describe "Deployed as a gem" do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new #{@proj_name}")
+      end
+    end
+
+    # =========================================================================
+    describe "Conditional includes that already resolve correctly today" do
+    # =========================================================================
+
+      before do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/widget.h"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/widget.c"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/project_flag_extra.h"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/local_flag_extra.h"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/nested_wrapper.h"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/nested_extra.h"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/macro_target_extra.h"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/test/test_widget.c"), 'test/'
+
+            settings = {
+              :project => { :use_partials => true },
+              :defines => { :test => ['PROJECT_FLAG'] }
+            }
+            @c.merge_project_yml_for_test(settings)
+          end
+        end
+      end
+
+      it "resolves a project-:defines-gated include, a same-file-#define-gated include, a macro-computed #include target, and correctly excludes a transitively-nested header from duplication" do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            output = @c.ceedling_build_exec("test:widget")
+            expect(@c.last_exit_status).to eq(0)
+            expect(output).to match(/TESTED:\s+4/)
+            expect(output).to match(/PASSED:\s+4/)
+            expect(output).to match(/FAILED:\s+0/)
+
+            # (c) nested_extra.h is reached only transitively, through
+            # nested_wrapper.h's own #include -- confirm it is not promoted
+            # into a spurious, duplicated top-level #include in the generated
+            # Partial implementation (the exact filtering property the #1223
+            # fix must not break).
+            generated = Dir.glob('build/test/partials/**/*_impl.c').first
+            expect(generated).not_to be_nil
+            contents = File.read(generated)
+            expect(contents.scan(/#include\s+"nested_extra\.h"/).length).to eq(0)
+          end
+        end
+      end
+
+    end
+
+    # =========================================================================
+    describe "Conditional include gated on a macro from an earlier #include in the same file (issue #1223)" do
+    # =========================================================================
+
+      before do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/widget_feature.h"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/widget_feature.c"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/feature_config.h"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/feature_extra.h"), 'src/'
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/test/test_widget_feature.c"), 'test/'
+
+            settings = { :project => { :use_partials => true } }
+            @c.merge_project_yml_for_test(settings)
+          end
+        end
+      end
+
+      it "keeps FEATURE_EXTRA_MACRO visible in the generated Partial so the build compiles" do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            output = @c.ceedling_build_exec("test:widget_feature")
+            expect(@c.last_exit_status).to eq(0)
+            expect(output).to match(/TESTED:\s+1/)
+            expect(output).to match(/PASSED:\s+1/)
+            expect(output).to match(/FAILED:\s+0/)
+          end
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/spec/units/preprocess/preprocessinator_includes_handler_spec.rb
+++ b/spec/units/preprocess/preprocessinator_includes_handler_spec.rb
@@ -340,6 +340,67 @@ RSpec.describe PreprocessinatorIncludesHandler do
 
 
   # ===========================================================================
+  describe '#extract_bare_includes_from_text' do
+  # ===========================================================================
+
+    let(:filepath) { '/src/module.c' }
+
+    it 'extracts a simple user include' do
+      stub_file_open(filepath, "#include \"foo.h\"\n")
+      result = subject.extract_bare_includes_from_text(filepath: filepath)
+      expect(result.map(&:filename)).to include('foo.h')
+    end
+
+    it 'extracts a system include too, unlike extract_user_includes_from_text' do
+      stub_file_open(filepath, "#include <stdio.h>\n")
+      result = subject.extract_bare_includes_from_text(filepath: filepath)
+      expect(result.map(&:filename)).to include('stdio.h')
+    end
+
+    it 'returns plain Include objects, not UserInclude/SystemInclude' do
+      stub_file_open(filepath, "#include \"foo.h\"\n#include <stdio.h>\n")
+      result = subject.extract_bare_includes_from_text(filepath: filepath)
+      expect(result).to all( be_an_instance_of(Include) )
+    end
+
+    it 'ignores includes inside line comments' do
+      stub_file_open(filepath, "// #include \"commented_out.h\"\n")
+      result = subject.extract_bare_includes_from_text(filepath: filepath)
+      expect(result).to be_empty
+    end
+
+    it 'ignores includes inside block comments' do
+      content = "/* #include \"in_block.h\" */\n#include \"real.h\"\n"
+      stub_file_open(filepath, content)
+      result = subject.extract_bare_includes_from_text(filepath: filepath)
+      expect(result.map(&:filename)).to contain_exactly('real.h')
+    end
+
+    # The defining difference from extract_user_includes_from_text: no conditional
+    # tracking at all -- an #include inside an #ifdef for an undefined macro is
+    # still captured, since this method's whole purpose is to see past a guard
+    # whose condition can't be evaluated without opening another header (issue #1223).
+    it 'captures a conditionally-guarded include regardless of whether the guard could be evaluated true' do
+      content = <<~C
+        #ifdef UNDEFINED_MACRO
+        #include "conditional.h"
+        #endif
+      C
+      stub_file_open(filepath, content)
+      result = subject.extract_bare_includes_from_text(filepath: filepath)
+      expect(result.map(&:filename)).to include('conditional.h')
+    end
+
+    it 'removes a self-referential include matching the file being scanned' do
+      stub_file_open(filepath, "#include \"#{filepath}\"\n#include \"foo.h\"\n")
+      result = subject.extract_bare_includes_from_text(filepath: filepath)
+      expect(result.map(&:filename)).to contain_exactly('foo.h')
+    end
+
+  end
+
+
+  # ===========================================================================
   describe '#extract_system_includes_from_text' do
   # ===========================================================================
 

--- a/spec/units/preprocess/preprocessinator_spec.rb
+++ b/spec/units/preprocess/preprocessinator_spec.rb
@@ -1,0 +1,136 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/preprocess/preprocessinator'
+require 'ceedling/includes/includes'
+
+RSpec.describe Preprocessinator do
+
+  before :each do
+    @includes_handler  = double('preprocessinator_includes_handler')
+    @comment_stripper  = double('preprocessinator_comment_stripper')
+    @file_assembler    = double('preprocessinator_file_assembler')
+    @reconstructor     = double('preprocessinator_reconstructor')
+    @file_path_utils   = double('file_path_utils')
+    @tool_executor     = double('tool_executor')
+    @plugin_manager    = double('plugin_manager')
+    @configurator      = double('configurator')
+    @loginator         = double('loginator')
+    @reportinator      = double('reportinator')
+
+    allow(@loginator).to receive(:log)
+    allow(@loginator).to receive(:log_list)
+    allow(@reportinator).to receive(:generate_module_progress).and_return('')
+    allow(@configurator).to receive(:cmock_mock_prefix).and_return('Mock')
+  end
+
+  subject do
+    Preprocessinator.new(
+      preprocessinator_includes_handler: @includes_handler,
+      preprocessinator_comment_stripper: @comment_stripper,
+      preprocessinator_file_assembler:   @file_assembler,
+      preprocessinator_reconstructor:    @reconstructor,
+      file_path_utils:                   @file_path_utils,
+      tool_executor:                     @tool_executor,
+      plugin_manager:                    @plugin_manager,
+      configurator:                      @configurator,
+      loginator:                         @loginator,
+      reportinator:                      @reportinator
+    )
+  end
+
+  # ===========================================================================
+  describe '#preprocess_file_includes_common' do
+  # ===========================================================================
+
+    let(:filepath) { '/src/module.c' }
+
+    def call_it(defines: [])
+      subject.send(
+        :preprocess_file_includes_common,
+        test:                      'test',
+        filepath:                  filepath,
+        directives_only_filepath:  '/build/directives_only/module.c',
+        fallback:                  false,
+        flags:                     [],
+        include_paths:             [],
+        vendor_paths:              [],
+        defines:                   defines
+      )
+    end
+
+    before do
+      # preprocess_file_includes_common is only ever called once a caller has
+      # already determined, via its own DependencyTracker target, that this
+      # file/test pair is stale -- no internal freshness check to route around,
+      # so extraction runs for real on every call here.
+      allow(@file_path_utils).to receive(:form_preprocessed_includes_list_filepath).and_return('/build/includes/module.c.yml')
+      allow(@includes_handler).to receive(:write_includes_list)
+
+      allow(@includes_handler).to receive(:extract_system_includes_preprocess).and_return([])
+    end
+
+    # Regression coverage for #1223: the gcc-based bare pass runs against an
+    # isolated copy that can never open another header, so a conditional
+    # #include guarded by a macro defined by an earlier #include in the same
+    # file evaluates false there and is silently dropped from that pass's own
+    # result. extract_bare_includes_from_text (a plain literal-text scan, no
+    # conditional evaluation at all) still sees it. Reconciliation should keep
+    # it once the accurate pass (user_includes here) also confirms it's real.
+    it "keeps an entry the gcc bare pass missed but the text-scan bare pass and the accurate pass both found" do
+      allow(@includes_handler).to receive(:extract_bare_includes).and_return(
+        [ Include.new('Types.h') ]
+      )
+      allow(@includes_handler).to receive(:extract_bare_includes_from_text).and_return(
+        [ Include.new('Types.h'), Include.new('types2.h') ]
+      )
+      allow(@includes_handler).to receive(:extract_user_includes_preprocess).and_return(
+        [ UserInclude.new('Types.h'), UserInclude.new('types2.h') ]
+      )
+
+      result = call_it()
+
+      expect(result.map(&:filename)).to include('types2.h')
+    end
+
+    # The union only ever adds candidates for reconcile to match against the
+    # accurate pass -- it must never single-handedly promote an entry neither
+    # gcc's bare pass nor the accurate pass itself ever reported.
+    it "does not introduce an entry the text-scan bare pass found but the accurate pass never confirms" do
+      allow(@includes_handler).to receive(:extract_bare_includes).and_return([])
+      allow(@includes_handler).to receive(:extract_bare_includes_from_text).and_return(
+        [ Include.new('phantom.h') ]
+      )
+      allow(@includes_handler).to receive(:extract_user_includes_preprocess).and_return([])
+
+      result = call_it()
+
+      expect(result.map(&:filename)).not_to include('phantom.h')
+    end
+
+    # Both bare sources finding the same entry must not produce a duplicate
+    # (the union is deduplicated by filename before being handed to reconcile).
+    it "does not duplicate an entry both bare passes agree on" do
+      allow(@includes_handler).to receive(:extract_bare_includes).and_return(
+        [ Include.new('Types.h') ]
+      )
+      allow(@includes_handler).to receive(:extract_bare_includes_from_text).and_return(
+        [ Include.new('Types.h') ]
+      )
+      allow(@includes_handler).to receive(:extract_user_includes_preprocess).and_return(
+        [ UserInclude.new('Types.h') ]
+      )
+
+      result = call_it()
+
+      expect(result.map(&:filename)).to eq(['Types.h'])
+    end
+
+  end
+
+end


### PR DESCRIPTION
## Summary
Port of PR #1226 (already merged to `master`) to `next_version`, with expanded coverage per direction.

- Identical fix: unioned a literal `#include`-text scan into the existing gcc-based bare-includes pass before reconciliation, so a conditional `#include` whose guard depends on a macro defined by an earlier `#include` in the same file no longer silently drops out.
- Fixes [#1223](https://github.com/ThrowTheSwitch/Ceedling/issues/1223) on this branch.
- Ported unit coverage, adapted to `next_version`'s own `Preprocessinator` (no internal cache-freshness check here, unlike `master`).
- Ported the system-level fixture and spec, relocated to `assets/fixtures/` (this branch's convention, vs. master's flat `assets/`).
- **New**: added a `macro_target_extra.h` scenario proving the gcc-based bare pass still does real, irreplaceable work post-fix — it alone can resolve an `#include` whose own target is a macro, which a literal text scan structurally cannot do.
- **New**: added a section to `lib/ceedling/preprocess/README.md` explaining the gap and the fix in short narrative sentences — the need, the mechanism, and why the union is safe.
- Updated `docs/Changelog.md`'s `[1.2.0]` unreleased `Fixed` section, mirroring the `[1.1.6]`/`[1.1.5]` correction already made on `master`.

## Test plan
- [x] `bundle exec rspec spec/units` — 2601 examples, 0 failures.
- [x] Broad system-test regression subset via the `throwtheswitch/madsciencelab-plugins` Docker image (preprocessing/mocking/Partials/deployment specs + the new/expanded spec) — 186 examples total, 2 pre-existing environmental failures (missing docs bundle, unrelated), 5 expected pending (locale-gated).
- [x] New `conditional_include_macro_visibility_spec.rb` scenarios all pass, including the new macro-computed-`#include`-target case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)