### PR TITLE
Fix #1216: system tests wrongly assume local HTML docs bundle always exists

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -14,6 +14,7 @@ This changelog is complemented by three other documents:
 
 ## 💪 Fixed
 
+- [#1216](https://github.com/ThrowTheSwitch/Ceedling/issues/1216) Fixed self-test issue that caused docs-related failures when the local documentation was unavailable (generated in CI but not necessarily present during self tests).
 - [#1223](https://github.com/ThrowTheSwitch/Ceedling/issues/1223) Fixed a conditional `#include` silently dropping out of generated code derived from preprocessed code, breaking compilation with an undeclared identifier error. The specific case involves a macro defined by another header included earlier in the same file.
 
 ### Partials

--- a/spec/support/system/spec_system_helper.rb
+++ b/spec/support/system/spec_system_helper.rb
@@ -150,6 +150,17 @@ def test_asset_path(asset_file_name)
   File.join(File.dirname(__FILE__), '..', '..', '..', 'assets', asset_file_name)
 end
 
+# `ceedling new`/`upgrade` only populates a project's docs/ceedling/ by copying this
+# repo's own site-local/ -- the local mkdocs HTML bundle, built only by `rake
+# docs:build:local` (see bin/cli_helper.rb's own identical check). That's a step CI
+# runs in a dedicated job before the test suite, but a plain local `bundle install &&
+# rspec` never runs at all, so docs/ceedling/ is legitimately absent there. Tests
+# asserting a deployed project's doc contents check this first rather than hardcoding
+# an assumption that only ever holds in CI's own environment (issue #1216).
+def html_docs_bundle_available?
+  Dir.exist?(File.join(File.dirname(__FILE__), '..', '..', '..', 'site-local'))
+end
+
 def unique_proj_name(prefix)
   safe = RSpec.current_example.description
     .downcase

--- a/spec/system/support/common_test_cases.rb
+++ b/spec/system/support/common_test_cases.rb
@@ -114,7 +114,11 @@ module CommonSystemTestCases
     @c.with_context do
       Dir.chdir @proj_name do
         all_docs = Dir["docs/*"]
-        expect(all_docs).to contain_exactly('docs/ceedling', 'docs/unity', 'docs/cmock', 'docs/c_exception', 'docs/license.txt')
+        # docs/ceedling only exists when this repo's own local HTML docs bundle
+        # (site-local/) was available to copy in -- see html_docs_bundle_available?.
+        expected = ['docs/unity', 'docs/cmock', 'docs/c_exception', 'docs/license.txt']
+        expected << 'docs/ceedling' if html_docs_bundle_available?
+        expect(all_docs).to contain_exactly(*expected)
       end
     end
   end


### PR DESCRIPTION
## Summary
- `Deployed in a project's 'vendor' directory :: Contains documentation` unconditionally asserted `docs/ceedling` is present in a deployed project, but that directory only gets populated when this repo's own `site-local/` (the local mkdocs HTML bundle, built by `rake docs:build:local`) exists to copy from — a step CI runs in a dedicated job, but a plain local `bundle install && rspec` never runs at all.
- Fixes [#1216](https://github.com/ThrowTheSwitch/Ceedling/issues/1216).
- Added `html_docs_bundle_available?` (`spec/support/system/spec_system_helper.rb`), checking for `site-local/` the same way `bin/cli_helper.rb`'s own doc-copying logic already does.
- `contains_documentation` (`spec/system/support/common_test_cases.rb`) now builds its expected file list from that check instead of hardcoding `docs/ceedling` as always present. This is not a skip — the test still fully exercises doc-copying behavior either way: the fuller list (including `docs/ceedling`) when the bundle was already built, the narrower but still-real list when it wasn't.

## Test plan
- [x] Via `throwtheswitch/madsciencelab-plugins` Docker image, `site-local/` absent (the container's normal state, matching the issue reporter's own local environment): both previously-failing "Contains documentation" cases now pass.
- [x] Same image, `site-local/` present (placeholder `site-local/index.html`): both cases still pass, now including `docs/ceedling` in the expectation — confirms the fix doesn't weaken CI's own fuller check.
- [x] `bundle exec rspec spec/units` — 1971 examples, 0 failures, 1 pre-existing pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)