### PR TITLE
Port #1216 fix to next_version: system tests wrongly assume local HTML docs bundle always exists

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -63,9 +63,15 @@ Historically, Ceedling automatically compiles and links into a test executable a
 
 ## 💪 Fixed
 
+### 1.1.6
+
+1.1.6 is a `master` patch release shipping before 1.2.0; every fix below also
+ships there and is folded into this 1.2.0 prerelease as well.
+
+- [#1216](https://github.com/ThrowTheSwitch/Ceedling/issues/1216) Fixed self-test issue that caused docs-related failures when the local documentation was unavailable (generated in CI but not necessarily present during self tests).
 - [#1223](https://github.com/ThrowTheSwitch/Ceedling/issues/1223) Fixed a conditional `#include` silently dropping out of generated code derived from preprocessed code, breaking compilation with an undeclared identifier error. The specific case involves a macro defined by another header included earlier in the same file.
 
-### Partials
+#### Partials
 
 - [#1215](https://github.com/ThrowTheSwitch/Ceedling/issues/1215) Fixed `MOCK_PARTIAL_ALL_MODULE()`/`MOCK_PARTIAL_MODULE()` silently failing to partialize `inline` functions in some circumstances leading to duplicated symbols breaking compilation.
 

--- a/spec/support/system/spec_system_helper.rb
+++ b/spec/support/system/spec_system_helper.rb
@@ -156,6 +156,17 @@ def feature_asset_path(asset_file_name)
   File.join(File.dirname(__FILE__), '..', '..', '..', 'assets', 'features', asset_file_name)
 end
 
+# `ceedling new`/`upgrade` only populates a project's docs/ceedling/ by copying this
+# repo's own site-local/ -- the local mkdocs HTML bundle, built only by `rake
+# docs:build:local` (see bin/cli_helper.rb's own identical check). That's a step CI
+# runs in a dedicated job before the test suite, but a plain local `bundle install &&
+# rspec` never runs at all, so docs/ceedling/ is legitimately absent there. Tests
+# asserting a deployed project's doc contents check this first rather than hardcoding
+# an assumption that only ever holds in CI's own environment (issue #1216).
+def html_docs_bundle_available?
+  Dir.exist?(File.join(File.dirname(__FILE__), '..', '..', '..', 'site-local'))
+end
+
 def unique_proj_name(prefix)
   safe = RSpec.current_example.description
     .downcase

--- a/spec/system/support/common_test_cases.rb
+++ b/spec/system/support/common_test_cases.rb
@@ -124,7 +124,11 @@ module CommonSystemTestCases
     @c.with_context do
       Dir.chdir @proj_name do
         all_docs = Dir["docs/*"]
-        expect(all_docs).to contain_exactly('docs/ceedling', 'docs/unity', 'docs/cmock', 'docs/c_exception', 'docs/license.txt')
+        # docs/ceedling only exists when this repo's own local HTML docs bundle
+        # (site-local/) was available to copy in -- see html_docs_bundle_available?.
+        expected = ['docs/unity', 'docs/cmock', 'docs/c_exception', 'docs/license.txt']
+        expected << 'docs/ceedling' if html_docs_bundle_available?
+        expect(all_docs).to contain_exactly(*expected)
       end
     end
   end


### PR DESCRIPTION
## Summary
Port of PR #1228 (opened against `master`) to `next_version`.

- Identical fix: `html_docs_bundle_available?` checks for `site-local/` the same way `bin/cli_helper.rb`'s own doc-copying logic does; `contains_documentation` builds its expected file list from that check instead of hardcoding `docs/ceedling` as always present.
- Fixes [#1216](https://github.com/ThrowTheSwitch/Ceedling/issues/1216) on this branch.
- Restructured this branch's Changelog `Fixed` section: wrapped `#1216`, `#1223`, and `#1215` under a new `### 1.1.6` subheading, since all three are 1.1.6-origin fixes (shipping on `master` first) rather than 1.2.0-exclusive ones — per direction that 1.2.0 folds in all of 1.1.x's fixes.

## Test plan
- [x] `bundle exec rspec spec/units` — 2601 examples, 0 failures.
- [x] Via `throwtheswitch/madsciencelab-plugins` Docker image, `site-local/` absent: both previously-failing "Contains documentation" cases now pass.
- [x] Same image, `site-local/` present (placeholder file): both cases still pass, including `docs/ceedling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)