### PR TITLE
bin/ Phase 1: CLI layer cleanup, baseline coverage, and refactor

### DIFF
--- a/bin/cli.rb
+++ b/bin/cli.rb
@@ -206,11 +206,8 @@ module CeedlingTasks
         "--project is missing a required filepath parameter"
       )
 
-      # Get unfrozen copies so we can add / modify
+      # Get an unfrozen copy so we can add / modify
       _options = options.dup()
-      _options[:project] = options[:project].dup() if !options[:project].nil?
-      _options[:mixin] = []
-      options[:mixin].each {|mixin| _options[:mixin] << mixin.dup() }
 
       _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
       # Call application help with block to execute Thor's built-in help in the help logic
@@ -243,13 +240,12 @@ module CeedlingTasks
     def new(dest=nil)
       require 'version' # lib/version.rb for TAG constant
 
-      # Get unfrozen copies so we can add / modify
+      # Get an unfrozen copy so we can add / modify
       _options = options.dup()
-      _dest = dest.dup() if !dest.nil?
 
       _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
 
-      @handler.new_project( ENV, @app_cfg, Ceedling::Version::TAG, _options, _dest )
+      @handler.new_project( ENV, @app_cfg, Ceedling::Version::TAG, _options, dest )
     end
 
     desc "upgrade PATH", "Upgrade vendored installation of Ceedling for a project at PATH"
@@ -286,14 +282,12 @@ module CeedlingTasks
         "--project is missing a required filename parameter"
       )
 
-      # Get unfrozen copies so we can add / modify
+      # Get an unfrozen copy so we can add / modify
       _options = options.dup()
-      _options[:project] = options[:project].dup()
-      _path = path.dup()
 
       _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
 
-      @handler.upgrade_project( ENV, @app_cfg, _options, _path )
+      @handler.upgrade_project( ENV, @app_cfg, _options, path )
     end
 
 
@@ -378,13 +372,9 @@ module CeedlingTasks
         "--exclude-test-case is missing a required test case name parameter"
       )
 
-      # Get unfrozen copies so we can add / modify
+      # Get an unfrozen copy so we can add / modify
       _options = options.dup()
-      _options[:project] = options[:project].dup() if !options[:project].nil?
-      _options[:mixin] = []
-      options[:mixin].each {|mixin| _options[:mixin] << mixin.dup() }
       _options[:verbosity] = Verbosity::DEBUG if options[:debug]
-      _options[:logfile] = options[:logfile].dup()
 
       @handler.build( env:ENV, app_cfg:@app_cfg, options:_options, tasks:tasks )
     end
@@ -427,16 +417,12 @@ module CeedlingTasks
         "--project is missing a required filepath parameter"
       )
 
-      # Get unfrozen copies so we can add / modify
+      # Get an unfrozen copy so we can add / modify
       _options = options.dup()
-      _options[:project] = options[:project].dup() if !options[:project].nil?
-      _options[:mixin] = []
-      options[:mixin].each {|mixin| _options[:mixin] << mixin.dup() }
-      _filepath = filepath.dup()
 
       _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
 
-      @handler.dumpconfig( ENV, @app_cfg, _options, _filepath, sections )
+      @handler.dumpconfig( ENV, @app_cfg, _options, filepath, sections )
     end
 
 
@@ -468,11 +454,8 @@ module CeedlingTasks
         "--project is missing a required filepath parameter"
       )
 
-      # Get unfrozen copies so we can add / modify
+      # Get an unfrozen copy so we can add / modify
       _options = options.dup()
-      _options[:project] = options[:project].dup() if !options[:project].nil?
-      _options[:mixin] = []
-      options[:mixin].each {|mixin| _options[:mixin] << mixin.dup() }
 
       _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::NORMAL
 
@@ -504,11 +487,8 @@ module CeedlingTasks
         "--project is missing a required filepath parameter"
       )
 
-      # Get unfrozen copies so we can add / modify
+      # Get an unfrozen copy so we can add / modify
       _options = options.dup()
-      _options[:project] = options[:project].dup() if !options[:project].nil?
-      _options[:mixin] = []
-      options[:mixin].each {|mixin| _options[:mixin] << mixin.dup() }
 
       _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
 
@@ -561,13 +541,12 @@ module CeedlingTasks
       LONGDESC
     ) )
     def example(name, dest=nil)
-      # Get unfrozen copies so we can add / modify
+      # Get an unfrozen copy so we can add / modify
       _options = options.dup()
-      _dest = dest.dup() if !dest.nil?
 
       _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : nil
 
-      @handler.create_example( ENV, @app_cfg, _options, name, _dest )
+      @handler.create_example( ENV, @app_cfg, _options, name, dest )
     end
 
 

--- a/bin/cli.rb
+++ b/bin/cli.rb
@@ -7,6 +7,7 @@
 
 require 'thor'
 require 'ceedling/constants' # From Ceedling application
+require 'cli_options_transform'
 
 ##
 ## Command Line Handling
@@ -209,7 +210,8 @@ module CeedlingTasks
       # Get an unfrozen copy so we can add / modify
       _options = options.dup()
 
-      _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
+      _options[:verbosity] = Verbosity::ERRORS
+      CliOptionsTransform.apply_debug_flag( _options )
       # Call application help with block to execute Thor's built-in help in the help logic
       @handler.app_help( ENV, @app_cfg, _options, command ) { |command| super(command) }
     end
@@ -243,7 +245,8 @@ module CeedlingTasks
       # Get an unfrozen copy so we can add / modify
       _options = options.dup()
 
-      _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
+      _options[:verbosity] = Verbosity::ERRORS
+      CliOptionsTransform.apply_debug_flag( _options )
 
       @handler.new_project( ENV, @app_cfg, Ceedling::Version::TAG, _options, dest )
     end
@@ -285,7 +288,8 @@ module CeedlingTasks
       # Get an unfrozen copy so we can add / modify
       _options = options.dup()
 
-      _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
+      _options[:verbosity] = Verbosity::ERRORS
+      CliOptionsTransform.apply_debug_flag( _options )
 
       @handler.upgrade_project( ENV, @app_cfg, _options, path )
     end
@@ -374,7 +378,7 @@ module CeedlingTasks
 
       # Get an unfrozen copy so we can add / modify
       _options = options.dup()
-      _options[:verbosity] = Verbosity::DEBUG if options[:debug]
+      CliOptionsTransform.apply_debug_flag( _options )
 
       @handler.build( env:ENV, app_cfg:@app_cfg, options:_options, tasks:tasks )
     end
@@ -420,7 +424,8 @@ module CeedlingTasks
       # Get an unfrozen copy so we can add / modify
       _options = options.dup()
 
-      _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
+      _options[:verbosity] = Verbosity::ERRORS
+      CliOptionsTransform.apply_debug_flag( _options )
 
       @handler.dumpconfig( ENV, @app_cfg, _options, filepath, sections )
     end
@@ -457,7 +462,8 @@ module CeedlingTasks
       # Get an unfrozen copy so we can add / modify
       _options = options.dup()
 
-      _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::NORMAL
+      _options[:verbosity] = Verbosity::NORMAL
+      CliOptionsTransform.apply_debug_flag( _options )
 
       @handler.check( ENV, @app_cfg, _options )
     end
@@ -490,7 +496,8 @@ module CeedlingTasks
       # Get an unfrozen copy so we can add / modify
       _options = options.dup()
 
-      _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : Verbosity::ERRORS
+      _options[:verbosity] = Verbosity::ERRORS
+      CliOptionsTransform.apply_debug_flag( _options )
 
       @handler.environment( ENV, @app_cfg, _options )
     end
@@ -510,7 +517,7 @@ module CeedlingTasks
       # Get unfrozen copies so we can add / modify
       _options = options.dup()
 
-      _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : nil
+      CliOptionsTransform.apply_debug_flag( _options )
 
       @handler.list_examples( ENV, @app_cfg, _options )
     end
@@ -544,7 +551,7 @@ module CeedlingTasks
       # Get an unfrozen copy so we can add / modify
       _options = options.dup()
 
-      _options[:verbosity] = options[:debug] ? Verbosity::DEBUG : nil
+      CliOptionsTransform.apply_debug_flag( _options )
 
       @handler.create_example( ENV, @app_cfg, _options, name, dest )
     end

--- a/bin/cli_handler.rb
+++ b/bin/cli_handler.rb
@@ -55,7 +55,7 @@ class CliHandler
     thor_help.call( command ) if block_given?
 
     # If project configuration is available, also display Rake tasks
-    @path_validator.standardize_paths( options[:project], *@helper.process_mixin_filepaths(options[:mixin]) )
+    options[:project], options[:mixin] = standardize_project_and_mixins( options[:project], options[:mixin] )
     if @projectinator.config_available?( filepath:options[:project], env:env )
       list_rake_tasks(
         env:env,
@@ -88,7 +88,7 @@ class CliHandler
   def new_project(env, app_cfg, ceedling_tag, options, dest)
     @helper.set_verbosity( options[:verbosity] )
 
-    @path_validator.standardize_paths( dest )
+    dest = @path_validator.standardize_paths( dest ).first
 
     # If destination is nil, assume it's the working directory
     dest ||= '.'
@@ -139,7 +139,7 @@ class CliHandler
   def upgrade_project(env, app_cfg, options, path)
     @helper.set_verbosity( options[:verbosity] )
 
-    @path_validator.standardize_paths( path, options[:project] )
+    path, options[:project] = @path_validator.standardize_paths( path, options[:project] )
 
     # Check for existing project
     if !@helper.project_exists?( path, :&, options[:project], 'vendor/ceedling/lib/version.rb' )
@@ -180,7 +180,8 @@ class CliHandler
     @helper.set_verbosity( _verbosity, override: false )
     @helper.set_ruby_replacement( options[:ruby_replacement] )
 
-    @path_validator.standardize_paths( options[:project], options[:logfile], *@helper.process_mixin_filepaths(options[:mixin]) )
+    options[:project], options[:mixin] = standardize_project_and_mixins( options[:project], options[:mixin] )
+    options[:logfile] = @path_validator.standardize_paths( options[:logfile] ).first
 
     _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
@@ -279,7 +280,8 @@ class CliHandler
     @helper.set_verbosity( options[:verbosity] )
     @helper.set_ruby_replacement( options[:ruby_replacement] )
 
-    @path_validator.standardize_paths( filepath, options[:project], *@helper.process_mixin_filepaths(options[:mixin]) )
+    filepath = @path_validator.standardize_paths( filepath ).first
+    options[:project], options[:mixin] = standardize_project_and_mixins( options[:project], options[:mixin] )
 
     _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
@@ -318,7 +320,7 @@ class CliHandler
     @helper.set_verbosity( options[:verbosity] )
     @helper.set_ruby_replacement( options[:ruby_replacement] )
 
-    @path_validator.standardize_paths( options[:project], *@helper.process_mixin_filepaths(options[:mixin]) )
+    options[:project], options[:mixin] = standardize_project_and_mixins( options[:project], options[:mixin] )
 
     _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
@@ -349,7 +351,7 @@ class CliHandler
     @helper.set_verbosity( options[:verbosity] )
     @helper.set_ruby_replacement( options[:ruby_replacement] )
 
-    @path_validator.standardize_paths( options[:project], *@helper.process_mixin_filepaths(options[:mixin]) )
+    options[:project], options[:mixin] = standardize_project_and_mixins( options[:project], options[:mixin] )
 
     _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
@@ -428,7 +430,7 @@ class CliHandler
   def create_example(env, app_cfg, options, name, dest)
     @helper.set_verbosity( options[:verbosity] )
 
-    @path_validator.standardize_paths( dest )
+    dest = @path_validator.standardize_paths( dest ).first
 
     # Process which_ceedling for app_cfg modifications but ignore return values
     @helper.which_ceedling?( env:env, app_cfg:app_cfg )
@@ -550,6 +552,24 @@ class CliHandler
   ### Private ###
 
   private
+
+  # Standardizes a project filepath and a mixins list together. PathValidator's
+  # standardize_paths() returns new values rather than updating its arguments in
+  # place, so the mixins list can't just be passed through it directly -- inline
+  # YAML mixin entries aren't filepaths at all and must be left untouched, and
+  # only the filepath/name entries come back out standardized. Matches entries
+  # by object identity rather than value so repeated identical mixin values are
+  # each replaced correctly.
+  def standardize_project_and_mixins(project, mixins)
+    _project = @path_validator.standardize_paths( project ).first
+
+    file_mixins = @helper.process_mixin_filepaths( mixins )
+    standardized = @path_validator.standardize_paths( *file_mixins )
+    replacements = file_mixins.each_with_index.to_h {|m, i| [m.object_id, standardized[i]] }
+    _mixins = mixins.map {|m| replacements.fetch( m.object_id, m ) }
+
+    return _project, _mixins
+  end
 
   def list_rake_tasks(env:, app_cfg:, filepath:nil, mixins:[], silent:false)
     _, config = 

--- a/bin/cli_handler.rb
+++ b/bin/cli_handler.rb
@@ -9,7 +9,7 @@ require 'thor'
 require 'mixins' # Built-in Mixins
 require 'ceedling/constants' # From Ceedling application
 require 'ceedling/rake_app/rake_task_registry' # From Ceedling application
-require 'versionator' # Outisde DIY context
+require 'versionator' # Outside DIY context
 
 class CliHandler
 
@@ -20,7 +20,7 @@ class CliHandler
   # Override to prevent exception handling from walking & stringifying the object variables.
   # Object variables are lengthy and produce a flood of output.
   def inspect
-    return this.class.name
+    return self.class.name
   end
 
 
@@ -53,9 +53,6 @@ class CliHandler
 
     # Display Thor-generated help listing
     thor_help.call( command ) if block_given?
-
-    # If it was help for a specific command, we're done
-    return if !command.nil?
 
     # If project configuration is available, also display Rake tasks
     @path_validator.standardize_paths( options[:project], *@helper.process_mixin_filepaths(options[:mixin]) )
@@ -379,10 +376,10 @@ class CliHandler
     end
 
     # Process environment created by configuration
-    config[:environment].each do |env|
-      env.each_key do |key|
+    config[:environment].each do |section|
+      section.each_key do |key|
         name = key.to_s.upcase
-        env_list << "#{name}: \"#{env[key]}\""
+        env_list << "#{name}: \"#{section[key]}\""
       end
     end
 

--- a/bin/cli_handler.rb
+++ b/bin/cli_handler.rb
@@ -15,7 +15,7 @@ class CliHandler
 
   DOCS_SUBDIR = 'docs'
 
-  constructor :configinator, :projectinator, :cli_helper, :path_validator, :rake_task_registry, :actions_wrapper, :loginator
+  constructor :composinator, :projectinator, :cli_helper, :path_validator, :rake_task_registry, :actions_wrapper, :loginator
 
   # Override to prevent exception handling from walking & stringifying the object variables.
   # Object variables are lengthy and produce a flood of output.
@@ -185,7 +185,7 @@ class CliHandler
 
     @path_validator.standardize_paths( options[:project], options[:logfile], *@helper.process_mixin_filepaths(options[:mixin]) )
 
-    _, config = @configinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
+    _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
     @cli_helper.log_project_name( config )
 
@@ -194,7 +194,7 @@ class CliHandler
     # after all .rake files are loaded with constants fully resolved.
     @helper.build_rake_task_registry( config:config )
 
-    default_tasks = @configinator.default_tasks( config:config, default_tasks:app_cfg[:default_tasks] )
+    default_tasks = @composinator.default_tasks( config:config, default_tasks:app_cfg[:default_tasks] )
 
     @helper.process_testcase_filters(
       config: config,
@@ -284,7 +284,7 @@ class CliHandler
 
     @path_validator.standardize_paths( filepath, options[:project], *@helper.process_mixin_filepaths(options[:mixin]) )
 
-    _, config = @configinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
+    _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
     @cli_helper.console_project_name( config )
 
@@ -292,7 +292,7 @@ class CliHandler
     begin
       # If enabled, process the configuration through Ceedling automatic settings, defaults, plugins, etc.
       if options[:app]
-        default_tasks = @configinator.default_tasks( config:config, default_tasks:app_cfg[:default_tasks] )
+        default_tasks = @composinator.default_tasks( config:config, default_tasks:app_cfg[:default_tasks] )
 
         # Save references
         app_cfg.set_project_config( config )
@@ -323,11 +323,11 @@ class CliHandler
 
     @path_validator.standardize_paths( options[:project], *@helper.process_mixin_filepaths(options[:mixin]) )
 
-    _, config = @configinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
+    _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
     @cli_helper.log_project_name( config )
 
-    default_tasks = @configinator.default_tasks( config:config, default_tasks:app_cfg[:default_tasks] )
+    default_tasks = @composinator.default_tasks( config:config, default_tasks:app_cfg[:default_tasks] )
 
     # Save references; explicitly disable log file output
     app_cfg.set_project_config( config )
@@ -354,7 +354,7 @@ class CliHandler
 
     @path_validator.standardize_paths( options[:project], *@helper.process_mixin_filepaths(options[:mixin]) )
 
-    _, config = @configinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
+    _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
     @cli_helper.console_project_name( config )
 
@@ -556,7 +556,7 @@ class CliHandler
 
   def list_rake_tasks(env:, app_cfg:, filepath:nil, mixins:[], silent:false)
     _, config = 
-      @configinator.loadinate(
+      @composinator.loadinate(
         builtin_mixins:BUILTIN_MIXINS,
         builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS,
         filepath: filepath,

--- a/bin/cli_helper.rb
+++ b/bin/cli_helper.rb
@@ -11,7 +11,7 @@ require 'app_cfg'
 require 'ceedling/constants'
 require 'ceedling/exceptions'
 require 'ceedling/rake_app/rakefile_component_resolver'
-require 'versionator' # Outisde DIY context
+require 'versionator' # Outside DIY context
 
 class CliHelper
 
@@ -289,7 +289,7 @@ class CliHelper
     # If logging is enabled without a filepath in --logfile, then set up the default path
     elsif log
       filepath = File.join( logging_path, DEFAULT_CEEDLING_LOGFILE )
-    elsif logfile.empty?
+    else
       return ''
     end
 

--- a/bin/cli_options_transform.rb
+++ b/bin/cli_options_transform.rb
@@ -1,0 +1,22 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+# Transforms Thor command options into the parameters CliHandler/CliHelper
+# expect. Kept free of any Thor dependency -- it only ever touches plain
+# Hashes -- so this logic is testable without configuring or invoking Thor.
+module CliOptionsTransform
+
+  # Every application command hides a --debug convenience flag that forces
+  # Verbosity::DEBUG. When --debug isn't set, :verbosity is left exactly as
+  # the caller already has it -- an explicit fallback set beforehand, an
+  # already-parsed --verbosity flag, or simply absent.
+  def self.apply_debug_flag(options)
+    options[:verbosity] = Verbosity::DEBUG if options[:debug]
+    return options
+  end
+
+end

--- a/bin/composinator.rb
+++ b/bin/composinator.rb
@@ -8,7 +8,7 @@
 require 'deep_merge'
 require 'ceedling/constants'
 
-class Configinator
+class Composinator
 
   constructor :config_walkinator, :projectinator, :mixinator
 

--- a/bin/mixinator.rb
+++ b/bin/mixinator.rb
@@ -79,11 +79,8 @@ class Mixinator
     _vars = []
     # Iterate over sorted environment variable names
     var_names.each do |name|
-      # Duplicate the filepath string to get unfrozen copy
-      # Handle any Windows path shenanigans
-      # Insert in array {env var name => filepath}
-      path = env[name].dup()
-      @path_validator.standardize_paths( path )
+      # Handle any Windows path shenanigans; insert in array {env var name => filepath}
+      path = @path_validator.standardize_paths( env[name] ).first
       _vars << {name => path}
     end
 

--- a/bin/mixinator.rb
+++ b/bin/mixinator.rb
@@ -121,11 +121,11 @@ class Mixinator
     #   3. Project configuration :enabled mixins (last → lowest dedup priority)
     #
     dedup = []
-    # cmdline entries are pre-tagged {source_label => value} hashes from configinator;
+    # cmdline entries are pre-tagged {source_label => value} hashes from composinator;
     # they carry either 'command line' (file/builtin) or 'command line (inline)' (YAML string)
     cmdline.each {|mixin| dedup << mixin}
     dedup += env
-    # config entries arrive pre-built from configinator as {'project configuration' => path, :_input => name}
+    # config entries arrive pre-built from composinator as {'project configuration' => path, :_input => name}
     config.each  {|entry| dedup << entry}
 
     # Remove duplicate mixins, keeping the highest-priority (first) occurrence.

--- a/bin/objects.yml
+++ b/bin/objects.yml
@@ -46,7 +46,7 @@ actions_wrapper:
 # Separation of logic from CLI user interface
 cli_handler:
   compose:
-    - configinator
+    - composinator
     - projectinator
     - cli_helper
     - path_validator
@@ -96,7 +96,7 @@ projectinator:
     - system_wrapper
     - ruby_expandinator
 
-configinator:
+composinator:
   compose:
     - config_walkinator
     - projectinator

--- a/bin/path_validator.rb
+++ b/bin/path_validator.rb
@@ -36,12 +36,13 @@ class PathValidator
     return validated
   end
 
-  # Ensure any Windows backslashes are converted to Ruby path forward slashes
-  # Santization happens inline
+  # Ensure any Windows backslashes are converted to Ruby path forward slashes.
+  # Returns new values in the same order as the arguments given, rather than
+  # mutating the caller's own String objects in place.
   def standardize_paths( *paths )
-    paths.each do |path|
-      next if path.nil? or path.empty?
-      path.gsub!( "\\", '/' )
+    paths.map do |path|
+      next path if path.nil? or path.empty?
+      path.gsub( "\\", '/' )
     end
   end
 

--- a/bin/projectinator.rb
+++ b/bin/projectinator.rb
@@ -59,9 +59,6 @@ class Projectinator
     else
       raise "No project filepath provided and default #{DEFAULT_PROJECT_FILEPATH} not found"
     end
-
-    # We'll never get here but return nil/empty for completeness
-    return nil, {}
   end
 
 

--- a/bin/projectinator.rb
+++ b/bin/projectinator.rb
@@ -27,7 +27,7 @@ class Projectinator
   def load(filepath:nil, env:{}, silent:false)
     # Highest priority: command line argument
     if filepath
-      @path_validator.standardize_paths( filepath )
+      filepath = @path_validator.standardize_paths( filepath ).first
       _filepath = File.expand_path( filepath )
       config = load_and_log( _filepath, 'from command line argument', silent )
       config[:history] = { config: [{type: :file, path: filepath, mechanism: :project}] }
@@ -35,9 +35,7 @@ class Projectinator
 
     # Next priority: environment variable
     elsif env[PROJECT_FILEPATH_ENV_VAR]
-      # ENV lookup is frozen so dup() to operate on the string
-      filepath = env[PROJECT_FILEPATH_ENV_VAR].dup()
-      @path_validator.standardize_paths( filepath )
+      filepath = @path_validator.standardize_paths( env[PROJECT_FILEPATH_ENV_VAR] ).first
       _filepath = File.expand_path( filepath )
       config = load_and_log(
         _filepath,

--- a/bin/versionator.rb
+++ b/bin/versionator.rb
@@ -74,8 +74,8 @@ class Versionator
         raise CeedlingException.new( "Could not collect version information for vendor component ⏩️ #{filename}" )
       end
 
-      # Splat version and evaluate it to create Versionator object accessor
-      eval("@#{name.downcase}_tag = '#{version.join(".")}'")
+      # Set the version tag accessor directly instead of building and evaling a string
+      instance_variable_set("@#{name.downcase}_tag", version.join('.'))
     end
   end
 end

--- a/docs/mkdocs/getting-started/command-line.md
+++ b/docs/mkdocs/getting-started/command-line.md
@@ -106,6 +106,7 @@ configuration. If no tasks are provided, built-in default tasks or your
 | `--graceful-fail` | | Force exit code of 0 for unit test failures | unset |
 | `--test-case` | | Filter for individual unit test names | `''` (none) |
 | `--exclude-test-case` | | Prevent matched unit test names from running | `''` (none) |
+| `--force-test-rerun` | | Run test executables and report fresh results even if unchanged | `false` (disabled) |
 | `--ruby-replacement` | | Enables inline Ruby string expansion (`#{...}`) in project configuration | `false` (disabled) |
 
 ---

--- a/spec/system/cli_surface_spec.rb
+++ b/spec/system/cli_surface_spec.rb
@@ -1,0 +1,208 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+
+# Covers CLI surface area with no prior system-test coverage: the naked-task
+# backwards-compatibility retry, the bare -T/-v/--version ARGV hacks in
+# bin/ceedling, and several commands/flags exercised nowhere else.
+ceedling_system_tests do
+  before :all do
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  before { @proj_name = unique_proj_name("cli_surface") }
+
+  describe "Fresh project" do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new #{@proj_name}")
+      end
+    end
+
+    it "runs build tasks with no `build` keyword (PermissiveCLI retry)" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          FileUtils.cp test_asset_path("example_file.h"), 'src/'
+          FileUtils.cp test_asset_path("example_file.c"), 'src/'
+          FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+          # No leading `build` -- Thor raises Thor::UndefinedCommandError for
+          # `test:all`, and bin/ceedling retries with `build` unshifted on.
+          output = @c.ceedling_appcmd_exec("test:all")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/TESTED:\s+\d/)
+          expect(output).to match(/PASSED:\s+\d/)
+        end
+      end
+    end
+
+    it "lists build tasks with bare -T, without `build` or `help`" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_appcmd_exec("-T")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/ceedling test:all/i)
+        end
+      end
+    end
+
+    it "processes configuration with `check` and runs no build tasks" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_appcmd_exec("check")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/Project configuration processed/i)
+          # Configuration validation vendors Unity/CMock sources into build/ as
+          # scaffolding, but `check` compiles nothing and runs no tests -- no
+          # generated test runners or results, unlike an actual build.
+          expect(Dir.glob('build/test/runners/*')).to be_empty
+          expect(Dir.glob('build/artifacts/**/*').select { |path| File.file?(path) }).to be_empty
+        end
+      end
+    end
+
+    it "loads a project file from a non-default path via --project" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          FileUtils.mv('project.yml', 'custom_project.yml')
+
+          output = @c.ceedling_appcmd_exec("check --project=custom_project.yml")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/Project configuration processed/i)
+        end
+      end
+    end
+
+    it "surfaces obnoxious-verbosity diagnostics only when --debug is given" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          quiet_output = @c.ceedling_appcmd_exec("check")
+          expect(quiet_output).to_not match(/Launching Ceedling from/)
+
+          debug_output = @c.ceedling_appcmd_exec("check --debug")
+          expect(debug_output).to match(/Launching Ceedling from/)
+        end
+      end
+    end
+
+    it "writes to the explicit --logfile path" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          FileUtils.cp test_asset_path("example_file.h"), 'src/'
+          FileUtils.cp test_asset_path("example_file.c"), 'src/'
+          FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+          @c.ceedling_build_exec("test:all --logfile=custom.log")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(File.exist?('custom.log')).to eq(true)
+        end
+      end
+    end
+
+    it "writes to the default log path under --log" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          FileUtils.cp test_asset_path("example_file.h"), 'src/'
+          FileUtils.cp test_asset_path("example_file.c"), 'src/'
+          FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+          @c.ceedling_build_exec("test:all --log")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(Dir.glob('**/ceedling.log')).to_not be_empty
+        end
+      end
+    end
+
+    it "forces a success exit code under --graceful-fail even when tests fail" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          FileUtils.cp test_asset_path("example_file.h"), 'src/'
+          FileUtils.cp test_asset_path("example_file.c"), 'src/'
+          FileUtils.cp test_asset_path("test_example_file.c"), 'test/'
+
+          output = @c.ceedling_build_exec("test:all --graceful-fail")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/FAILED:\s+[1-9]/)
+        end
+      end
+    end
+
+    it "refuses to overwrite an existing project without --force" do
+      @c.with_context do
+        output = @c.ceedling_appcmd_exec("new #{@proj_name}")
+
+        expect(@c.last_exit_status).to eq(1)
+        expect(output).to match(/already exists/i)
+      end
+    end
+
+    it "destroys and recreates the project with --force" do
+      @c.with_context do
+        Dir.chdir(@proj_name) { File.write('marker.txt', 'should be wiped by --force') }
+
+        output = @c.ceedling_appcmd_exec("new #{@proj_name} --force")
+
+        expect(@c.last_exit_status).to eq(0)
+        expect(File.exist?(File.join(@proj_name, 'marker.txt'))).to eq(false)
+      end
+    end
+  end
+
+  describe "No project required" do
+    it "reports version via bare -v, without the `version` keyword" do
+      @c.with_context do
+        output = @c.ceedling_appcmd_exec("-v")
+
+        expect(@c.last_exit_status).to eq(0)
+        expect(output).to match(/Welcome to Ceedling!/)
+        expect(output).to match(/Ceedling => \d\.\d\.\d/)
+      end
+    end
+
+    it "reports version via bare --version, without the `version` keyword" do
+      @c.with_context do
+        output = @c.ceedling_appcmd_exec("--version")
+
+        expect(@c.last_exit_status).to eq(0)
+        expect(output).to match(/Welcome to Ceedling!/)
+      end
+    end
+
+    it "exports documentation with `docs`" do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("docs docs_dest")
+
+        expect(@c.last_exit_status).to eq(0)
+        expect(Dir.exist?('docs_dest/unity')).to eq(true)
+        expect(Dir.exist?('docs_dest/cmock')).to eq(true)
+        expect(Dir.exist?('docs_dest/c_exception')).to eq(true)
+      end
+    end
+
+    it "shows detailed help content specific to a named command" do
+      @c.with_context do
+        output = @c.ceedling_appcmd_exec("help build")
+
+        expect(@c.last_exit_status).to eq(0)
+        expect(output).to match(/force-test-rerun/i)
+      end
+    end
+  end
+end

--- a/spec/units/bin/actions_wrapper_spec.rb
+++ b/spec/units/bin/actions_wrapper_spec.rb
@@ -1,0 +1,95 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'tmpdir'
+require 'actions_wrapper'
+
+# ActionsWrapper is a thin pass-through onto Thor::Actions -- these specs confirm
+# the wrapper methods forward to real Thor behavior against a real filesystem
+# rather than re-testing Thor itself.
+describe ActionsWrapper do
+  before(:each) do
+    @actions = described_class.new
+  end
+
+  around(:each) do |example|
+    Dir.mktmpdir do |dir|
+      @tmpdir = dir
+      described_class.source_root( dir )
+      example.run
+    end
+  end
+
+  describe '#_directory' do
+    it 'copies a source directory to a destination, excluding junk files' do
+      src = File.join( @tmpdir, 'src_dir' )
+      FileUtils.mkdir_p( src )
+      File.write( File.join( src, 'keep.txt' ), 'keep me' )
+      File.write( File.join( src, '.DS_Store' ), 'junk' )
+
+      dest = File.join( @tmpdir, 'dest_dir' )
+      @actions._directory( 'src_dir', dest, :force => true, :verbose => false )
+
+      expect(File.exist?( File.join( dest, 'keep.txt' ) )).to eq( true )
+      expect(File.exist?( File.join( dest, '.DS_Store' ) )).to eq( false )
+    end
+  end
+
+  describe '#_copy_file' do
+    it 'copies a single file to a destination' do
+      File.write( File.join( @tmpdir, 'source.txt' ), 'hello' )
+
+      dest = File.join( @tmpdir, 'copy.txt' )
+      @actions._copy_file( 'source.txt', dest, :force => true, :verbose => false )
+
+      expect(File.read( dest )).to eq( 'hello' )
+    end
+  end
+
+  describe '#_touch_file' do
+    it 'creates an empty file if none exists' do
+      dest = File.join( @tmpdir, 'touched.txt' )
+
+      @actions._touch_file( dest )
+
+      expect(File.exist?( dest )).to eq( true )
+    end
+  end
+
+  describe '#_chmod' do
+    it 'sets file permissions', skip: (RUBY_PLATFORM.downcase =~ /mingw|win32/ ? 'chmod is not meaningful on Windows' : false) do
+      dest = File.join( @tmpdir, 'executable.txt' )
+      File.write( dest, 'content' )
+
+      @actions._chmod( dest, 0755, :verbose => false )
+
+      expect(File.stat( dest ).mode & 0777).to eq( 0755 )
+    end
+  end
+
+  describe '#_empty_directory' do
+    it 'creates an empty directory' do
+      dest = File.join( @tmpdir, 'empty_dir' )
+
+      @actions._empty_directory( dest, :verbose => false )
+
+      expect(File.directory?( dest )).to eq( true )
+    end
+  end
+
+  describe '#_gsub_file' do
+    it 'substitutes matched text in a file' do
+      target = File.join( @tmpdir, 'target.txt' )
+      File.write( target, "version: '?'\n" )
+
+      @actions._gsub_file( target, /version:\s+'\?'/, "version: '1.0.0'", :verbose => false )
+
+      expect(File.read( target )).to eq( "version: '1.0.0'\n" )
+    end
+  end
+end

--- a/spec/units/bin/app_cfg_spec.rb
+++ b/spec/units/bin/app_cfg_spec.rb
@@ -1,0 +1,90 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'app_cfg'
+
+describe CeedlingAppConfig do
+  before(:each) do
+    @app_cfg = described_class.new
+  end
+
+  describe 'initialization' do
+    it 'derives ceedling_root_path from this file\'s own location' do
+      expected_root = File.expand_path( File.join( File.dirname( __FILE__ ), '../../../bin', '..' ) )
+
+      expect(@app_cfg[:ceedling_root_path]).to eq( expected_root )
+    end
+
+    it 'sets default_tasks to test:all' do
+      expect(@app_cfg[:default_tasks]).to eq( ['test:all'] )
+    end
+
+    it 'defaults force_test_rerun to false' do
+      expect(@app_cfg[:force_test_rerun]).to eq( false )
+    end
+  end
+
+  describe '#set_paths' do
+    it 'derives every dependent path from the given root path' do
+      @app_cfg.set_paths( '/tmp/some/root' )
+
+      root = File.expand_path( '/tmp/some/root' )
+      expect(@app_cfg[:ceedling_root_path]).to eq( root )
+      expect(@app_cfg[:ceedling_lib_base_path]).to eq( File.join( root, 'lib' ) )
+      expect(@app_cfg[:ceedling_lib_path]).to eq( File.join( root, 'lib', 'ceedling' ) )
+      expect(@app_cfg[:ceedling_vendor_path]).to eq( File.join( root, 'vendor' ) )
+      expect(@app_cfg[:ceedling_plugins_path]).to eq( File.join( root, 'plugins' ) )
+      expect(@app_cfg[:ceedling_examples_path]).to eq( File.join( root, 'examples' ) )
+      expect(@app_cfg[:ceedling_rakefile_filepath]).to eq( File.join( root, 'lib', 'ceedling', 'rakefile.rb' ) )
+    end
+  end
+
+  describe 'simple setters' do
+    it '#set_project_config updates :project_config' do
+      @app_cfg.set_project_config( {:project => {}} )
+      expect(@app_cfg[:project_config]).to eq( {:project => {}} )
+    end
+
+    it '#set_logging_path updates :logging_path' do
+      @app_cfg.set_logging_path( 'build/logs' )
+      expect(@app_cfg[:logging_path]).to eq( 'build/logs' )
+    end
+
+    it '#set_log_filepath updates :log_filepath' do
+      @app_cfg.set_log_filepath( 'build/logs/ceedling.log' )
+      expect(@app_cfg[:log_filepath]).to eq( 'build/logs/ceedling.log' )
+    end
+
+    it '#set_include_test_case updates :include_test_case' do
+      @app_cfg.set_include_test_case( 'configure' )
+      expect(@app_cfg[:include_test_case]).to eq( 'configure' )
+    end
+
+    it '#set_exclude_test_case updates :exclude_test_case' do
+      @app_cfg.set_exclude_test_case( 'configure' )
+      expect(@app_cfg[:exclude_test_case]).to eq( 'configure' )
+    end
+
+    it '#set_force_test_rerun updates :force_test_rerun' do
+      @app_cfg.set_force_test_rerun( true )
+      expect(@app_cfg[:force_test_rerun]).to eq( true )
+    end
+
+    it '#set_build_tasks updates :build_tasks? and #build_tasks?' do
+      @app_cfg.set_build_tasks( true )
+      expect(@app_cfg[:build_tasks?]).to eq( true )
+      expect(@app_cfg.build_tasks?).to eq( true )
+    end
+
+    it '#set_tests_graceful_fail updates :tests_graceful_fail? and #tests_graceful_fail?' do
+      @app_cfg.set_tests_graceful_fail( true )
+      expect(@app_cfg[:tests_graceful_fail?]).to eq( true )
+      expect(@app_cfg.tests_graceful_fail?).to eq( true )
+    end
+  end
+end

--- a/spec/units/bin/cli_handler_spec.rb
+++ b/spec/units/bin/cli_handler_spec.rb
@@ -1,0 +1,46 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+
+# bin/versionator.rb (pulled in transitively by cli_handler.rb) uses bare `require`
+# statements that only resolve when lib/ceedling/ and lib/ are directly on the load
+# path -- true in the real bin/ceedling bootstrap but not in this spec harness's
+# load path setup. Add the same directories here so `require 'cli_handler'` succeeds.
+here = File.dirname(__FILE__)
+$: << File.join(here, '../../../lib/ceedling')
+$: << File.join(here, '../../../lib')
+
+# cli_handler.rb requires 'mixins' before 'ceedling/constants', but bin/mixins.rb
+# references UNITY_ROOT_PATH, a constant only defined by ceedling/constants. The
+# real bin/ceedling bootstrap always loads ceedling/constants first, so this load
+# order only ever bites a spec harness requiring cli_handler.rb directly.
+require 'ceedling/constants'
+require 'cli_handler'
+
+# Scoped narrowly to #inspect for now. CliHandler's other public methods are
+# still only exercised end-to-end through system tests; broader unit coverage
+# is added separately.
+describe CliHandler do
+  before(:each) do
+    @cli_handler = described_class.new({
+      :composinator       => double('composinator').as_null_object,
+      :projectinator      => double('projectinator').as_null_object,
+      :cli_helper         => double('cli_helper').as_null_object,
+      :path_validator     => double('path_validator').as_null_object,
+      :rake_task_registry => double('rake_task_registry').as_null_object,
+      :actions_wrapper    => double('actions_wrapper').as_null_object,
+      :loginator          => double('loginator').as_null_object,
+    })
+  end
+
+  describe '#inspect' do
+    it 'returns the class name instead of dumping instance variables' do
+      expect(@cli_handler.inspect).to eq('CliHandler')
+    end
+  end
+end

--- a/spec/units/bin/cli_handler_spec.rb
+++ b/spec/units/bin/cli_handler_spec.rb
@@ -22,6 +22,10 @@ $: << File.join(here, '../../../lib')
 require 'ceedling/constants'
 require 'cli_handler'
 require 'app_cfg'
+require 'path_validator'
+require 'cli_helper'
+require 'ceedling/ruby_expandinator'
+require 'ceedling/rake_app/rake_task_registry'
 
 # Most of CliHandler's public methods (build, dumpconfig, check, environment,
 # new_project, upgrade_project, create_example, list_rake_tasks) are thin
@@ -31,7 +35,9 @@ require 'app_cfg'
 # mirror the implementation rather than guard behavior -- they're exercised
 # end-to-end by system tests instead. Coverage here is scoped to methods with
 # real, self-contained branching logic: #inspect, #validate_string_param,
-# #version, and #list_examples.
+# #version, #list_examples, and the private #standardize_project_and_mixins
+# helper (real collaborators, not doubles, since testing it meaningfully means
+# exercising the real filtering/standardizing behavior it coordinates).
 describe CliHandler do
   before(:each) do
     @loginator = double('loginator').as_null_object
@@ -133,6 +139,66 @@ describe CliHandler do
       listing = messages.join
       expect(listing).to include( 'blinky' )
       expect(listing).to include( 'temp_sensor' )
+    end
+  end
+
+  describe '#standardize_project_and_mixins (private)' do
+    before(:each) do
+      real_path_validator = PathValidator.new({
+        :file_wrapper => double('file_wrapper').as_null_object,
+        :loginator    => double('loginator').as_null_object,
+      })
+      real_cli_helper = CliHelper.new({
+        :file_wrapper       => double('file_wrapper').as_null_object,
+        :actions_wrapper    => double('actions_wrapper').as_null_object,
+        :config_walkinator  => double('config_walkinator').as_null_object,
+        :path_validator     => real_path_validator,
+        :rake_task_registry => double('rake_task_registry').as_null_object,
+        :loginator          => double('loginator').as_null_object,
+        :reportinator       => double('reportinator').as_null_object,
+        :system_wrapper     => double('system_wrapper').as_null_object,
+        :ruby_expandinator  => RubyExpandinator.new,
+      })
+
+      @cli_handler_real = described_class.new({
+        :composinator       => double('composinator').as_null_object,
+        :projectinator      => double('projectinator').as_null_object,
+        :cli_helper         => real_cli_helper,
+        :path_validator     => real_path_validator,
+        :rake_task_registry => double('rake_task_registry').as_null_object,
+        :actions_wrapper    => double('actions_wrapper').as_null_object,
+        :loginator          => double('loginator').as_null_object,
+      })
+    end
+
+    def standardize(project, mixins)
+      @cli_handler_real.send( :standardize_project_and_mixins, project, mixins )
+    end
+
+    it 'standardizes backslashes in the project path' do
+      project, _mixins = standardize( 'some\\project.yml', [] )
+
+      expect(project).to eq( 'some/project.yml' )
+    end
+
+    it 'standardizes filepath/name mixin entries but leaves inline YAML entries untouched' do
+      inline_yaml = "=:project:\n  :build_root: some\\path"
+
+      _project, mixins = standardize( nil, ['mixin\\dir\\clang.yml', inline_yaml] )
+
+      expect(mixins).to eq( ['mixin/dir/clang.yml', inline_yaml] )
+    end
+
+    it 'standardizes each occurrence of a repeated mixin value independently' do
+      _project, mixins = standardize( nil, ['dup\\path.yml', 'other\\path.yml', 'dup\\path.yml'] )
+
+      expect(mixins).to eq( ['dup/path.yml', 'other/path.yml', 'dup/path.yml'] )
+    end
+
+    it 'passes a nil project through unchanged' do
+      project, _mixins = standardize( nil, [] )
+
+      expect(project).to be_nil
     end
   end
 end

--- a/spec/units/bin/cli_handler_spec.rb
+++ b/spec/units/bin/cli_handler_spec.rb
@@ -21,26 +21,118 @@ $: << File.join(here, '../../../lib')
 # order only ever bites a spec harness requiring cli_handler.rb directly.
 require 'ceedling/constants'
 require 'cli_handler'
+require 'app_cfg'
 
-# Scoped narrowly to #inspect for now. CliHandler's other public methods are
-# still only exercised end-to-end through system tests; broader unit coverage
-# is added separately.
+# Most of CliHandler's public methods (build, dumpconfig, check, environment,
+# new_project, upgrade_project, create_example, list_rake_tasks) are thin
+# orchestration wiring together many already-independently-tested collaborators
+# in sequence. Unit testing those would mean mocking most of the collaborator
+# chain just to reach the one interesting line, producing brittle tests that
+# mirror the implementation rather than guard behavior -- they're exercised
+# end-to-end by system tests instead. Coverage here is scoped to methods with
+# real, self-contained branching logic: #inspect, #validate_string_param,
+# #version, and #list_examples.
 describe CliHandler do
   before(:each) do
+    @loginator = double('loginator').as_null_object
+    @helper    = double('cli_helper').as_null_object
+
     @cli_handler = described_class.new({
       :composinator       => double('composinator').as_null_object,
       :projectinator      => double('projectinator').as_null_object,
-      :cli_helper         => double('cli_helper').as_null_object,
+      :cli_helper         => @helper,
       :path_validator     => double('path_validator').as_null_object,
       :rake_task_registry => double('rake_task_registry').as_null_object,
       :actions_wrapper    => double('actions_wrapper').as_null_object,
-      :loginator          => double('loginator').as_null_object,
+      :loginator          => @loginator,
     })
   end
 
   describe '#inspect' do
     it 'returns the class name instead of dumping instance variables' do
       expect(@cli_handler.inspect).to eq('CliHandler')
+    end
+  end
+
+  describe '#validate_string_param' do
+    it 'raises a Thor::Error when the param equals the missing sentinel' do
+      expect {
+        @cli_handler.validate_string_param( 'MISSING', 'MISSING', '--project is missing a required filename parameter' )
+      }.to raise_error( Thor::Error, '--project is missing a required filename parameter' )
+    end
+
+    it 'does nothing when the param is a real value' do
+      expect {
+        @cli_handler.validate_string_param( 'project.yml', 'MISSING', 'unused message' )
+      }.to_not raise_error
+    end
+  end
+
+  describe '#version' do
+    before(:each) do
+      @app_cfg = CeedlingAppConfig.new
+    end
+
+    def fake_application_version(install_path)
+      double('application_versionator',
+        :ceedling_install_path => install_path,
+        :ceedling_build        => '1.2.0',
+        :cmock_tag             => '2.7.0',
+        :unity_tag             => '2.7.1',
+        :cexception_tag        => '1.3.4',
+      )
+    end
+
+    it 'renders a single Ceedling block when launcher and application share an install path' do
+      allow(@helper).to receive(:manufacture_app_version).and_return(
+        fake_application_version( @app_cfg[:ceedling_root_path] )
+      )
+
+      expect(@loginator).to receive(:console) do |message, _label|
+        expect(message).to include( 'Ceedling => 1.2.0' )
+        expect(message).to_not include( 'Ceedling Launcher' )
+        expect(message).to_not include( 'Ceedling App' )
+      end
+
+      @cli_handler.version( {}, @app_cfg )
+    end
+
+    it 'renders separate launcher and application blocks when their install paths differ' do
+      allow(@helper).to receive(:manufacture_app_version).and_return(
+        fake_application_version( '/somewhere/else/entirely' )
+      )
+
+      expect(@loginator).to receive(:console) do |message, _label|
+        expect(message).to include( 'Ceedling Launcher => 1.2.0' )
+        expect(message).to include( 'Ceedling App => 1.2.0' )
+      end
+
+      @cli_handler.version( {}, @app_cfg )
+    end
+  end
+
+  describe '#list_examples' do
+    it 'raises when no example projects are found' do
+      allow(@helper).to receive(:lookup_example_projects).and_return( [] )
+
+      expect {
+        @cli_handler.list_examples( {}, CeedlingAppConfig.new, {} )
+      }.to raise_error( 'No examples projects found' )
+    end
+
+    it 'lists each example project found' do
+      allow(@helper).to receive(:lookup_example_projects).and_return( ['blinky', 'temp_sensor'] )
+
+      # #list_examples logs the listing and a separate documentation pointer --
+      # collect every console call rather than assume a single message.
+      messages = []
+      allow(@loginator).to receive(:console) {|message, _label| messages << message }
+
+      @cli_handler.list_examples( {}, CeedlingAppConfig.new, {} )
+
+      listing = messages.join
+      expect(listing).to include( 'blinky' )
+      expect(listing).to include( 'temp_sensor' )
     end
   end
 end

--- a/spec/units/bin/cli_helper_spec.rb
+++ b/spec/units/bin/cli_helper_spec.rb
@@ -6,6 +6,8 @@
 # =========================================================================
 
 require 'spec_helper'
+require 'tmpdir'
+require 'rake'
 
 # bin/versionator.rb (pulled in transitively by cli_helper.rb) uses bare `require`
 # statements (`require 'exceptions'`, `require 'constants'`, `require 'version'`)
@@ -18,6 +20,7 @@ $: << File.join(here, '../../../lib/ceedling')
 $: << File.join(here, '../../../lib')
 
 require 'cli_helper'
+require 'app_cfg'
 require 'ceedling/ruby_expandinator'
 # CliHelper#test_task? references RakeTaskRegistry::TAG_TEST, but only
 # bin/cli_handler.rb requires this file in the real bootstrap (loaded before
@@ -25,23 +28,22 @@ require 'ceedling/ruby_expandinator'
 # spec exercises CliHelper in isolation.
 require 'ceedling/rake_app/rake_task_registry'
 
-# Scoped narrowly to #set_ruby_replacement and #process_force_test_rerun, the
-# --ruby-replacement and --force-test-rerun CLI flags' wiring. Broader CliHelper
-# coverage (including the pre-existing #process_testcase_filters and
-# #process_graceful_fail this new method is modeled on) is a pre-existing gap
-# outside either feature's scope.
 describe CliHelper do
   before(:each) do
     @ruby_expandinator  = RubyExpandinator.new
     @rake_task_registry = double('rake_task_registry').as_null_object
+    @file_wrapper       = double('file_wrapper').as_null_object
+    @config_walkinator  = double('config_walkinator').as_null_object
+    @path_validator     = double('path_validator').as_null_object
+    @loginator          = double('loginator').as_null_object
 
     @cli_helper = described_class.new({
-      :file_wrapper       => double('file_wrapper').as_null_object,
+      :file_wrapper       => @file_wrapper,
       :actions_wrapper    => double('actions_wrapper').as_null_object,
-      :config_walkinator  => double('config_walkinator').as_null_object,
-      :path_validator     => double('path_validator').as_null_object,
+      :config_walkinator  => @config_walkinator,
+      :path_validator     => @path_validator,
       :rake_task_registry => @rake_task_registry,
-      :loginator          => double('loginator').as_null_object,
+      :loginator          => @loginator,
       :reportinator       => double('reportinator').as_null_object,
       :system_wrapper     => double('system_wrapper').as_null_object,
       :ruby_expandinator  => @ruby_expandinator,
@@ -106,6 +108,190 @@ describe CliHelper do
       expect {
         @cli_helper.process_force_test_rerun( force_test_rerun: true, tasks: [], default_tasks: ['test:all'] )
       }.to_not raise_error
+    end
+  end
+
+  describe '#which_ceedling?' do
+    before(:each) do
+      @app_cfg = CeedlingAppConfig.new
+      # Baseline: no :project ↳ :which_ceedling entry found. Tests exercising that
+      # config path override this with a more specific `.with(...)` stub below.
+      allow(@config_walkinator).to receive(:fetch_value).and_return( [nil, nil] )
+    end
+
+    it 'uses the WHICH_CEEDLING environment variable at highest priority' do
+      which, path = @cli_helper.which_ceedling?( env: {'WHICH_CEEDLING' => 'gem'}, app_cfg: @app_cfg )
+
+      expect(which).to eq( :gem )
+      expect(path).to eq( @app_cfg[:ceedling_rakefile_filepath] )
+    end
+
+    it 'falls back to config :project ↳ :which_ceedling when no environment variable is set' do
+      config = {:project => {:which_ceedling => 'gem'}}
+      allow(@config_walkinator).to receive(:fetch_value).with( :project, :which_ceedling, hash: config ).and_return( ['gem', nil] )
+
+      which, path = @cli_helper.which_ceedling?( env: {}, config: config, app_cfg: @app_cfg )
+
+      expect(which).to eq( :gem )
+      expect(path).to eq( @app_cfg[:ceedling_rakefile_filepath] )
+    end
+
+    it 'falls back to a vendor/ceedling directory when neither environment nor config specify anything' do
+      allow(@file_wrapper).to receive(:directory?).with( 'vendor/ceedling' ).and_return( true )
+      allow(@file_wrapper).to receive(:exist?).and_return( true )
+
+      which, path = @cli_helper.which_ceedling?( env: {}, app_cfg: @app_cfg )
+
+      expect(which).to eq( :path )
+      expect(path).to eq( @app_cfg[:ceedling_rakefile_filepath] )
+      expect(@app_cfg[:ceedling_root_path]).to eq( File.expand_path('vendor/ceedling') )
+    end
+
+    it 'defaults to :gem when nothing is set and no vendor/ceedling directory exists' do
+      allow(@file_wrapper).to receive(:directory?).with( 'vendor/ceedling' ).and_return( false )
+
+      which, path = @cli_helper.which_ceedling?( env: {}, app_cfg: @app_cfg )
+
+      expect(which).to eq( :gem )
+      expect(path).to eq( @app_cfg[:ceedling_rakefile_filepath] )
+    end
+
+    it 'raises when a configured launch path does not exist as a directory' do
+      config = {:project => {:which_ceedling => 'nonexistent/path'}}
+      allow(@config_walkinator).to receive(:fetch_value).with( :project, :which_ceedling, hash: config ).and_return( ['nonexistent/path', nil] )
+      allow(@file_wrapper).to receive(:directory?).and_return( false )
+
+      expect {
+        @cli_helper.which_ceedling?( env: {}, config: config, app_cfg: @app_cfg )
+      }.to raise_error( /does not exist/ )
+    end
+
+    it 'raises when a configured launch path exists but contains no Ceedling installation' do
+      config = {:project => {:which_ceedling => 'empty/path'}}
+      allow(@config_walkinator).to receive(:fetch_value).with( :project, :which_ceedling, hash: config ).and_return( ['empty/path', nil] )
+      allow(@file_wrapper).to receive(:directory?).and_return( true )
+      allow(@file_wrapper).to receive(:exist?).and_return( false )
+
+      expect {
+        @cli_helper.which_ceedling?( env: {}, config: config, app_cfg: @app_cfg )
+      }.to raise_error( /contains no Ceedling installation/ )
+    end
+  end
+
+  describe '#set_verbosity' do
+    after(:each) do
+      # These globals are frozen once set -- clear them so later specs in the
+      # same process (unit suite runs as one process) start from a clean slate.
+      Object.send(:remove_const, 'PROJECT_VERBOSITY') if Object.const_defined?('PROJECT_VERBOSITY')
+      Object.send(:remove_const, 'PROJECT_DEBUG') if Object.const_defined?('PROJECT_DEBUG')
+    end
+
+    it 'defaults to Verbosity::NORMAL when given nil' do
+      expect(@cli_helper.set_verbosity( nil )).to eq( Verbosity::NORMAL )
+      expect(PROJECT_VERBOSITY).to eq( Verbosity::NORMAL )
+      expect(PROJECT_DEBUG).to eq( false )
+    end
+
+    it 'passes an Integer verbosity constant through directly' do
+      expect(@cli_helper.set_verbosity( Verbosity::OBNOXIOUS )).to eq( Verbosity::OBNOXIOUS )
+    end
+
+    it 'parses a numeric string as an integer verbosity level' do
+      expect(@cli_helper.set_verbosity( '4' )).to eq( 4 )
+    end
+
+    it 'looks up a named verbosity string' do
+      expect(@cli_helper.set_verbosity( 'debug' )).to eq( Verbosity::DEBUG )
+      expect(PROJECT_DEBUG).to eq( true )
+    end
+
+    it 'raises for an unrecognized named verbosity' do
+      expect { @cli_helper.set_verbosity( 'not-a-real-level' ) }.to raise_error( /Unkown Verbosity/ )
+    end
+
+    it 'is idempotent once established unless override is true' do
+      @cli_helper.set_verbosity( Verbosity::DEBUG )
+
+      expect(@cli_helper.set_verbosity( Verbosity::NORMAL, override: false )).to eq( Verbosity::DEBUG )
+    end
+
+    it 'reconfigures when override is true, the default' do
+      @cli_helper.set_verbosity( Verbosity::DEBUG )
+
+      expect(@cli_helper.set_verbosity( Verbosity::NORMAL )).to eq( Verbosity::NORMAL )
+    end
+  end
+
+  describe '#process_log_filepath' do
+    around(:each) do |example|
+      Dir.mktmpdir do |dir|
+        @tmpdir = dir
+        example.run
+      end
+    end
+
+    it 'returns an empty string when logging is explicitly disabled' do
+      result = @cli_helper.process_log_filepath( @tmpdir, false, 'ignored.log' )
+
+      expect(result).to eq( '' )
+    end
+
+    it 'returns an empty string when neither --log nor --logfile is set' do
+      result = @cli_helper.process_log_filepath( @tmpdir, nil, '' )
+
+      expect(result).to eq( '' )
+    end
+
+    it 'uses the explicit --logfile path when one is given, creating its directory' do
+      logfile = File.join( @tmpdir, 'nested', 'custom.log' )
+      expect(@file_wrapper).to receive(:mkdir).with( File.join( @tmpdir, 'nested' ) )
+
+      result = @cli_helper.process_log_filepath( @tmpdir, nil, logfile )
+
+      expect(result).to eq( File.expand_path( logfile ) )
+    end
+
+    it 'falls back to the default logfile path under logging_path when --log is enabled with no --logfile' do
+      # @tmpdir itself already exists, so no mkdir call is expected here.
+      expect(@file_wrapper).to_not receive(:mkdir)
+
+      result = @cli_helper.process_log_filepath( @tmpdir, true, '' )
+
+      expect(result).to eq( File.expand_path( File.join( @tmpdir, DEFAULT_CEEDLING_LOGFILE ) ) )
+    end
+  end
+
+  describe '#run_rake_tasks' do
+    before(:each) do
+      @rake_application = double('rake_application')
+      allow(Rake).to receive(:application).and_return( @rake_application )
+    end
+
+    it 'raises a friendlier CeedlingException when Rake reports an unrecognized task' do
+      allow(@rake_application).to receive(:collect_command_line_tasks).with( ['bogus:task'] )
+      allow(@rake_application).to receive(:top_level).and_raise(
+        RuntimeError.new("Don't know how to build task 'bogus:task' (See the list of available tasks with `rake --tasks`)")
+      )
+
+      expect {
+        @cli_helper.run_rake_tasks( ['bogus:task'] )
+      }.to raise_error( CeedlingException, /Unrecognized build task 'bogus:task'/ )
+    end
+
+    it 're-raises RuntimeErrors unrelated to an unrecognized task unchanged' do
+      allow(@rake_application).to receive(:collect_command_line_tasks)
+      allow(@rake_application).to receive(:top_level).and_raise( RuntimeError.new('Something else entirely went wrong') )
+
+      expect {
+        @cli_helper.run_rake_tasks( ['test:all'] )
+      }.to raise_error( RuntimeError, 'Something else entirely went wrong' )
+    end
+
+    it 'does not raise when Rake completes normally' do
+      allow(@rake_application).to receive(:collect_command_line_tasks)
+      allow(@rake_application).to receive(:top_level)
+
+      expect { @cli_helper.run_rake_tasks( ['test:all'] ) }.to_not raise_error
     end
   end
 end

--- a/spec/units/bin/cli_options_transform_spec.rb
+++ b/spec/units/bin/cli_options_transform_spec.rb
@@ -1,0 +1,49 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/constants'
+require 'cli_options_transform'
+
+# Plain hashes stand in for Thor's options -- this module has no Thor
+# dependency, matching the posture that CLI logic worth testing in isolation
+# should be extractable from Thor configuration itself.
+describe CliOptionsTransform do
+  describe '.apply_debug_flag' do
+    it 'forces Verbosity::DEBUG when the hidden --debug flag is set' do
+      options = { debug: true, verbosity: Verbosity::NORMAL }
+
+      result = described_class.apply_debug_flag( options )
+
+      expect(result[:verbosity]).to eq( Verbosity::DEBUG )
+    end
+
+    it 'leaves an already-set :verbosity untouched when --debug is not set' do
+      options = { debug: false, verbosity: Verbosity::OBNOXIOUS }
+
+      result = described_class.apply_debug_flag( options )
+
+      expect(result[:verbosity]).to eq( Verbosity::OBNOXIOUS )
+    end
+
+    it 'leaves a missing :verbosity as nil when --debug is not set' do
+      options = { debug: false }
+
+      result = described_class.apply_debug_flag( options )
+
+      expect(result[:verbosity]).to be_nil
+    end
+
+    it 'returns the same Hash it was given' do
+      options = { debug: false }
+
+      result = described_class.apply_debug_flag( options )
+
+      expect(result).to equal( options )
+    end
+  end
+end

--- a/spec/units/bin/mixinator_spec.rb
+++ b/spec/units/bin/mixinator_spec.rb
@@ -212,7 +212,7 @@ describe Mixinator do
     end
 
     it 'returns pre-tagged cmdline entry when only cmdline is provided' do
-      # cmdline entries arrive as pre-tagged hashes from configinator
+      # cmdline entries arrive as pre-tagged hashes from composinator
       result = @mixinator.assemble_mixins(
         config:  [],
         env:     [],

--- a/spec/units/bin/path_validator_spec.rb
+++ b/spec/units/bin/path_validator_spec.rb
@@ -56,36 +56,43 @@ describe PathValidator do
   end
 
   describe '#standardize_paths' do
-    # Current behavior: converts backslashes in place via String#gsub!, mutating
-    # the caller's own String objects rather than returning new ones.
-    it 'converts backslashes to forward slashes in place' do
+    it 'returns backslashes converted to forward slashes, as a new value' do
       path = 'some\\windows\\path.yml'
+
+      result = @path_validator.standardize_paths( path )
+
+      expect(result).to eq( ['some/windows/path.yml'] )
+    end
+
+    it 'does not mutate the argument given' do
+      path = 'some\\windows\\path.yml'
+      original_object_id = path.object_id
 
       @path_validator.standardize_paths( path )
 
-      expect(path).to eq( 'some/windows/path.yml' )
+      expect(path).to eq( 'some\\windows\\path.yml' )
+      expect(path.object_id).to eq( original_object_id )
     end
 
-    it 'mutates every argument given' do
+    it 'returns every argument given, standardized, in the same order' do
       a = 'one\\two'
       b = 'three\\four'
 
-      @path_validator.standardize_paths( a, b )
+      result = @path_validator.standardize_paths( a, b )
 
-      expect(a).to eq( 'one/two' )
-      expect(b).to eq( 'three/four' )
+      expect(result).to eq( ['one/two', 'three/four'] )
     end
 
-    it 'leaves already-forward-slash paths unchanged' do
+    it 'returns already-forward-slash paths unchanged' do
       path = 'already/unix/style.yml'
 
-      @path_validator.standardize_paths( path )
+      result = @path_validator.standardize_paths( path )
 
-      expect(path).to eq( 'already/unix/style.yml' )
+      expect(result).to eq( ['already/unix/style.yml'] )
     end
 
-    it 'skips nil and empty arguments without raising' do
-      expect { @path_validator.standardize_paths( nil, '' ) }.to_not raise_error
+    it 'passes nil and empty arguments through unchanged, without raising' do
+      expect(@path_validator.standardize_paths( nil, '' )).to eq( [nil, ''] )
     end
   end
 

--- a/spec/units/bin/path_validator_spec.rb
+++ b/spec/units/bin/path_validator_spec.rb
@@ -1,0 +1,105 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'path_validator'
+require 'ceedling/constants'
+
+describe PathValidator do
+  before(:each) do
+    @file_wrapper = double('file_wrapper')
+    @loginator    = double('loginator').as_null_object
+
+    @path_validator = described_class.new({
+      :file_wrapper => @file_wrapper,
+      :loginator    => @loginator,
+    })
+  end
+
+  describe '#validate' do
+    it 'passes when every path exists as a filepath' do
+      allow(@file_wrapper).to receive(:exist?).and_return( true )
+
+      expect(@path_validator.validate( paths: ['a.yml', 'b.yml'], source: 'Test' )).to eq( true )
+    end
+
+    it 'fails and logs when a path is empty' do
+      expect(@loginator).to receive(:log).with( /contains an empty path/, Verbosity::ERRORS )
+
+      expect(@path_validator.validate( paths: [''], source: 'Test' )).to eq( false )
+    end
+
+    it 'fails and logs when a filepath does not exist' do
+      allow(@file_wrapper).to receive(:exist?).and_return( false )
+      expect(@loginator).to receive(:log).with( /does not exist in the filesystem/, Verbosity::ERRORS )
+
+      expect(@path_validator.validate( paths: ['missing.yml'], source: 'Test' )).to eq( false )
+    end
+
+    it 'fails and logs when a directory does not exist' do
+      allow(@file_wrapper).to receive(:directory?).and_return( false )
+      expect(@loginator).to receive(:log).with( /does not exist as a directory/, Verbosity::ERRORS )
+
+      expect(@path_validator.validate( paths: ['missing/'], source: 'Test', type: :directory )).to eq( false )
+    end
+
+    it 'checks every path rather than stopping at the first failure' do
+      allow(@file_wrapper).to receive(:exist?).and_return( false )
+      expect(@loginator).to receive(:log).twice
+
+      expect(@path_validator.validate( paths: ['a.yml', 'b.yml'], source: 'Test' )).to eq( false )
+    end
+  end
+
+  describe '#standardize_paths' do
+    # Current behavior: converts backslashes in place via String#gsub!, mutating
+    # the caller's own String objects rather than returning new ones.
+    it 'converts backslashes to forward slashes in place' do
+      path = 'some\\windows\\path.yml'
+
+      @path_validator.standardize_paths( path )
+
+      expect(path).to eq( 'some/windows/path.yml' )
+    end
+
+    it 'mutates every argument given' do
+      a = 'one\\two'
+      b = 'three\\four'
+
+      @path_validator.standardize_paths( a, b )
+
+      expect(a).to eq( 'one/two' )
+      expect(b).to eq( 'three/four' )
+    end
+
+    it 'leaves already-forward-slash paths unchanged' do
+      path = 'already/unix/style.yml'
+
+      @path_validator.standardize_paths( path )
+
+      expect(path).to eq( 'already/unix/style.yml' )
+    end
+
+    it 'skips nil and empty arguments without raising' do
+      expect { @path_validator.standardize_paths( nil, '' ) }.to_not raise_error
+    end
+  end
+
+  describe '#filepath?' do
+    it 'is true for a value with a file extension' do
+      expect(@path_validator.filepath?( 'clang.yml' )).to eq( true )
+    end
+
+    it 'is true for a value containing a path separator, even without an extension' do
+      expect(@path_validator.filepath?( File.join('mixins', 'clang') )).to eq( true )
+    end
+
+    it 'is false for a bare name with neither an extension nor a separator' do
+      expect(@path_validator.filepath?( 'clang' )).to eq( false )
+    end
+  end
+end

--- a/spec/units/bin/rake_patches_spec.rb
+++ b/spec/units/bin/rake_patches_spec.rb
@@ -1,0 +1,52 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'rake_patches'
+
+# Rake::ColonTaskNameFileTaskPatch only ever matters on Windows (see the comment
+# block in rake_patches.rb for why), but Errno::EINVAL can be stubbed from any
+# platform -- no real Windows machine is needed to exercise the rescue itself.
+describe Rake::ColonTaskNameFileTaskPatch do
+  around(:each) do |example|
+    # Rake.application is process-global; save/restore it so this spec's throwaway
+    # application doesn't leak into any other spec that happens to run in the
+    # same process.
+    original_application = Rake.application
+    Rake.application = Rake::Application.new
+
+    example.run
+
+    Rake.application = original_application
+  end
+
+  def file_task(name)
+    Rake::FileTask.define_task(name)
+  end
+
+  describe '#needed?' do
+    it 'treats Errno::EINVAL the same as Rake would treat a missing file' do
+      allow(File).to receive(:mtime).and_raise( Errno::EINVAL )
+
+      expect(file_task('release:compile:foo.c').needed?).to eq( true )
+    end
+
+    it 'leaves ordinary Errno::ENOENT handling (already rescued by Rake) unaffected' do
+      allow(File).to receive(:mtime).and_raise( Errno::ENOENT )
+
+      expect(file_task('release:compile:foo.c').needed?).to eq( true )
+    end
+  end
+
+  describe '#timestamp' do
+    it 'treats Errno::EINVAL the same as Rake would treat a missing file' do
+      allow(File).to receive(:mtime).and_raise( Errno::EINVAL )
+
+      expect(file_task('release:compile:foo.c').timestamp).to eq( Rake::LATE )
+    end
+  end
+end

--- a/spec/units/bin/versionator_spec.rb
+++ b/spec/units/bin/versionator_spec.rb
@@ -1,0 +1,104 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+# versionator.rb's bare `require 'exceptions'`/`require 'constants'` statements only
+# resolve when lib/ceedling/ is directly on the load path -- true in the real
+# bin/ceedling bootstrap but not in this spec harness's load path setup. `require
+# 'version'` similarly needs lib/ on the load path.
+here = File.dirname(__FILE__)
+$: << File.join(here, '../../../lib/ceedling')
+$: << File.join(here, '../../../lib')
+
+require 'versionator'
+
+describe Versionator do
+  # Builds a throwaway vendor/ tree with just enough of each dependency's version
+  # header for Versionator to parse -- the real files live in vendor/<project>/,
+  # but Versionator only cares about the three VERSION_* macro lines.
+  def write_version_header(vendor_path, project, relative_path, major:, minor:, build:)
+    header_dir, name = File.split( relative_path )
+    dir = File.join( vendor_path, project, header_dir )
+    FileUtils.mkdir_p( dir )
+    macro_prefix = project.upcase.sub('C_EXCEPTION', 'CEXCEPTION')
+    File.write( File.join( dir, name ), <<~HEADER )
+      #define #{macro_prefix}_VERSION_MAJOR #{major}
+      #define #{macro_prefix}_VERSION_MINOR #{minor}
+      #define #{macro_prefix}_VERSION_BUILD #{build}
+    HEADER
+  end
+
+  describe 'Ceedling tag and build string' do
+    it 'sets the Ceedling tag from the Version module' do
+      Dir.mktmpdir do |root|
+        versionator = described_class.new( root )
+
+        expect(versionator.ceedling_tag).to eq( Ceedling::Version::TAG )
+      end
+    end
+
+    it 'builds without a commit SHA suffix when no SHA file is present' do
+      Dir.mktmpdir do |root|
+        versionator = described_class.new( root )
+
+        expect(versionator.ceedling_build).to eq( Ceedling::Version::TAG )
+      end
+    end
+
+    it 'appends the commit SHA to the build string when the SHA file is present' do
+      Dir.mktmpdir do |root|
+        File.write( File.join( root, GIT_COMMIT_SHA_FILENAME ), "abc1234\n" )
+
+        versionator = described_class.new( root )
+
+        expect(versionator.ceedling_build).to eq( "#{Ceedling::Version::TAG}-abc1234" )
+      end
+    end
+  end
+
+  describe 'framework version gathering' do
+    it 'skips framework tags entirely when no vendor path is given' do
+      Dir.mktmpdir do |root|
+        versionator = described_class.new( root )
+
+        expect(versionator.unity_tag).to be_nil
+        expect(versionator.cmock_tag).to be_nil
+        expect(versionator.cexception_tag).to be_nil
+      end
+    end
+
+    it 'parses version tags out of each vendored framework header' do
+      Dir.mktmpdir do |root|
+        Dir.mktmpdir do |vendor|
+          write_version_header( vendor, 'unity', File.join('src', 'unity.h'), major: 2, minor: 7, build: 1 )
+          write_version_header( vendor, 'cmock', File.join('src', 'cmock.h'), major: 2, minor: 7, build: 0 )
+          write_version_header( vendor, 'c_exception', File.join('lib', 'CException.h'), major: 1, minor: 3, build: 4 )
+
+          versionator = described_class.new( root, vendor )
+
+          expect(versionator.unity_tag).to eq('2.7.1')
+          expect(versionator.cmock_tag).to eq('2.7.0')
+          expect(versionator.cexception_tag).to eq('1.3.4')
+        end
+      end
+    end
+
+    it 'raises a CeedlingException when a framework header cannot be read' do
+      Dir.mktmpdir do |root|
+        Dir.mktmpdir do |vendor|
+          # No headers written -- vendor is empty, so every read fails.
+          expect {
+            described_class.new( root, vendor )
+          }.to raise_error( CeedlingException, /Could not collect version information/ )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 1 of the `bin/` code review, refactoring, and test coverage plan (CLI layer). Six commits, each independently reviewable:

1. **Rename `Configinator` → `Composinator`** — too close in name to the main application's `Configurator`.
2. **Trivial bug fixes**, each with a proving test: `#inspect` referencing undefined `this`, dead code in `#app_help` and `Projectinator#load`, a variable shadowing an `env:` parameter, `eval()` replaced with `instance_variable_set`, a redundant `elsif`, two typos, and a missing `--force-test-rerun` row in the `build` command's docs table.
3. **Baseline unit coverage** for `app_cfg.rb`, `versionator.rb`, `path_validator.rb`, `actions_wrapper.rb` (previously zero unit specs), plus expanded `cli_helper.rb`/`cli_handler.rb` coverage scoped to methods with self-contained logic — the many thin orchestration methods stay covered by system tests only, to avoid brittle mock-heavy tests.
4. **Baseline system-test coverage** for previously-untested CLI surface: the naked-task `PermissiveCLI` retry, bare `-T`/`-v`/`--version`, `check`, `docs`, `--project`, `--logfile`/`--log`, `--force` on `new`, `--graceful-fail`, `--debug`, and `help COMMAND`. Plus a unit spec for `rake_patches.rb`'s Windows-only `EINVAL` handling (stubbed, no real Windows machine needed).
5. **Fix `PathValidator#standardize_paths`'s in-place mutation** — it mutated String arguments via `gsub!`, relying on scattered `.dup()` calls at every call site to avoid corrupting Thor's shared default-value objects (a real risk since `bin/ceedling`'s naked-task retry can invoke `CeedlingTasks::CLI.start` twice in one process). Now returns new values; updates every call site and removes ~20 now-unnecessary `.dup()` calls in `cli.rb`.
6. **Extract the repeated `--debug`-to-verbosity transform** out of `cli.rb`'s nine Thor commands into `CliOptionsTransform`, a small Thor-agnostic module with its own unit coverage.

## Test plan
- [x] Full unit suite (`bundle exec rspec spec/units`) — 2676 examples, 0 failures
- [x] Targeted system-test verification via `throwtheswitch/madsciencelab-plugins:v1.1.4` (naked-task, mixin ordering, gem/vendor deployment, upgrade) — 201 examples, 0 failures
- [ ] Full CI (unit + system, all platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)