### PR TITLE
bin/ Phase 2: Mixins subsystem bug fixes, dead code cleanup, and coverage baseline

### DIFF
--- a/bin/cli_handler.rb
+++ b/bin/cli_handler.rb
@@ -183,7 +183,7 @@ class CliHandler
     options[:project], options[:mixin] = standardize_project_and_mixins( options[:project], options[:mixin] )
     options[:logfile] = @path_validator.standardize_paths( options[:logfile] ).first
 
-    _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
+    _, config = @composinator.loadinate( builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
     @cli_helper.log_project_name( config )
 
@@ -283,7 +283,7 @@ class CliHandler
     filepath = @path_validator.standardize_paths( filepath ).first
     options[:project], options[:mixin] = standardize_project_and_mixins( options[:project], options[:mixin] )
 
-    _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
+    _, config = @composinator.loadinate( builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
     @cli_helper.console_project_name( config )
 
@@ -322,7 +322,7 @@ class CliHandler
 
     options[:project], options[:mixin] = standardize_project_and_mixins( options[:project], options[:mixin] )
 
-    _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
+    _, config = @composinator.loadinate( builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
     @cli_helper.log_project_name( config )
 
@@ -353,7 +353,7 @@ class CliHandler
 
     options[:project], options[:mixin] = standardize_project_and_mixins( options[:project], options[:mixin] )
 
-    _, config = @composinator.loadinate( builtin_mixins:BUILTIN_MIXINS, builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
+    _, config = @composinator.loadinate( builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
     @cli_helper.console_project_name( config )
 
@@ -574,7 +574,6 @@ class CliHandler
   def list_rake_tasks(env:, app_cfg:, filepath:nil, mixins:[], silent:false)
     _, config = 
       @composinator.loadinate(
-        builtin_mixins:BUILTIN_MIXINS,
         builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS,
         filepath: filepath,
         mixins: mixins,

--- a/bin/composinator.rb
+++ b/bin/composinator.rb
@@ -113,21 +113,31 @@ class Composinator
     )
     file_resolution_map = Hash[cmdline_file_values.zip(resolved_file_values)]
 
+    # A repeated raw --mixin value (e.g. `--mixin foo.yml --mixin bar.yml
+    # --mixin foo.yml`) must resolve using its LAST occurrence's position, not
+    # its first, so the user's actual last-typed flag ends up last (highest
+    # priority) -- matching ordinary left-to-right command line override
+    # semantics. Record the index of each file value's last occurrence so the
+    # reconstruction below can keep only that one.
+    last_file_index = {}
+    tagged_cmdline.each_with_index do |e, idx|
+      last_file_index[e[:value]] = idx if e[:type] == :file
+    end
+
     # Reconstruct the full cmdline sequence in original left-to-right order,
     # replacing stripped file values with their resolved forms and tagging each
     # entry with a source label that mixin() uses to select the load strategy.
-    # File entries that were deduplicated (absent from map after first use) are
-    # skipped — delete after first fetch enforces single-use per unique value.
-    cmdline_ordered = tagged_cmdline.each_with_object([]) do |e, arr|
+    # An earlier occurrence of a file value superseded by a later, identical
+    # one is skipped entirely -- only the last occurrence's position survives.
+    cmdline_ordered = tagged_cmdline.each_with_index.each_with_object([]) do |(e, idx), arr|
       if e[:type] == :yaml
         # Inline YAML: source label 'command line (inline)' triggers load_string() in mixin()
         # :_input carries the raw YAML string as the original user value for history traceability
         arr << {'command line (inline)' => e[:value], :_input => e[:value]}
-      elsif (resolved = file_resolution_map[e[:value]])
+      elsif idx == last_file_index[e[:value]]
         # File/name: source label 'command line' triggers existing file/builtin dispatch in mixin()
         # :_input carries the original user-provided value (before load-path resolution) for history
-        arr << {'command line' => resolved, :_input => e[:value]}
-        file_resolution_map.delete(e[:value])  # consume so duplicate raw values are skipped
+        arr << {'command line' => file_resolution_map[e[:value]], :_input => e[:value]}
       end
     end
 

--- a/bin/composinator.rb
+++ b/bin/composinator.rb
@@ -12,7 +12,7 @@ class Composinator
 
   constructor :config_walkinator, :projectinator, :mixinator
 
-  def loadinate(builtin_mixins:, builtin_load_paths:[], filepath:nil, mixins:[], env:{}, silent:false)
+  def loadinate(builtin_load_paths:[], filepath:nil, mixins:[], env:{}, silent:false)
     # Aliases for clarity
     cmdline_filepath = filepath
     cmdline_mixins = mixins || []
@@ -65,7 +65,6 @@ class Composinator
     if not @projectinator.validate_mixins(
       mixins: cfg_enabled_mixins,
       load_paths: cfg_load_paths,
-      builtins: builtin_mixins,
       source: 'Config :mixins ↳ :enabled =>',
       yaml_extension: yaml_ext
     )
@@ -76,7 +75,6 @@ class Composinator
     if not @projectinator.validate_mixins(
       mixins: cmdline_file_values,
       load_paths: cfg_load_paths,
-      builtins: builtin_mixins,
       source: 'Mixin',
       yaml_extension: yaml_ext
     )
@@ -86,12 +84,11 @@ class Composinator
     # Validate inline YAML strings: must parse cleanly and produce a Hash
     @mixinator.validate_cmdline_yaml_strings( cmdline_yaml_values )
 
-    # Find mixins in project file among load paths or built-in mixins
-    # Return ordered list of filepaths or built-in mixin names
+    # Find mixins in project file among load paths
+    # Return ordered list of filepaths
     config_mixins = @projectinator.lookup_mixins(
       mixins: cfg_enabled_mixins,
       load_paths: cfg_load_paths,
-      builtins: builtin_mixins,
       yaml_extension: yaml_ext
     )
 
@@ -102,13 +99,12 @@ class Composinator
       {'project configuration' => path, :_input => name}
     end
 
-    # Resolve file-based names/paths to canonical filepaths (or built-in keys).
+    # Resolve file-based names/paths to canonical filepaths.
     # Returns values in the same order as the input; zip them back into a hash for
     # O(1) lookup when reconstructing positional order below.
     resolved_file_values = @projectinator.lookup_mixins(
       mixins: cmdline_file_values,
       load_paths: cfg_load_paths,
-      builtins: builtin_mixins,
       yaml_extension: yaml_ext
     )
     file_resolution_map = Hash[cmdline_file_values.zip(resolved_file_values)]
@@ -157,7 +153,7 @@ class Composinator
     )
 
     # Merge mixins
-    @mixinator.mixin( builtins:builtin_mixins, config:config, mixins:mixins_assembled )
+    @mixinator.mixin( config:config, mixins:mixins_assembled )
 
     return project_filepath, config
   end

--- a/bin/mixin_standardizer.rb
+++ b/bin/mixin_standardizer.rb
@@ -112,10 +112,9 @@ class MixinStandardizer
 
     # Promote config value list to all-matches matcher hash
     if config_value.is_a?(Array) && mixin_value.is_a?(Hash)
-      # Ensure all-matches matcher key is a symbol and not a string
-      if (deleted = mixin_value.delete( '*' ))
-        mixin_value[:*] = deleted
-      end
+      # mixin_value's own keys need no symbol/string normalization here --
+      # Mixinator#mixin already symbolizes every mixin key before this method
+      # ever runs, so a string '*' key is not possible on this side.
 
       # Replace the value of a simple array list with a matcher hash that stores the original list
       config_parent[key] = {:* => config_value}

--- a/bin/mixinator.rb
+++ b/bin/mixinator.rb
@@ -162,7 +162,7 @@ class Mixinator
     return config_entries + env_entries + cmdline_entries
   end
 
-  def mixin(builtins:, config:, mixins:)
+  def mixin(config:, mixins:)
     mixins.each do |mixin|
       source = mixin.keys.first
       filepath = mixin.values.first
@@ -198,12 +198,11 @@ class Mixinator
         # Log what filepath we used for this mixin
         @loginator.lazy( Verbosity::OBNOXIOUS ) { " + Merging #{'(empty) ' if _mixin.nil?}#{source} mixin using #{filepath}" }
 
-      # Reference mixin from built-in hash-based mixins
+      # lookup_mixins() only ever hands back inline YAML or a real filepath for
+      # validated input -- reaching here means something upstream let an
+      # unresolved bare name through.
       else
-        _mixin = builtins[filepath.to_sym()]
-
-        # Log built-in mixin we used
-        @loginator.lazy( Verbosity::OBNOXIOUS ) { " + Merging built-in mixin '#{filepath}' from #{source}" }
+        raise "Mixin '#{filepath}' from #{source} could not be resolved to a file"
       end
 
       # Hnadle an empty mixin (it's unlikely but logically coherent and a good safety check)

--- a/bin/mixinator.rb
+++ b/bin/mixinator.rb
@@ -68,13 +68,21 @@ class Mixinator
   def fetch_env_filepaths(env)
     var_names = []
 
-    env.each do |var, filepath|
-      # Explicitly ignores CEEDLING_MIXIN_0
-      var_names << var if var =~ /CEEDLING_MIXIN_[1-9]\d*/
+    env.each_key do |var|
+      next unless var.start_with?( 'CEEDLING_MIXIN_' )
+
+      suffix = var.sub( 'CEEDLING_MIXIN_', '' )
+      unless suffix.match?( /\A\d+\z/ )
+        raise "Malformed mixin environment variable name '#{var}' — expected CEEDLING_MIXIN_<number>"
+      end
+
+      # Explicitly ignores CEEDLING_MIXIN_0 (a leading zero, e.g. CEEDLING_MIXIN_01,
+      # is otherwise treated the same as no leading zero)
+      var_names << var unless suffix.to_i() == 0
     end
 
-    # Extract numeric string (guranteed to exist) and convert to integer for ascending sorting
-    var_names.sort_by! {|name| name.match(/\d+$/)[0].to_i() }
+    # Ascending numeric order; to_i() ignores leading zeros so CEEDLING_MIXIN_01 sorts as 1
+    var_names.sort_by! {|name| name.sub( 'CEEDLING_MIXIN_', '' ).to_i() }
 
     _vars = []
     # Iterate over sorted environment variable names

--- a/bin/mixinator.rb
+++ b/bin/mixinator.rb
@@ -16,17 +16,6 @@ class Mixinator
     @standardinator = @mixin_standardizer
   end
 
-  def validate_cmdline_filepaths(paths)
-    validated = @path_validator.validate(
-      paths: paths,
-      source: 'Filepath argument',
-    )
-
-    if !validated
-      raise 'Mixins command line failed validation'
-    end
-  end
-
   def validate_cmdline_yaml_strings(yaml_strings)
     # Validate a list of inline YAML strings from --mixin "=..." command line arguments.
     # Errors are accumulated so the user sees all problems before the run aborts.

--- a/bin/mixins.rb
+++ b/bin/mixins.rb
@@ -5,10 +5,5 @@
 #   SPDX-License-Identifier: MIT
 # =========================================================================
 
-BUILTIN_MIXINS = {
-  # Mixin name as symbol => mixin config hash
-  # :mixin => {}
-}
-
 _vendor = defined?(CEEDLING_APPCFG) ? CEEDLING_APPCFG[:ceedling_vendor_path] : File.expand_path( File.join( File.dirname(__FILE__), '..', 'vendor' ) )
 BUILTIN_MIXIN_LOAD_PATHS = [ File.join( _vendor, UNITY_ROOT_PATH, 'test', 'targets' ) ].freeze

--- a/bin/projectinator.rb
+++ b/bin/projectinator.rb
@@ -140,7 +140,7 @@ class Projectinator
 
 
   # Validate mixins list
-  def validate_mixins(mixins:, load_paths:, builtins:, source:, yaml_extension:)
+  def validate_mixins(mixins:, load_paths:, source:, yaml_extension:)
     validated = true
 
     mixins.each do |mixin|
@@ -151,7 +151,7 @@ class Projectinator
           validated = false
         end
 
-      # Otherwise, validate that mixin name can be found in load paths or builtins
+      # Otherwise, validate that mixin name can be found in load paths
       else
         found = false
         load_paths.each do |path|
@@ -161,10 +161,8 @@ class Projectinator
           end
         end
 
-        builtins.keys.each {|key| found = true if (mixin == key.to_s)}
-
         if !found
-          msg = "#{source} '#{mixin}' cannot be found in mixin load paths as '#{mixin + yaml_extension}' or among built-in mixins"
+          msg = "#{source} '#{mixin}' cannot be found in mixin load paths as '#{mixin + yaml_extension}'"
           @loginator.log( msg, Verbosity::ERRORS )
           validated = false
         end
@@ -175,15 +173,13 @@ class Projectinator
   end
 
 
-  # Yield ordered list of filepaths or built-in mixin names
-  def lookup_mixins(mixins:, load_paths:, builtins:, yaml_extension:)
+  # Yield ordered list of filepaths
+  def lookup_mixins(mixins:, load_paths:, yaml_extension:)
     _mixins = []
 
-    # Already validated, so we know:
-    #  1. Any mixin filepaths exists
-    #  2. Built-in mixin names exist in the internal hash
+    # Already validated, so we know any mixin filepath or name is found in load_paths
 
-    # Fill filepaths array with filepaths or builtin names
+    # Fill filepaths array with filepaths
     mixins.each do |mixin|
       # Handle explicit filepaths
       if @path_validator.filepath?( mixin )
@@ -201,7 +197,7 @@ class Projectinator
       end
 
       # Finally, fall through to simply add the unmodified name to the list.
-      # It's a built-in mixin.
+      # validate_mixins() should have already confirmed it exists in load_paths.
       _mixins << mixin
     end
 

--- a/bin/projectinator.rb
+++ b/bin/projectinator.rb
@@ -105,13 +105,17 @@ class Projectinator
     enabled = _mixins[:enabled] || []
     enabled = enabled.clone # Ensure it's a copy of configuration section
 
-    # Handle any inline Ruby string expansion
+    # Handle any inline Ruby string expansion, then standardize Windows backslashes --
+    # cmdline and env var mixin paths already go through standardize_paths elsewhere,
+    # so config :mixins section paths need the same treatment for consistency.
     load_paths.each do |load_path|
       load_path.replace( @ruby_expandinator.expand( load_path, source: ":mixins ↳ :load_paths" ) )
+      load_path.replace( @path_validator.standardize_paths( load_path ).first )
     end
 
     enabled.each do |mixin|
       mixin.replace( @ruby_expandinator.expand( mixin, source: ":mixins ↳ :enabled" ) )
+      mixin.replace( @path_validator.standardize_paths( mixin ).first )
     end
 
     # Remove the :mixins section of the configuration

--- a/bin/recursive_merger.rb
+++ b/bin/recursive_merger.rb
@@ -35,7 +35,8 @@
 ##   Single value merged into a config list:
 ##     The mixin's single value is wrapped in a one-element list and then
 ##     placed BEFORE the config list entries, consistent with the general
-##     list rule above.
+##     list rule above. The same [:tools, <tool name>, :arguments] exception
+##     applies here too: a single value at that path is appended instead.
 ##
 ##   List merged into a config single value:
 ##     The mixin's list replaces the config value outright. This is flagged
@@ -87,6 +88,11 @@ class RecursiveMerger
             # appears first in the combined list (e.g. include search paths).
             config[key] = mixin_val + config_val
           end
+        elsif tool_arguments_path?(current_path)
+          # EXCEPTION: same left-to-right override guarantee as the list + list
+          # case above applies here too, even though this mixin value is a
+          # single value rather than the expected Array.
+          config[key] = config_val + [mixin_val]
         else
           # Mixin has a single value (or hash treated as a value) where config
           # has a list. Wrap the mixin value in a one-element list and prepend

--- a/spec/system/mixin_ordering_spec.rb
+++ b/spec/system/mixin_ordering_spec.rb
@@ -252,6 +252,60 @@ ceedling_system_tests do
       expect(pos_1).to be < pos_2
       expect(pos_2).to be < pos_3
     end
+
+    it 'reflects ascending env var merge order in the actual merged array content, not just log position' do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          File.write('mixin/array_mixin_1.yml', ARRAY_MIXIN_1)
+          File.write('mixin/array_mixin_2.yml', ARRAY_MIXIN_2)
+          File.write('mixin/array_mixin_3.yml', ARRAY_MIXIN_3)
+          ENV['CEEDLING_MIXIN_1'] = convert_slashes('mixin/array_mixin_1.yml')
+          ENV['CEEDLING_MIXIN_2'] = convert_slashes('mixin/array_mixin_2.yml')
+          ENV['CEEDLING_MIXIN_3'] = convert_slashes('mixin/array_mixin_3.yml')
+
+          dump_file = 'dump_array_order.yml'
+          @c.ceedling_appcmd_exec("dumpconfig --no-app #{dump_file}")
+          @dump_config = File.exist?(dump_file) ? YAML.load(File.read(dump_file)) : {}
+        end
+      end
+
+      # Each higher-priority (later-merged) mixin's list entries are prepended
+      # ahead of everything already accumulated, so the highest-numbered env
+      # var's marker ends up earliest in the final array.
+      enabled = @dump_config.dig(:plugins, :enabled)
+      expect(enabled.index('marker_from_mixin_3')).to be < enabled.index('marker_from_mixin_2')
+      expect(enabled.index('marker_from_mixin_2')).to be < enabled.index('marker_from_mixin_1')
+    end
+  end
+
+  # =========================================================================
+  describe 'Mixin loading :: same-source duplicate --mixin ordering' do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec('example temp_sensor')
+      end
+    end
+
+    it 'resolves a repeated --mixin value at its last-typed position, not its first' do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          File.write('mixin/mixin_foo.yml', SCALAR_MIXIN_LOW)
+          File.write('mixin/mixin_bar.yml', SCALAR_MIXIN_HIGH)
+
+          dump_file = 'dump_duplicate_ordering.yml'
+          @c.ceedling_appcmd_exec(
+            "dumpconfig --no-app #{dump_file}" \
+            " --mixin #{convert_slashes('mixin/mixin_foo.yml')}" \
+            " --mixin #{convert_slashes('mixin/mixin_bar.yml')}" \
+            " --mixin #{convert_slashes('mixin/mixin_foo.yml')}"
+          )
+          @dump_config = File.exist?(dump_file) ? YAML.load(File.read(dump_file)) : {}
+        end
+      end
+      # mixin_foo.yml was the user's actual last-typed flag -- its value (build_low)
+      # must win, even though mixin_bar.yml (build_high) is the second, distinct flag.
+      expect(@dump_config.dig(:project, :build_root)).to eq('build_low')
+    end
   end
 
   # =========================================================================
@@ -417,6 +471,66 @@ ceedling_system_tests do
   end
 
   # =========================================================================
+  describe 'Mixin loading :: --mixin @ sigil (explicit file/name reference)' do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec('example temp_sensor')
+      end
+    end
+
+    it 'loads a file the same way an unprefixed --mixin value would' do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          File.write('mixin/at_sigil.yml', SCALAR_MIXIN_HIGH)
+
+          dump_file = 'dump_at_sigil.yml'
+          @c.ceedling_appcmd_exec(
+            "dumpconfig --no-app #{dump_file} --mixin @#{convert_slashes('mixin/at_sigil.yml')}"
+          )
+          @dump_config = File.exist?(dump_file) ? YAML.load(File.read(dump_file)) : {}
+        end
+      end
+      expect(@dump_config.dig(:project, :build_root)).to eq('build_high')
+    end
+  end
+
+  # =========================================================================
+  describe 'Mixin loading :: :tools arguments append exception' do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec('example temp_sensor')
+      end
+    end
+
+    it 'appends mixin :arguments after existing config :arguments instead of prepending' do
+      mixin_content = <<~YAML
+        :tools:
+          :test_compiler:
+            :arguments:
+              - -DMIXIN_ARG
+      YAML
+
+      @c.with_context do
+        Dir.chdir @proj_name do
+          File.write('mixin/tool_args.yml', mixin_content)
+          @c.merge_project_yml_for_test({
+            tools: {test_compiler: {arguments: ['-DBASE_ARG']}}
+          })
+
+          dump_file = 'dump_tool_args.yml'
+          @c.ceedling_appcmd_exec(
+            "dumpconfig --no-app #{dump_file} --mixin #{convert_slashes('mixin/tool_args.yml')}"
+          )
+          @dump_config = File.exist?(dump_file) ? YAML.load(File.read(dump_file)) : {}
+        end
+      end
+      # -DMIXIN_ARG must come after -DBASE_ARG so it takes effect left-to-right
+      arguments = @dump_config.dig(:tools, :test_compiler, :arguments)
+      expect(arguments.index('-DBASE_ARG')).to be < arguments.index('-DMIXIN_ARG')
+    end
+  end
+
+  # =========================================================================
   describe 'Mixin loading :: project directory as default load path' do
     before do
       @c.with_context do
@@ -431,6 +545,7 @@ ceedling_system_tests do
         Dir.chdir @proj_name do
           FileUtils.rm_f('no_stdlib.yml')
           FileUtils.rm_f('project_mixin.yml')
+          FileUtils.rm_rf('user_mixins')
         end
       end
     end
@@ -462,6 +577,28 @@ ceedling_system_tests do
       defines_test = @dump_config.dig(:defines, :test)
       defines_list = defines_test.is_a?(Hash) ? defines_test.values.flatten : Array(defines_test)
       expect(defines_list).to include('PROJECT_DIR_GCC64_WINS')
+      expect(defines_list).not_to include('UNITY_EXCLUDE_STDINT_H')
+    end
+
+    it 'user-configured :load_paths wins over both the project directory and unity/targets for the same name' do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          FileUtils.mkdir_p('user_mixins')
+          File.write('user_mixins/no_stdlib.yml', ":defines:\n  :test:\n    - USER_LOAD_PATH_WINS\n")
+          # Also shadow the same name in the project directory to confirm the
+          # user load path -- checked first -- still takes priority over it.
+          File.write('no_stdlib.yml', ":defines:\n  :test:\n    - PROJECT_DIR_GCC64_WINS\n")
+          @c.merge_project_yml_for_test({mixins: {load_paths: ['user_mixins']}})
+
+          dump_file = 'dump_user_load_path_wins.yml'
+          @c.ceedling_appcmd_exec("dumpconfig --no-app #{dump_file} --mixin no_stdlib")
+          @dump_config = File.exist?(dump_file) ? YAML.load(File.read(dump_file)) : {}
+        end
+      end
+      defines_test = @dump_config.dig(:defines, :test)
+      defines_list = defines_test.is_a?(Hash) ? defines_test.values.flatten : Array(defines_test)
+      expect(defines_list).to include('USER_LOAD_PATH_WINS')
+      expect(defines_list).not_to include('PROJECT_DIR_GCC64_WINS')
       expect(defines_list).not_to include('UNITY_EXCLUDE_STDINT_H')
     end
   end
@@ -504,6 +641,62 @@ ceedling_system_tests do
       defines_test = @dump_config.dig(:defines, :test)
       defines_list = defines_test.is_a?(Hash) ? defines_test.values.flatten : Array(defines_test)
       expect(defines_list).to include('UNITY_EXCLUDE_STDINT_H')
+    end
+
+    # Each named built-in toolchain target under vendor/unity/test/targets/,
+    # loaded by name with no :load_paths configuration -- one distinctive
+    # setting per target confirms the right file was actually found and merged.
+    {
+      'clang'         => [[:tools, :test_compiler, :executable], 'clang'],
+      'gcc'           => [[:tools, :test_compiler, :executable], 'gcc'],
+      'hitech_picc18' => [[:tools, :test_compiler, :executable], 'cd build && picc18'],
+      'iar_arm'       => [[:iar_config], nil],
+    }.each do |target_name, (key_path, expected)|
+      it "loads the built-in '#{target_name}' toolchain target by name" do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            dump_file = "dump_target_#{target_name}.yml"
+            @c.ceedling_appcmd_exec("dumpconfig --no-app #{dump_file} --mixin #{target_name}")
+            @dump_config = File.exist?(dump_file) ? YAML.load(File.read(dump_file)) : {}
+          end
+        end
+        if expected.nil?
+          expect(@dump_config.dig(*key_path)).to_not be_nil
+        else
+          expect(@dump_config.dig(*key_path)).to eq(expected)
+        end
+      end
+    end
+  end
+
+  # =========================================================================
+  describe 'Mixin loading :: :extension ↳ :yaml override' do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec('example temp_sensor')
+      end
+    end
+
+    after do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          FileUtils.rm_f('custom_ext_mixin.yaml')
+        end
+      end
+    end
+
+    it 'finds a mixin by name using the configured :extension ↳ :yaml, not the default .yml' do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          File.write('custom_ext_mixin.yaml', ":project:\n  :build_root: from_custom_extension\n")
+          @c.merge_project_yml_for_test({extension: {yaml: '.yaml'}})
+
+          dump_file = 'dump_custom_extension.yml'
+          @c.ceedling_appcmd_exec("dumpconfig --no-app #{dump_file} --mixin custom_ext_mixin")
+          @dump_config = File.exist?(dump_file) ? YAML.load(File.read(dump_file)) : {}
+        end
+      end
+      expect(@dump_config.dig(:project, :build_root)).to eq('from_custom_extension')
     end
   end
 

--- a/spec/units/bin/composinator_spec.rb
+++ b/spec/units/bin/composinator_spec.rb
@@ -1,0 +1,83 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'composinator'
+require 'ceedling/constants'
+
+describe Composinator do
+  before(:each) do
+    @config_walkinator = double('config_walkinator')
+    @projectinator      = double('projectinator')
+    @mixinator          = double('mixinator')
+
+    @composinator = described_class.new({
+      :config_walkinator => @config_walkinator,
+      :projectinator     => @projectinator,
+      :mixinator         => @mixinator,
+    })
+  end
+
+  # Stubs every collaborator #loadinate touches except assemble_mixins, so a
+  # test can observe exactly what cmdline sequence reaches it without needing
+  # a real project file, real mixin files, or real YAML.
+  def stub_loadinate_pipeline(config: {})
+    allow(@projectinator).to receive(:load).and_return( ['/proj/project.yml', config] )
+    allow(@projectinator).to receive(:extract_mixins).and_return( [[], []] )
+    allow(@projectinator).to receive(:lookup_yaml_extension).and_return( '.yml' )
+    allow(@projectinator).to receive(:validate_mixin_load_paths)
+    allow(@projectinator).to receive(:validate_mixins).and_return( true )
+    allow(@projectinator).to receive(:lookup_mixins) {|mixins:, **| mixins }
+    allow(@mixinator).to receive(:validate_cmdline_yaml_strings)
+    allow(@mixinator).to receive(:fetch_env_filepaths).and_return( [] )
+    allow(@mixinator).to receive(:validate_env_filepaths)
+    allow(@mixinator).to receive(:mixin)
+  end
+
+  describe '#loadinate -- cmdline mixin ordering' do
+    it 'positions a repeated --mixin value at its last-typed occurrence, not its first' do
+      stub_loadinate_pipeline
+
+      captured_cmdline = nil
+      allow(@mixinator).to receive(:assemble_mixins) do |config:, env:, cmdline:|
+        captured_cmdline = cmdline
+        []
+      end
+
+      @composinator.loadinate(
+        builtin_mixins: {},
+        filepath: 'project.yml',
+        mixins: ['foo.yml', 'bar.yml', 'foo.yml'],
+        env: {}
+      )
+
+      # The user's actual last-typed flag was `foo.yml` -- it must end up last
+      # (highest priority), with `bar.yml` before it, and the earlier, now-
+      # superseded `foo.yml` occurrence dropped entirely.
+      expect(captured_cmdline.map {|e| e[:_input]}).to eq(['bar.yml', 'foo.yml'])
+    end
+
+    it 'leaves distinct cmdline mixin values in their original left-to-right order' do
+      stub_loadinate_pipeline
+
+      captured_cmdline = nil
+      allow(@mixinator).to receive(:assemble_mixins) do |config:, env:, cmdline:|
+        captured_cmdline = cmdline
+        []
+      end
+
+      @composinator.loadinate(
+        builtin_mixins: {},
+        filepath: 'project.yml',
+        mixins: ['foo.yml', 'bar.yml', 'baz.yml'],
+        env: {}
+      )
+
+      expect(captured_cmdline.map {|e| e[:_input]}).to eq(['foo.yml', 'bar.yml', 'baz.yml'])
+    end
+  end
+end

--- a/spec/units/bin/composinator_spec.rb
+++ b/spec/units/bin/composinator_spec.rb
@@ -49,7 +49,6 @@ describe Composinator do
       end
 
       @composinator.loadinate(
-        builtin_mixins: {},
         filepath: 'project.yml',
         mixins: ['foo.yml', 'bar.yml', 'foo.yml'],
         env: {}
@@ -71,7 +70,6 @@ describe Composinator do
       end
 
       @composinator.loadinate(
-        builtin_mixins: {},
         filepath: 'project.yml',
         mixins: ['foo.yml', 'bar.yml', 'baz.yml'],
         env: {}

--- a/spec/units/bin/composinator_spec.rb
+++ b/spec/units/bin/composinator_spec.rb
@@ -8,10 +8,14 @@
 require 'spec_helper'
 require 'composinator'
 require 'ceedling/constants'
+require 'ceedling/config/config_walkinator'
+require 'deep_merge'
 
 describe Composinator do
   before(:each) do
-    @config_walkinator = double('config_walkinator')
+    # Real instance -- simple utility class with no dependencies of its own,
+    # and #default_tasks's behavior is easiest to verify accurately this way.
+    @config_walkinator = ConfigWalkinator.new
     @projectinator      = double('projectinator')
     @mixinator          = double('mixinator')
 
@@ -76,6 +80,156 @@ describe Composinator do
       )
 
       expect(captured_cmdline.map {|e| e[:_input]}).to eq(['foo.yml', 'bar.yml', 'baz.yml'])
+    end
+  end
+
+  describe '#loadinate -- return value' do
+    it 'returns the project filepath and the loaded config hash' do
+      config = {}
+      stub_loadinate_pipeline(config: config)
+      allow(@mixinator).to receive(:assemble_mixins).and_return( [] )
+
+      filepath, returned_config = @composinator.loadinate(
+        filepath: 'project.yml',
+        mixins: [],
+        env: {}
+      )
+
+      expect(filepath).to eq('/proj/project.yml')
+      expect(returned_config).to equal(config)
+    end
+  end
+
+  describe '#loadinate -- --mixin sigil parsing' do
+    it 'strips the = sigil and routes the value to inline YAML validation' do
+      stub_loadinate_pipeline
+
+      captured_yaml_strings = nil
+      allow(@mixinator).to receive(:validate_cmdline_yaml_strings) {|strings| captured_yaml_strings = strings }
+      allow(@mixinator).to receive(:assemble_mixins).and_return( [] )
+
+      @composinator.loadinate(
+        filepath: 'project.yml',
+        mixins: ['=:project: {}'],
+        env: {}
+      )
+
+      expect(captured_yaml_strings).to eq([':project: {}'])
+    end
+
+    it 'strips the @ sigil and treats the value as an ordinary file/name reference' do
+      stub_loadinate_pipeline
+
+      captured_cmdline = nil
+      allow(@mixinator).to receive(:assemble_mixins) do |cmdline:, **|
+        captured_cmdline = cmdline
+        []
+      end
+
+      @composinator.loadinate(
+        filepath: 'project.yml',
+        mixins: ['@explicit.yml'],
+        env: {}
+      )
+
+      expect(captured_cmdline.map {|e| e[:_input]}).to eq(['explicit.yml'])
+    end
+
+    it 'treats a value with no sigil the same as an @-prefixed value' do
+      stub_loadinate_pipeline
+
+      captured_cmdline = nil
+      allow(@mixinator).to receive(:assemble_mixins) do |cmdline:, **|
+        captured_cmdline = cmdline
+        []
+      end
+
+      @composinator.loadinate(
+        filepath: 'project.yml',
+        mixins: ['plain_name'],
+        env: {}
+      )
+
+      expect(captured_cmdline.map {|e| e[:_input]}).to eq(['plain_name'])
+    end
+
+    it 'preserves left-to-right order across a mix of inline YAML, @, and bare entries' do
+      stub_loadinate_pipeline
+
+      captured_cmdline = nil
+      allow(@mixinator).to receive(:validate_cmdline_yaml_strings)
+      allow(@mixinator).to receive(:assemble_mixins) do |cmdline:, **|
+        captured_cmdline = cmdline
+        []
+      end
+
+      @composinator.loadinate(
+        filepath: 'project.yml',
+        mixins: ['@explicit.yml', '=:key: value', 'plain_name'],
+        env: {}
+      )
+
+      expect(captured_cmdline.map {|e| e[:_input]}).to eq(['explicit.yml', ':key: value', 'plain_name'])
+    end
+  end
+
+  describe '#loadinate -- load path precedence' do
+    it 'orders load paths as user :load_paths, then project directory, then built-in paths' do
+      stub_loadinate_pipeline
+      allow(@projectinator).to receive(:extract_mixins).and_return( [[], ['user/path']] )
+
+      captured_load_paths = nil
+      allow(@projectinator).to receive(:lookup_mixins) do |load_paths:, **|
+        captured_load_paths = load_paths
+        []
+      end
+      allow(@mixinator).to receive(:assemble_mixins).and_return( [] )
+
+      @composinator.loadinate(
+        builtin_load_paths: ['builtin/path'],
+        filepath: 'project.yml',
+        mixins: [],
+        env: {}
+      )
+
+      expect(captured_load_paths).to eq(['user/path', '/proj', 'builtin/path'])
+    end
+  end
+
+  describe '#default_tasks' do
+    it 'uses config :project ↳ :default_tasks when present' do
+      config = {:project => {:default_tasks => ['test:all', 'release']}}
+
+      result = @composinator.default_tasks( config: config, default_tasks: ['test:all'] )
+
+      expect(result).to eq(['test:all', 'release'])
+    end
+
+    it 'returns a copy of the config value rather than the same Array object' do
+      config_tasks = ['test:all']
+      config = {:project => {:default_tasks => config_tasks}}
+
+      result = @composinator.default_tasks( config: config, default_tasks: [] )
+
+      expect(result).to_not equal(config_tasks)
+    end
+
+    it 'falls back to the given default and records it in config when :default_tasks is absent' do
+      config = {}
+
+      result = @composinator.default_tasks( config: config, default_tasks: ['test:all'] )
+
+      expect(result).to eq(['test:all'])
+      expect(config[:project][:default_tasks]).to eq(['test:all'])
+    end
+
+    it 'preserves other existing :project keys when recording the fallback default' do
+      config = {:project => {:build_root => 'build'}}
+
+      @composinator.default_tasks( config: config, default_tasks: ['test:all'] )
+
+      expect(config[:project][:build_root]).to eq('build')
+      expect(config[:project][:default_tasks]).to eq(['test:all'])
     end
   end
 end

--- a/spec/units/bin/mixin_standardizer_spec.rb
+++ b/spec/units/bin/mixin_standardizer_spec.rb
@@ -152,8 +152,9 @@ describe MixinStandardizer do
         :flags => {
           :test => {
             :compile => {
-              # All-matches string-based matcher hash that could occur in wild (:* is preferred)
-              '*' => ['-pedantic']
+              # By the time smart_standardize runs, Mixinator#mixin has already
+              # symbolized every mixin key, so this is always :* here, never '*'
+              :* => ['-pedantic']
             }
           }
         },
@@ -203,7 +204,7 @@ describe MixinStandardizer do
         :flags => {
           :test => {
             :compile => {
-              # Unchanged compilation flag matcher hash but standardized to use matcher symbol key
+              # Unchanged compilation flag matcher hash
               :* => ['-pedantic']
             }
           }

--- a/spec/units/bin/mixinator_spec.rb
+++ b/spec/units/bin/mixinator_spec.rb
@@ -405,7 +405,6 @@ describe Mixinator do
   # =========================================================================
   describe '#mixin' do
     let(:base_config) { {:project => {:build_root => 'build'}} }
-    let(:builtins)    { {:my_builtin => {:foo => :bar}} }
 
     it 'loads a filepath mixin via yaml_wrapper and merges it into config' do
       mixin_filepath = 'path/to/mixin.yml'
@@ -418,22 +417,21 @@ describe Mixinator do
       ).and_return(true)
 
       @mixinator.mixin(
-        builtins: builtins,
         config:   base_config,
         mixins:   [{'command line' => mixin_filepath}]
       )
     end
 
-    it 'looks up a builtin mixin by name and merges its content into config' do
-      expect(@merginator).to receive(:merge).with(
-        hash_including(mixin: {:foo => :bar})
-      ).and_return(true)
-
-      @mixinator.mixin(
-        builtins: builtins,
-        config:   base_config,
-        mixins:   [{'command line' => 'my_builtin'}]
-      )
+    it 'raises when a mixin entry resolves to neither inline YAML nor a filepath' do
+      # lookup_mixins() only ever hands back inline YAML or a real filepath for
+      # validated input -- reaching neither here means something upstream let
+      # an unresolved bare name through.
+      expect {
+        @mixinator.mixin(
+          config: base_config,
+          mixins: [{'command line' => 'unresolved_name'}]
+        )
+      }.to raise_error( /unresolved_name/ )
     end
 
     it 'logs a WARNING when a loaded mixin contains a :mixins section' do
@@ -450,7 +448,6 @@ describe Mixinator do
       )
 
       @mixinator.mixin(
-        builtins: builtins,
         config:   base_config,
         mixins:   [{'command line' => mixin_filepath}]
       )
@@ -471,7 +468,6 @@ describe Mixinator do
       end
 
       @mixinator.mixin(
-        builtins: builtins,
         config:   base_config,
         mixins:   [{'command line' => mixin_filepath}]
       )
@@ -490,7 +486,6 @@ describe Mixinator do
 
       expect {
         @mixinator.mixin(
-          builtins: builtins,
           config:   base_config,
           mixins:   [{'command line' => mixin_filepath}]
         )
@@ -502,7 +497,6 @@ describe Mixinator do
 
       expect {
         @mixinator.mixin(
-          builtins: builtins,
           config:   {},
           mixins:   [{'command line' => 'path/to/mixin.yml'}]
         )
@@ -520,7 +514,6 @@ describe Mixinator do
       expect(@loginator).to receive(:log).at_least(:twice)
 
       @mixinator.mixin(
-        builtins: builtins,
         config:   base_config,
         mixins:   [{'command line' => mixin_filepath}]
       )
@@ -541,7 +534,6 @@ describe Mixinator do
       )
 
       @mixinator.mixin(
-        builtins: builtins,
         config:   base_config,
         mixins:   [{'command line' => mixin_filepath}]
       )
@@ -560,7 +552,6 @@ describe Mixinator do
       ).and_return(true)
 
       @mixinator.mixin(
-        builtins: builtins,
         config:   base_config,
         mixins:   [{'command line (inline)' => yaml_string}]
       )
@@ -571,7 +562,6 @@ describe Mixinator do
       allow(@yaml_wrapper).to receive(:load_string).and_return({:defines => {:release => ['MY_SYM']}})
 
       @mixinator.mixin(
-        builtins: builtins,
         config:   base_config,
         mixins:   [{'command line (inline)' => yaml_string, :_input => yaml_string}]
       )
@@ -601,7 +591,6 @@ describe Mixinator do
       )
 
       @mixinator.mixin(
-        builtins: builtins,
         config:   base_config,
         mixins:   [{'command line (inline)' => yaml_string}]
       )

--- a/spec/units/bin/mixinator_spec.rb
+++ b/spec/units/bin/mixinator_spec.rb
@@ -98,6 +98,36 @@ describe Mixinator do
         expect(result.first.keys.first).to eq('CEEDLING_MIXIN_1')
       end
     end
+
+    it 'treats a leading zero the same as no leading zero' do
+      env = {'CEEDLING_MIXIN_01' => 'path/to/mixin.yml'}
+      result = @mixinator.fetch_env_filepaths(env)
+      expect(result).to eq([{'CEEDLING_MIXIN_01' => 'path/to/mixin.yml'}])
+    end
+
+    it 'sorts a leading-zero variable numerically alongside ordinary ones' do
+      env = {
+        'CEEDLING_MIXIN_10' => 'path/mixin10.yml',
+        'CEEDLING_MIXIN_01' => 'path/mixin01.yml',
+        'CEEDLING_MIXIN_2'  => 'path/mixin2.yml',
+      }
+      result = @mixinator.fetch_env_filepaths(env)
+      expect(result.map { |e| e.keys.first }).to eq([
+        'CEEDLING_MIXIN_01',
+        'CEEDLING_MIXIN_2',
+        'CEEDLING_MIXIN_10'
+      ])
+    end
+
+    it 'raises a clear error for a malformed mixin variable name instead of crashing' do
+      env = {'CEEDLING_MIXIN_1_OLD' => 'path/to/mixin.yml'}
+      expect { @mixinator.fetch_env_filepaths(env) }.to raise_error( /CEEDLING_MIXIN_1_OLD/ )
+    end
+
+    it 'raises a clear error for a non-numeric mixin variable suffix' do
+      env = {'CEEDLING_MIXIN_ABC' => 'path/to/mixin.yml'}
+      expect { @mixinator.fetch_env_filepaths(env) }.to raise_error( /CEEDLING_MIXIN_ABC/ )
+    end
   end
 
   # =========================================================================

--- a/spec/units/bin/projectinator_mixin_spec.rb
+++ b/spec/units/bin/projectinator_mixin_spec.rb
@@ -206,14 +206,12 @@ describe Projectinator do
 
   # =========================================================================
   describe '#lookup_mixins' do
-    let(:builtins)       { {:builtin_mixin => {:foo => :bar}} }
     let(:yaml_extension) { '.yml' }
 
     it 'returns empty array for an empty mixin list' do
       result = @projectinator.lookup_mixins(
         mixins:         [],
         load_paths:     ['support/mixins'],
-        builtins:       builtins,
         yaml_extension: yaml_extension
       )
       expect(result).to eq([])
@@ -225,7 +223,6 @@ describe Projectinator do
       result = @projectinator.lookup_mixins(
         mixins:         ['path/to/mixin.yml'],
         load_paths:     ['support/mixins'],
-        builtins:       builtins,
         yaml_extension: yaml_extension
       )
       expect(result).to eq(['path/to/mixin.yml'])
@@ -238,7 +235,6 @@ describe Projectinator do
       result = @projectinator.lookup_mixins(
         mixins:         ['my_mixin'],
         load_paths:     ['first/path', 'second/path'],
-        builtins:       builtins,
         yaml_extension: yaml_extension
       )
       expect(result).to eq(['first/path/my_mixin.yml'])
@@ -252,23 +248,21 @@ describe Projectinator do
       result = @projectinator.lookup_mixins(
         mixins:         ['my_mixin'],
         load_paths:     ['first/path', 'second/path'],
-        builtins:       builtins,
         yaml_extension: yaml_extension
       )
       expect(result).to eq(['second/path/my_mixin.yml'])
     end
 
-    it 'returns the name unchanged when not found in any load_path (treated as builtin)' do
-      allow(@path_validator).to receive(:filepath?).with('builtin_mixin').and_return(false)
+    it 'returns the name unchanged when not found in any load_path' do
+      allow(@path_validator).to receive(:filepath?).with('unresolved_name').and_return(false)
       allow(@file_wrapper).to receive(:exist?).and_return(false)
 
       result = @projectinator.lookup_mixins(
-        mixins:         ['builtin_mixin'],
+        mixins:         ['unresolved_name'],
         load_paths:     ['support/mixins'],
-        builtins:       builtins,
         yaml_extension: yaml_extension
       )
-      expect(result).to eq(['builtin_mixin'])
+      expect(result).to eq(['unresolved_name'])
     end
 
     it 'preserves input ordering across a mix of filepaths and simple names' do
@@ -279,7 +273,6 @@ describe Projectinator do
       result = @projectinator.lookup_mixins(
         mixins:         ['explicit.yml', 'named_mixin'],
         load_paths:     ['support'],
-        builtins:       builtins,
         yaml_extension: yaml_extension
       )
       expect(result).to eq(['explicit.yml', 'support/named_mixin.yml'])
@@ -288,7 +281,6 @@ describe Projectinator do
 
   # =========================================================================
   describe '#validate_mixins' do
-    let(:builtins)       { {:builtin_mixin => {:foo => :bar}} }
     let(:yaml_extension) { '.yml' }
 
     it 'returns true for a mixin filepath that exists' do
@@ -298,7 +290,6 @@ describe Projectinator do
       result = @projectinator.validate_mixins(
         mixins:         ['path/to/mixin.yml'],
         load_paths:     [],
-        builtins:       builtins,
         source:         'Test',
         yaml_extension: yaml_extension
       )
@@ -317,7 +308,6 @@ describe Projectinator do
       result = @projectinator.validate_mixins(
         mixins:         ['missing/mixin.yml'],
         load_paths:     [],
-        builtins:       builtins,
         source:         'Test',
         yaml_extension: yaml_extension
       )
@@ -331,21 +321,6 @@ describe Projectinator do
       result = @projectinator.validate_mixins(
         mixins:         ['my_mixin'],
         load_paths:     ['support'],
-        builtins:       builtins,
-        source:         'Test',
-        yaml_extension: yaml_extension
-      )
-      expect(result).to be true
-    end
-
-    it 'returns true for a simple mixin name matching a builtin key' do
-      allow(@path_validator).to receive(:filepath?).with('builtin_mixin').and_return(false)
-      allow(@file_wrapper).to receive(:exist?).and_return(false)
-
-      result = @projectinator.validate_mixins(
-        mixins:         ['builtin_mixin'],
-        load_paths:     [],
-        builtins:       builtins,
         source:         'Test',
         yaml_extension: yaml_extension
       )
@@ -364,7 +339,6 @@ describe Projectinator do
       result = @projectinator.validate_mixins(
         mixins:         ['unknown_mixin'],
         load_paths:     ['support'],
-        builtins:       builtins,
         source:         'Test',
         yaml_extension: yaml_extension
       )
@@ -383,7 +357,6 @@ describe Projectinator do
       result = @projectinator.validate_mixins(
         mixins:         ['good/mixin.yml', 'bad/mixin.yml'],
         load_paths:     [],
-        builtins:       builtins,
         source:         'Test',
         yaml_extension: yaml_extension
       )

--- a/spec/units/bin/projectinator_mixin_spec.rb
+++ b/spec/units/bin/projectinator_mixin_spec.rb
@@ -22,7 +22,12 @@ describe Projectinator do
     allow(@file_wrapper).to receive(:directory?).and_return(false)
 
     @path_validator = double('path_validator')
-    allow(@path_validator).to receive(:standardize_paths)
+    # Mirrors PathValidator#standardize_paths's real backslash-to-forward-slash
+    # behavior closely enough for these specs -- most fixtures have no
+    # backslashes, so this is a no-op pass-through for them.
+    allow(@path_validator).to receive(:standardize_paths) do |*paths|
+      paths.map {|p| (p.nil? || p.empty?) ? p : p.gsub("\\", '/') }
+    end
     allow(@path_validator).to receive(:filepath?).and_return(false)
     allow(@path_validator).to receive(:validate).and_return(true)
 
@@ -153,6 +158,32 @@ describe Projectinator do
 
       expect(enabled).to eq(['plain_mixin'])
       expect(load_paths).to eq(['plain/path'])
+    end
+
+    it 'standardizes Windows backslashes in :enabled entries, matching cmdline/env mixin handling' do
+      config = {
+        :mixins => {
+          :enabled    => ['mixin\\dir\\clang.yml'],
+          :load_paths => []
+        }
+      }
+
+      enabled, _ = @projectinator.extract_mixins(config: config)
+
+      expect(enabled).to eq(['mixin/dir/clang.yml'])
+    end
+
+    it 'standardizes Windows backslashes in :load_paths entries, matching cmdline/env mixin handling' do
+      config = {
+        :mixins => {
+          :enabled    => [],
+          :load_paths => ['support\\mixins']
+        }
+      }
+
+      _, load_paths = @projectinator.extract_mixins(config: config)
+
+      expect(load_paths).to eq(['support/mixins'])
     end
 
     it 'raises CeedlingException when an entry contains inline Ruby and the feature is disabled' do

--- a/spec/units/bin/projectinator_spec.rb
+++ b/spec/units/bin/projectinator_spec.rb
@@ -1,0 +1,175 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'projectinator'
+require 'ceedling/constants'
+require 'ceedling/exceptions'
+
+# Covers Projectinator's namesake responsibility -- discovering and loading the
+# project file itself -- as opposed to projectinator_mixin_spec.rb, which
+# covers its :mixins section handling.
+describe Projectinator do
+  before(:each) do
+    @loginator = double('loginator')
+    allow(@loginator).to receive(:lazy)
+    allow(@loginator).to receive(:log)
+
+    @file_wrapper = double('file_wrapper')
+    allow(@file_wrapper).to receive(:exist?).and_return(false)
+
+    @path_validator = double('path_validator')
+    allow(@path_validator).to receive(:standardize_paths) do |*paths|
+      paths.map {|p| (p.nil? || p.empty?) ? p : p.gsub("\\", '/') }
+    end
+
+    @yaml_wrapper = double('yaml_wrapper')
+
+    @system_wrapper = double('system_wrapper')
+    @ruby_expandinator = double('ruby_expandinator')
+
+    @projectinator = described_class.new({
+      :file_wrapper      => @file_wrapper,
+      :path_validator    => @path_validator,
+      :yaml_wrapper      => @yaml_wrapper,
+      :loginator         => @loginator,
+      :system_wrapper    => @system_wrapper,
+      :ruby_expandinator => @ruby_expandinator,
+    })
+  end
+
+  # =========================================================================
+  describe '#load' do
+    it 'loads from an explicit filepath argument at highest priority' do
+      allow(@yaml_wrapper).to receive(:load).with('/abs/custom.yml').and_return({:project => {}})
+
+      filepath, config = @projectinator.load( filepath: '/abs/custom.yml', env: {'CEEDLING_PROJECT_FILE' => 'ignored.yml'} )
+
+      expect(filepath).to eq('/abs/custom.yml')
+      expect(config[:project]).to eq({})
+    end
+
+    it 'records cmdline-argument history with the original (non-expanded) path' do
+      allow(@yaml_wrapper).to receive(:load).and_return({})
+
+      _, config = @projectinator.load( filepath: 'custom.yml' )
+      # File.expand_path resolves relative to the real working directory, so
+      # only assert on the structure, not the exact absolute path.
+      entry = config[:history][:config].first
+      expect(entry[:type]).to eq(:file)
+      expect(entry[:mechanism]).to eq(:project)
+      expect(entry[:path]).to eq('custom.yml')
+    end
+
+    it 'falls back to the environment variable when no filepath argument is given' do
+      allow(@yaml_wrapper).to receive(:load).with('/abs/env_project.yml').and_return({:project => {}})
+
+      filepath, config = @projectinator.load( env: {'CEEDLING_PROJECT_FILE' => '/abs/env_project.yml'} )
+
+      expect(filepath).to eq('/abs/env_project.yml')
+      expect(config[:history][:config].first[:mechanism]).to eq(:project)
+    end
+
+    it 'falls back to the default project.yml in the working directory when available' do
+      allow(@file_wrapper).to receive(:exist?).with('./project.yml').and_return(true)
+      allow(@yaml_wrapper).to receive(:load).with(File.expand_path('./project.yml')).and_return({:project => {}})
+
+      filepath, config = @projectinator.load
+
+      expect(filepath).to eq(File.expand_path('./project.yml'))
+      expect(config[:history][:config].first[:mechanism]).to eq(:project)
+    end
+
+    it 'raises when no filepath, env var, or default project.yml is available' do
+      expect {
+        @projectinator.load
+      }.to raise_error( /No project filepath provided/ )
+    end
+
+    it 'treats a blank YAML file as an empty config hash rather than nil' do
+      allow(@yaml_wrapper).to receive(:load).and_return(nil)
+
+      _, config = @projectinator.load( filepath: 'blank.yml' )
+
+      expect(config).to eq({:history => config[:history]})
+    end
+
+    it 'wraps a not-found YAML load failure with a clearer message' do
+      allow(@yaml_wrapper).to receive(:load).and_raise(
+        YamlLoadException.new( reason: :not_found, source: 'missing.yml', original_error: nil, message: 'original message' )
+      )
+
+      expect {
+        @projectinator.load( filepath: 'missing.yml' )
+      }.to raise_error( YamlLoadException, /Could not find project filepath/ )
+    end
+
+    it 'wraps a non-not-found YAML load failure, preserving the original message' do
+      allow(@yaml_wrapper).to receive(:load).and_raise(
+        YamlLoadException.new( reason: :syntax, source: 'broken.yml', original_error: nil, message: 'line 3: bad indentation' )
+      )
+
+      expect {
+        @projectinator.load( filepath: 'broken.yml' )
+      }.to raise_error( YamlLoadException, /line 3: bad indentation/ )
+    end
+
+    it 'logs a loading message when not silent' do
+      allow(@yaml_wrapper).to receive(:load).and_return({})
+
+      expect(@loginator).to receive(:lazy)
+
+      @projectinator.load( filepath: 'project.yml', silent: false )
+    end
+
+    it 'does not log when silent' do
+      allow(@yaml_wrapper).to receive(:load).and_return({})
+
+      expect(@loginator).to_not receive(:lazy)
+
+      @projectinator.load( filepath: 'project.yml', silent: true )
+    end
+  end
+
+  # =========================================================================
+  describe '#config_available?' do
+    it 'returns true when a project file can be loaded' do
+      allow(@yaml_wrapper).to receive(:load).and_return({})
+
+      expect(@projectinator.config_available?( filepath: 'project.yml' )).to eq(true)
+    end
+
+    it 'returns false when no project file can be found' do
+      expect(@projectinator.config_available?).to eq(false)
+    end
+
+    it 'returns false when the found project file fails to load' do
+      allow(@yaml_wrapper).to receive(:load).and_raise(
+        YamlLoadException.new( reason: :syntax, source: 'broken.yml', original_error: nil, message: 'bad yaml' )
+      )
+
+      expect(@projectinator.config_available?( filepath: 'broken.yml' )).to eq(false)
+    end
+  end
+
+  # =========================================================================
+  describe '#lookup_yaml_extension' do
+    it 'returns the default extension when no :extension section is present' do
+      expect(@projectinator.lookup_yaml_extension( config: {} )).to eq('.yml')
+    end
+
+    it 'returns the default extension when :extension is present but :yaml is not' do
+      config = {:extension => {:header => '.h'}}
+      expect(@projectinator.lookup_yaml_extension( config: config )).to eq('.yml')
+    end
+
+    it 'returns the configured :extension ↳ :yaml value when present' do
+      config = {:extension => {:yaml => '.yaml'}}
+      expect(@projectinator.lookup_yaml_extension( config: config )).to eq('.yaml')
+    end
+  end
+end

--- a/spec/units/bin/recursive_merger_spec.rb
+++ b/spec/units/bin/recursive_merger_spec.rb
@@ -160,6 +160,28 @@ describe RecursiveMerger do
   end
 
   # =========================================================================
+  describe '.merge! — single value merged into list (:tools :name :arguments exception)' do
+    it 'appends a single mixin :arguments value instead of prepending it' do
+      # A mixin author writing `:arguments: -O0` (a scalar) instead of the
+      # expected `:arguments: [-O0]` must still get the left-to-right
+      # override guarantee -- appended after config's -O2, not before it.
+      config = {tools: {test_compiler: {arguments: ['-O2']}}}
+      mixin  = {tools: {test_compiler: {arguments: '-O0'}}}
+      expect(merge(config, mixin)).to eq(
+        {tools: {test_compiler: {arguments: ['-O2', '-O0']}}}
+      )
+    end
+
+    it 'still prepends a single mixin value at a non-:arguments list key' do
+      config = {tools: {test_compiler: {other: ['a']}}}
+      mixin  = {tools: {test_compiler: {other: 'b'}}}
+      expect(merge(config, mixin)).to eq(
+        {tools: {test_compiler: {other: ['b', 'a']}}}
+      )
+    end
+  end
+
+  # =========================================================================
   describe '.merge! — single mixin value merged into config list' do
     it 'prepends mixin single string value into config list' do
       config = {foo: ['bar', 'baz']}


### PR DESCRIPTION
## Summary

Phase 2 of the `bin/` code review, refactoring, and test coverage plan (mixins subsystem). Nine commits, each independently reviewable:

1. **Fix `Mixinator#fetch_env_filepaths` crash on malformed env var names** — an unanchored regex let names like `CEEDLING_MIXIN_1_OLD` through as a substring match, then crashed with `NoMethodError` extracting a trailing digit that didn't exist. Also fixes `CEEDLING_MIXIN_01` (leading zero) being silently dropped instead of treated as `CEEDLING_MIXIN_1`.
2. **Fix `RecursiveMerger` prepending non-Array `:tools` arguments values** — the `[:tools, <tool>, :arguments]` left-to-right append exception only applied when both sides were Arrays; a mixin scalar (e.g. `:arguments: -O0` instead of `[-O0]`) fell through to the general prepend rule, silently reversing override precedence.
3. **Standardize Windows backslashes in config `:mixins` section paths** — cmdline and env var mixin paths already got backslash-to-forward-slash treatment; base-config `:mixins ↳ :enabled`/`:load_paths` entries didn't.
4. **Fix same-source repeated `--mixin` value resolving to the wrong position** — `--mixin foo.yml --mixin bar.yml --mixin foo.yml` merged `bar.yml` last (highest priority) even though `foo.yml` was the user's actual last-typed flag. Confirmed via git archaeology as a genuine, previously-unaddressed bug distinct from two earlier ordering fixes (#902, #1128). Highest-scrutiny fix in this phase — verified against both prior regression suites.
5. **Remove dead `BUILTIN_MIXINS` mechanism** — 2024 scaffolding for a hash-based lookup that was never populated; superseded by the fully-working `BUILTIN_MIXIN_LOAD_PATHS` (Unity's `targets/` folder) before ever being wired up.
6. **Remove two more dead mixin code paths** — `Mixinator#validate_cmdline_filepaths` (would have broken name-based mixins like `--mixin clang` if wired in as named) and an unreachable string-to-symbol `'*'` key promotion in `MixinStandardizer`.
7. **Expand `composinator_spec.rb` baseline coverage** — sigil parsing, load path precedence, `#default_tasks`.
8. **Add `Projectinator` core file-loading unit coverage** — `load`, `config_available?`, `lookup_yaml_extension` had zero direct tests.
9. **Expand system-level mixin coverage** — array merge order via actual dumped config content, the same-source duplicate regression, the `:tools` arguments exception, `@` sigil, three-way load path precedence, all four named built-in targets, `:extension ↳ :yaml` override.

## Test plan
- [x] Full unit suite (`bundle exec rspec spec/units`) — 2711 examples, 0 failures
- [x] Targeted system-test verification via `throwtheswitch/madsciencelab-plugins:v1.1.4` (mixin ordering, CLI surface, gem/vendor deployment) — 179 examples, 0 failures
- [x] Manual smoke tests confirming no regression in name-based mixin resolution (`--mixin clang`) or clean error handling for unresolvable names after the `BUILTIN_MIXINS` removal
- [ ] Full CI (unit + system, all platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)