### PR TITLE
bin/ Phase 3: Mixins subsystem structural refactor

### DIFF
--- a/bin/composinator.rb
+++ b/bin/composinator.rb
@@ -5,7 +5,6 @@
 #   SPDX-License-Identifier: MIT
 # =========================================================================
 
-require 'deep_merge'
 require 'ceedling/constants'
 
 class Composinator
@@ -166,8 +165,10 @@ class Composinator
       # Update method parameter to config value
       default_tasks = value.dup()
     else
-      # Set key/value in config if it's not set
-      config.deep_merge( {:project => {:default_tasks => default_tasks}} )
+      # Set key/value in config if it's not set, without disturbing any other
+      # existing :project keys
+      config[:project] ||= {}
+      config[:project][:default_tasks] = default_tasks
     end
 
     return default_tasks

--- a/bin/composinator.rb
+++ b/bin/composinator.rb
@@ -10,7 +10,7 @@ require 'ceedling/constants'
 
 class Composinator
 
-  constructor :config_walkinator, :projectinator, :mixinator
+  constructor :config_walkinator, :projectinator, :mixin_resolvinator, :mixinator
 
   def loadinate(builtin_load_paths:[], filepath:nil, mixins:[], env:{}, silent:false)
     # Aliases for clarity
@@ -21,7 +21,7 @@ class Composinator
     project_filepath, config = @projectinator.load( filepath:cmdline_filepath, env:env, silent:silent )
 
     # Extract cfg_enabled_mixins mixins list plus load paths list from config
-    cfg_enabled_mixins, cfg_load_paths = @projectinator.extract_mixins( config: config )
+    cfg_enabled_mixins, cfg_load_paths = @mixin_resolvinator.extract_mixins( config: config )
 
     # Get our YAML file extension
     yaml_ext = @projectinator.lookup_yaml_extension( config:config )
@@ -59,10 +59,10 @@ class Composinator
     cmdline_file_values.uniq!
 
     # Validate :cfg_load_paths from :mixins section of project configuration
-    @projectinator.validate_mixin_load_paths( cfg_load_paths )
+    @mixin_resolvinator.validate_mixin_load_paths( cfg_load_paths )
 
     # Validate enabled mixins from :mixins section of project configuration
-    if not @projectinator.validate_mixins(
+    if not @mixin_resolvinator.validate_mixins(
       mixins: cfg_enabled_mixins,
       load_paths: cfg_load_paths,
       source: 'Config :mixins ↳ :enabled =>',
@@ -72,7 +72,7 @@ class Composinator
     end
 
     # Validate only file-based cmdline entries; inline YAML is validated separately below
-    if not @projectinator.validate_mixins(
+    if not @mixin_resolvinator.validate_mixins(
       mixins: cmdline_file_values,
       load_paths: cfg_load_paths,
       source: 'Mixin',
@@ -86,7 +86,7 @@ class Composinator
 
     # Find mixins in project file among load paths
     # Return ordered list of filepaths
-    config_mixins = @projectinator.lookup_mixins(
+    config_mixins = @mixin_resolvinator.lookup_mixins(
       mixins: cfg_enabled_mixins,
       load_paths: cfg_load_paths,
       yaml_extension: yaml_ext
@@ -102,7 +102,7 @@ class Composinator
     # Resolve file-based names/paths to canonical filepaths.
     # Returns values in the same order as the input; zip them back into a hash for
     # O(1) lookup when reconstructing positional order below.
-    resolved_file_values = @projectinator.lookup_mixins(
+    resolved_file_values = @mixin_resolvinator.lookup_mixins(
       mixins: cmdline_file_values,
       load_paths: cfg_load_paths,
       yaml_extension: yaml_ext

--- a/bin/mixin_resolvinator.rb
+++ b/bin/mixin_resolvinator.rb
@@ -1,0 +1,132 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'ceedling/constants' # From Ceedling application
+
+class MixinResolvinator
+
+  constructor :file_wrapper, :path_validator, :loginator, :ruby_expandinator
+
+  # Pick apart a :mixins projcet configuration section and return components
+  # Layout mirrors :plugins section
+  def extract_mixins(config:)
+    # Get mixins config hash
+    _mixins = config[:mixins]
+
+    # If no :mixins section, return:
+    #  - Empty enabled list
+    #  - Empty load paths
+    return [], [] if _mixins.nil?
+
+    # Build list of load paths
+    # Configured load paths are higher in search path ordering
+    load_paths = _mixins[:load_paths] || []
+
+    # Get list of mixins
+    enabled = _mixins[:enabled] || []
+    enabled = enabled.clone # Ensure it's a copy of configuration section
+
+    # Handle any inline Ruby string expansion, then standardize Windows backslashes --
+    # cmdline and env var mixin paths already go through standardize_paths elsewhere,
+    # so config :mixins section paths need the same treatment for consistency.
+    load_paths.each do |load_path|
+      load_path.replace( @ruby_expandinator.expand( load_path, source: ":mixins ↳ :load_paths" ) )
+      load_path.replace( @path_validator.standardize_paths( load_path ).first )
+    end
+
+    enabled.each do |mixin|
+      mixin.replace( @ruby_expandinator.expand( mixin, source: ":mixins ↳ :enabled" ) )
+      mixin.replace( @path_validator.standardize_paths( mixin ).first )
+    end
+
+    # Remove the :mixins section of the configuration
+    config.delete( :mixins )
+
+    return enabled, load_paths
+  end
+
+
+  # Validate :load_paths from :mixins section in project configuration
+  def validate_mixin_load_paths(load_paths)
+    validated = @path_validator.validate(
+      paths: load_paths,
+      source: 'Config :mixins ↳ :load_paths =>',
+      type: :directory
+    )
+
+    if !validated
+      raise 'Project configuration file section :mixins failed validation'
+    end
+  end
+
+
+  # Validate mixins list
+  def validate_mixins(mixins:, load_paths:, source:, yaml_extension:)
+    validated = true
+
+    mixins.each do |mixin|
+      # Validate mixin filepaths
+      if @path_validator.filepath?( mixin )
+        if !@file_wrapper.exist?( mixin )
+          @loginator.log( "Cannot find mixin at #{mixin}", Verbosity::ERRORS )
+          validated = false
+        end
+
+      # Otherwise, validate that mixin name can be found in load paths
+      else
+        found = false
+        load_paths.each do |path|
+          if @file_wrapper.exist?( File.join( path, mixin + yaml_extension ) )
+            found = true
+            break
+          end
+        end
+
+        if !found
+          msg = "#{source} '#{mixin}' cannot be found in mixin load paths as '#{mixin + yaml_extension}'"
+          @loginator.log( msg, Verbosity::ERRORS )
+          validated = false
+        end
+      end
+    end
+
+    return validated
+  end
+
+
+  # Yield ordered list of filepaths
+  def lookup_mixins(mixins:, load_paths:, yaml_extension:)
+    _mixins = []
+
+    # Already validated, so we know any mixin filepath or name is found in load_paths
+
+    # Fill filepaths array with filepaths
+    mixins.each do |mixin|
+      # Handle explicit filepaths
+      if @path_validator.filepath?( mixin )
+        _mixins << mixin
+        next # Success, move on in mixin iteration
+      end
+
+      # Look for mixin in load paths.
+      # Move on in mixin iteration if mixin is found.
+      next if load_paths.any? do |path|
+        filepath = File.join( path, mixin + yaml_extension )
+        exist = @file_wrapper.exist?( filepath )
+        _mixins << filepath if exist
+        exist
+      end
+
+      # Finally, fall through to simply add the unmodified name to the list.
+      # validate_mixins() should have already confirmed it exists in load_paths.
+      _mixins << mixin
+    end
+
+    return _mixins
+  end
+
+end

--- a/bin/mixin_standardizer.rb
+++ b/bin/mixin_standardizer.rb
@@ -15,8 +15,11 @@ class MixinStandardizer
 
   def smart_standardize(config:, mixin:, notices:)
     modified = false
-    modified |= smart_standardize_defines(config, mixin, notices)
-    modified |= smart_standardize_flags(config, mixin, notices)
+    # :defines ↳ <context> is one category level deep; :flags ↳ <context> ↳
+    # <operation> is two. Both bottom out at the same matcher-hash-or-array
+    # value standardize_matchers() knows how to reconcile.
+    modified |= smart_standardize_section(config, mixin, notices, :defines, depth: 1)
+    modified |= smart_standardize_section(config, mixin, notices, :flags, depth: 2)
     return modified
   end
 
@@ -24,73 +27,41 @@ class MixinStandardizer
 
   private
 
-  def smart_standardize_defines(config, mixin, notices)
-    modified = false
-    
-    # Bail out if config and mixin do noth both have :defines
-    return false unless config[:defines] && mixin[:defines]
-    
-    # Iterate over :defines ↳ <context> keys
-    # If both config and mixin contain the same key paths, process their (matcher) values
-    config[:defines].each do |context, context_hash|
-      if mixin[:defines][context]
+  # Walks a config section (:defines or :flags) through `depth` levels of
+  # matching category keys shared between config and mixin, then
+  # standardizes matcher conventions at the leaf value.
+  def smart_standardize_section(config, mixin, notices, section, depth:)
+    return false unless config[section] && mixin[section]
 
-        # Standardize :defines ↳ <context> matcher conventions if they differ so they can be merged later
+    modified = false
+
+    walk = lambda do |config_node, mixin_node, path, remaining_depth|
+      config_node.each do |key, value|
+        next unless mixin_node[key]
+
+        current_path = path + [key]
+
+        if remaining_depth > 1
+          walk.call( value, mixin_node[key], current_path, remaining_depth - 1 )
+          next
+        end
+
+        # Standardize matcher conventions at the leaf so they can be merged later
         standardized, notice = standardize_matchers(
-          config[:defines][context],
-          mixin[:defines][context],
-          config[:defines],
-          mixin[:defines],
-          context
+          value, mixin_node[key], config_node, mixin_node, key
         )
 
         if standardized
-          path, _ = @reportinator.generate_config_walk( [:defines, context] )
-          _notice = "At #{path}: #{notice}"
-          notices.push( _notice )
+          full_path, _ = @reportinator.generate_config_walk( [section] + current_path )
+          notices.push( "At #{full_path}: #{notice}" )
         end
 
         modified |= standardized
       end
     end
-    
-    return modified
-  end
 
-  def smart_standardize_flags(config, mixin, notices)
-    modified = false
-    
-    # Bail out if config and mixin do noth both have :flags
-    return false unless config[:flags] && mixin[:flags]
-    
-    # Iterate over :flags ↳ <context> ↳ <operation> keys
-    # If both config and mixin contain the same key paths, process their (matcher) values
-    config[:flags].each do |context, context_hash|
-      next unless mixin[:flags][context]
-      
-      context_hash.each do |operation, operation_hash|
-        if mixin[:flags][context][operation]
+    walk.call( config[section], mixin[section], [], depth )
 
-          # Standardize :flags ↳ <context> ↳ <operation> matcher conventions if they differ so they can be merged later
-          standardized, notice = standardize_matchers(
-            config[:flags][context][operation],
-            mixin[:flags][context][operation],
-            config[:flags][context],
-            mixin[:flags][context],
-            operation
-          )
-
-          if standardized
-            path, _ = @reportinator.generate_config_walk( [:flags, context, operation] )
-            _notice = "At #{path}: #{notice}"
-            notices.push( _notice )
-          end
-
-          modified |= standardized
-        end
-      end
-    end
-    
     return modified
   end
 

--- a/bin/objects.yml
+++ b/bin/objects.yml
@@ -93,13 +93,19 @@ projectinator:
     - path_validator
     - yaml_wrapper
     - loginator
-    - system_wrapper
+
+mixin_resolvinator:
+  compose:
+    - file_wrapper
+    - path_validator
+    - loginator
     - ruby_expandinator
 
 composinator:
   compose:
     - config_walkinator
     - projectinator
+    - mixin_resolvinator
     - mixinator
 
 

--- a/bin/projectinator.rb
+++ b/bin/projectinator.rb
@@ -14,7 +14,7 @@ class Projectinator
   DEFAULT_PROJECT_FILEPATH = './' + DEFAULT_PROJECT_FILENAME
   DEFAULT_YAML_FILE_EXTENSION = '.yml'
 
-  constructor :file_wrapper, :path_validator, :yaml_wrapper, :loginator, :system_wrapper, :ruby_expandinator
+  constructor :file_wrapper, :path_validator, :yaml_wrapper, :loginator
 
   # Discovers project file path and loads configuration.
   # Precendence of attempts:
@@ -85,124 +85,6 @@ class Projectinator
     return config[:extension][:yaml]
   end
 
-
-  # Pick apart a :mixins projcet configuration section and return components
-  # Layout mirrors :plugins section
-  def extract_mixins(config:)
-    # Get mixins config hash
-    _mixins = config[:mixins]
-
-    # If no :mixins section, return:
-    #  - Empty enabled list
-    #  - Empty load paths
-    return [], [] if _mixins.nil?
-
-    # Build list of load paths
-    # Configured load paths are higher in search path ordering
-    load_paths = _mixins[:load_paths] || []
-
-    # Get list of mixins
-    enabled = _mixins[:enabled] || []
-    enabled = enabled.clone # Ensure it's a copy of configuration section
-
-    # Handle any inline Ruby string expansion, then standardize Windows backslashes --
-    # cmdline and env var mixin paths already go through standardize_paths elsewhere,
-    # so config :mixins section paths need the same treatment for consistency.
-    load_paths.each do |load_path|
-      load_path.replace( @ruby_expandinator.expand( load_path, source: ":mixins ↳ :load_paths" ) )
-      load_path.replace( @path_validator.standardize_paths( load_path ).first )
-    end
-
-    enabled.each do |mixin|
-      mixin.replace( @ruby_expandinator.expand( mixin, source: ":mixins ↳ :enabled" ) )
-      mixin.replace( @path_validator.standardize_paths( mixin ).first )
-    end
-
-    # Remove the :mixins section of the configuration
-    config.delete( :mixins )
-
-    return enabled, load_paths
-  end
-
-
-  # Validate :load_paths from :mixins section in project configuration
-  def validate_mixin_load_paths(load_paths)
-    validated = @path_validator.validate(
-      paths: load_paths,
-      source: 'Config :mixins ↳ :load_paths =>',
-      type: :directory
-    )
-
-    if !validated
-      raise 'Project configuration file section :mixins failed validation'
-    end
-  end
-
-
-  # Validate mixins list
-  def validate_mixins(mixins:, load_paths:, source:, yaml_extension:)
-    validated = true
-
-    mixins.each do |mixin|
-      # Validate mixin filepaths
-      if @path_validator.filepath?( mixin )
-        if !@file_wrapper.exist?( mixin )
-          @loginator.log( "Cannot find mixin at #{mixin}", Verbosity::ERRORS )
-          validated = false
-        end
-
-      # Otherwise, validate that mixin name can be found in load paths
-      else
-        found = false
-        load_paths.each do |path|
-          if @file_wrapper.exist?( File.join( path, mixin + yaml_extension ) )
-            found = true
-            break
-          end
-        end
-
-        if !found
-          msg = "#{source} '#{mixin}' cannot be found in mixin load paths as '#{mixin + yaml_extension}'"
-          @loginator.log( msg, Verbosity::ERRORS )
-          validated = false
-        end
-      end
-    end
-
-    return validated
-  end
-
-
-  # Yield ordered list of filepaths
-  def lookup_mixins(mixins:, load_paths:, yaml_extension:)
-    _mixins = []
-
-    # Already validated, so we know any mixin filepath or name is found in load_paths
-
-    # Fill filepaths array with filepaths
-    mixins.each do |mixin|
-      # Handle explicit filepaths
-      if @path_validator.filepath?( mixin )
-        _mixins << mixin
-        next # Success, move on in mixin iteration
-      end
-
-      # Look for mixin in load paths.
-      # Move on in mixin iteration if mixin is found.
-      next if load_paths.any? do |path|
-        filepath = File.join( path, mixin + yaml_extension )
-        exist = @file_wrapper.exist?( filepath )
-        _mixins << filepath if exist
-        exist
-      end
-
-      # Finally, fall through to simply add the unmodified name to the list.
-      # validate_mixins() should have already confirmed it exists in load_paths.
-      _mixins << mixin
-    end
-
-    return _mixins
-  end
 
   ### Private ###
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -49,6 +49,16 @@ The `TEST_SOURCE_FILE()` build directive macro can now be used to remove source 
 ### Filepath limit checks
 Platform filepath limits (especially Windows) can lead to mysterious build failures, especially in CI where deep project subdirectories can occur. To help track down funny business, filepaths are intercepted and their lengths logged if they are nearing or exceed the platform limit.
 
+## 💪 Fixed
+
+- A CLI parameter string mutation issue that could corrupt certain build or plugin task invocations.
+
+### Mixins
+
+- Fixed priority / precedence issues with command line mixin edge case (same mixin provided multiple times).
+- Fixed mixin environment variable name matching issues such as a leading zero for `01` numbering or improperly matching on an environment variable similar to the mixin convention.
+- Fixed an edge case for `tools:` argument special handling merging involving a single string argument instead of list of arguments.
+
 ## ⚠️ Changed
 
 ### `#include` relative paths & duplicate filename disambiguation in test builds
@@ -61,12 +71,9 @@ Because of the support added for handling paths and distinguishing duplicated fi
 
 Historically, Ceedling automatically compiles and links into a test executable any C source file whose name matches an `#include`d header file. Sometimes this convention can select the wrong file among same-named files or compile and link an entirely unwanted source file whose name happens to match a header file.
 
+# [1.1.6] — Prerelease
+
 ## 💪 Fixed
-
-### 1.1.6
-
-1.1.6 is a `master` patch release shipping before 1.2.0; every fix below also
-ships there and is folded into this 1.2.0 prerelease as well.
 
 - [#1223](https://github.com/ThrowTheSwitch/Ceedling/issues/1223) Fixed a conditional `#include` silently dropping out of generated code derived from preprocessed code, breaking compilation with an undeclared identifier error. The specific case involves a macro defined by another header included earlier in the same file.
 - [#1216](https://github.com/ThrowTheSwitch/Ceedling/issues/1216) Fixed self-test issue that caused docs-related failures when the local documentation was unavailable (generated in CI but not necessarily present during self tests).
@@ -77,7 +84,7 @@ ships there and is folded into this 1.2.0 prerelease as well.
 
 ---
 
-# [1.1.5] — Prerelease
+# [1.1.5] — 2026-08-19
 
 ## 💪 Fixed
 

--- a/spec/units/bin/composinator_spec.rb
+++ b/spec/units/bin/composinator_spec.rb
@@ -9,7 +9,6 @@ require 'spec_helper'
 require 'composinator'
 require 'ceedling/constants'
 require 'ceedling/config/config_walkinator'
-require 'deep_merge'
 
 describe Composinator do
   before(:each) do

--- a/spec/units/bin/composinator_spec.rb
+++ b/spec/units/bin/composinator_spec.rb
@@ -15,14 +15,16 @@ describe Composinator do
   before(:each) do
     # Real instance -- simple utility class with no dependencies of its own,
     # and #default_tasks's behavior is easiest to verify accurately this way.
-    @config_walkinator = ConfigWalkinator.new
+    @config_walkinator  = ConfigWalkinator.new
     @projectinator      = double('projectinator')
+    @mixin_resolvinator = double('mixin_resolvinator')
     @mixinator          = double('mixinator')
 
     @composinator = described_class.new({
-      :config_walkinator => @config_walkinator,
-      :projectinator     => @projectinator,
-      :mixinator         => @mixinator,
+      :config_walkinator  => @config_walkinator,
+      :projectinator      => @projectinator,
+      :mixin_resolvinator => @mixin_resolvinator,
+      :mixinator          => @mixinator,
     })
   end
 
@@ -31,11 +33,11 @@ describe Composinator do
   # a real project file, real mixin files, or real YAML.
   def stub_loadinate_pipeline(config: {})
     allow(@projectinator).to receive(:load).and_return( ['/proj/project.yml', config] )
-    allow(@projectinator).to receive(:extract_mixins).and_return( [[], []] )
     allow(@projectinator).to receive(:lookup_yaml_extension).and_return( '.yml' )
-    allow(@projectinator).to receive(:validate_mixin_load_paths)
-    allow(@projectinator).to receive(:validate_mixins).and_return( true )
-    allow(@projectinator).to receive(:lookup_mixins) {|mixins:, **| mixins }
+    allow(@mixin_resolvinator).to receive(:extract_mixins).and_return( [[], []] )
+    allow(@mixin_resolvinator).to receive(:validate_mixin_load_paths)
+    allow(@mixin_resolvinator).to receive(:validate_mixins).and_return( true )
+    allow(@mixin_resolvinator).to receive(:lookup_mixins) {|mixins:, **| mixins }
     allow(@mixinator).to receive(:validate_cmdline_yaml_strings)
     allow(@mixinator).to receive(:fetch_env_filepaths).and_return( [] )
     allow(@mixinator).to receive(:validate_env_filepaths)
@@ -176,10 +178,10 @@ describe Composinator do
   describe '#loadinate -- load path precedence' do
     it 'orders load paths as user :load_paths, then project directory, then built-in paths' do
       stub_loadinate_pipeline
-      allow(@projectinator).to receive(:extract_mixins).and_return( [[], ['user/path']] )
+      allow(@mixin_resolvinator).to receive(:extract_mixins).and_return( [[], ['user/path']] )
 
       captured_load_paths = nil
-      allow(@projectinator).to receive(:lookup_mixins) do |load_paths:, **|
+      allow(@mixin_resolvinator).to receive(:lookup_mixins) do |load_paths:, **|
         captured_load_paths = load_paths
         []
       end

--- a/spec/units/bin/mixin_resolvinator_spec.rb
+++ b/spec/units/bin/mixin_resolvinator_spec.rb
@@ -6,12 +6,12 @@
 # =========================================================================
 
 require 'spec_helper'
-require 'projectinator'
+require 'mixin_resolvinator'
 require 'ceedling/constants'
 require 'ceedling/ruby_expandinator'
 require 'ceedling/exceptions'
 
-describe Projectinator do
+describe MixinResolvinator do
   before(:each) do
     @loginator = double('loginator')
     allow(@loginator).to receive(:lazy)
@@ -31,22 +31,16 @@ describe Projectinator do
     allow(@path_validator).to receive(:filepath?).and_return(false)
     allow(@path_validator).to receive(:validate).and_return(true)
 
-    @yaml_wrapper = double('yaml_wrapper')
-
-    @system_wrapper = double('system_wrapper')
-
     # Default pass-through stub mirrors RubyExpandinator#expand's real behavior for
     # strings without a `#{...}` pattern (the common case in these specs). Individual
     # tests override with a tighter `.with(...)` expectation where expansion matters.
     @ruby_expandinator = double('ruby_expandinator')
     allow(@ruby_expandinator).to receive(:expand) { |s, source:| s }
 
-    @projectinator = described_class.new({
-      :file_wrapper   => @file_wrapper,
-      :path_validator => @path_validator,
-      :yaml_wrapper   => @yaml_wrapper,
-      :loginator      => @loginator,
-      :system_wrapper => @system_wrapper,
+    @mixin_resolvinator = described_class.new({
+      :file_wrapper      => @file_wrapper,
+      :path_validator    => @path_validator,
+      :loginator         => @loginator,
       :ruby_expandinator => @ruby_expandinator
     })
   end
@@ -55,7 +49,7 @@ describe Projectinator do
   describe '#extract_mixins' do
     it 'returns empty lists and leaves config unchanged when no :mixins key present' do
       config = {:project => {:build_root => 'build'}}
-      enabled, load_paths = @projectinator.extract_mixins(config: config)
+      enabled, load_paths = @mixin_resolvinator.extract_mixins(config: config)
 
       expect(enabled).to eq([])
       expect(load_paths).to eq([])
@@ -69,7 +63,7 @@ describe Projectinator do
         }
       }
 
-      enabled, load_paths = @projectinator.extract_mixins(config: config)
+      enabled, load_paths = @mixin_resolvinator.extract_mixins(config: config)
 
       expect(enabled).to eq(['mixin_a', 'path/to/mixin_b.yml'])
       expect(load_paths).to eq([])
@@ -82,7 +76,7 @@ describe Projectinator do
         }
       }
 
-      enabled, load_paths = @projectinator.extract_mixins(config: config)
+      enabled, load_paths = @mixin_resolvinator.extract_mixins(config: config)
 
       expect(enabled).to eq([])
       expect(load_paths).to eq(['support/mixins', 'vendor/mixins'])
@@ -96,7 +90,7 @@ describe Projectinator do
         }
       }
 
-      enabled, load_paths = @projectinator.extract_mixins(config: config)
+      enabled, load_paths = @mixin_resolvinator.extract_mixins(config: config)
 
       expect(enabled).to eq(['mixin_a'])
       expect(load_paths).to eq(['support/mixins'])
@@ -108,7 +102,7 @@ describe Projectinator do
         :mixins  => {:enabled => ['mixin_a'], :load_paths => ['support']}
       }
 
-      @projectinator.extract_mixins(config: config)
+      @mixin_resolvinator.extract_mixins(config: config)
 
       expect(config).not_to have_key(:mixins)
       expect(config).to have_key(:project)
@@ -125,7 +119,7 @@ describe Projectinator do
         .with('#{ENV["MIXIN_NAME"]}', source: ':mixins ↳ :enabled')
         .and_return('resolved_mixin_name')
 
-      enabled, _ = @projectinator.extract_mixins(config: config)
+      enabled, _ = @mixin_resolvinator.extract_mixins(config: config)
 
       expect(enabled).to eq(['resolved_mixin_name'])
     end
@@ -141,7 +135,7 @@ describe Projectinator do
         .with('#{File.join(Dir.pwd, "mixins")}', source: ':mixins ↳ :load_paths')
         .and_return('/project/mixins')
 
-      _, load_paths = @projectinator.extract_mixins(config: config)
+      _, load_paths = @mixin_resolvinator.extract_mixins(config: config)
 
       expect(load_paths).to eq(['/project/mixins'])
     end
@@ -154,7 +148,7 @@ describe Projectinator do
         }
       }
 
-      enabled, load_paths = @projectinator.extract_mixins(config: config)
+      enabled, load_paths = @mixin_resolvinator.extract_mixins(config: config)
 
       expect(enabled).to eq(['plain_mixin'])
       expect(load_paths).to eq(['plain/path'])
@@ -168,7 +162,7 @@ describe Projectinator do
         }
       }
 
-      enabled, _ = @projectinator.extract_mixins(config: config)
+      enabled, _ = @mixin_resolvinator.extract_mixins(config: config)
 
       expect(enabled).to eq(['mixin/dir/clang.yml'])
     end
@@ -181,25 +175,23 @@ describe Projectinator do
         }
       }
 
-      _, load_paths = @projectinator.extract_mixins(config: config)
+      _, load_paths = @mixin_resolvinator.extract_mixins(config: config)
 
       expect(load_paths).to eq(['support/mixins'])
     end
 
     it 'raises CeedlingException when an entry contains inline Ruby and the feature is disabled' do
       real_ruby_expandinator = RubyExpandinator.new # disabled by default
-      projectinator = described_class.new({
-        :file_wrapper   => @file_wrapper,
-        :path_validator => @path_validator,
-        :yaml_wrapper   => @yaml_wrapper,
-        :loginator      => @loginator,
-        :system_wrapper => @system_wrapper,
+      mixin_resolvinator = described_class.new({
+        :file_wrapper      => @file_wrapper,
+        :path_validator    => @path_validator,
+        :loginator         => @loginator,
         :ruby_expandinator => real_ruby_expandinator
       })
       config = { :mixins => { :enabled => ['#{ENV["MIXIN_NAME"]}'], :load_paths => [] } }
 
       expect {
-        projectinator.extract_mixins(config: config)
+        mixin_resolvinator.extract_mixins(config: config)
       }.to raise_error(CeedlingException, /:mixins/)
     end
   end
@@ -209,7 +201,7 @@ describe Projectinator do
     let(:yaml_extension) { '.yml' }
 
     it 'returns empty array for an empty mixin list' do
-      result = @projectinator.lookup_mixins(
+      result = @mixin_resolvinator.lookup_mixins(
         mixins:         [],
         load_paths:     ['support/mixins'],
         yaml_extension: yaml_extension
@@ -220,7 +212,7 @@ describe Projectinator do
     it 'returns an explicit filepath as-is without searching load_paths' do
       allow(@path_validator).to receive(:filepath?).with('path/to/mixin.yml').and_return(true)
 
-      result = @projectinator.lookup_mixins(
+      result = @mixin_resolvinator.lookup_mixins(
         mixins:         ['path/to/mixin.yml'],
         load_paths:     ['support/mixins'],
         yaml_extension: yaml_extension
@@ -232,7 +224,7 @@ describe Projectinator do
       allow(@path_validator).to receive(:filepath?).with('my_mixin').and_return(false)
       allow(@file_wrapper).to receive(:exist?).with('first/path/my_mixin.yml').and_return(true)
 
-      result = @projectinator.lookup_mixins(
+      result = @mixin_resolvinator.lookup_mixins(
         mixins:         ['my_mixin'],
         load_paths:     ['first/path', 'second/path'],
         yaml_extension: yaml_extension
@@ -245,7 +237,7 @@ describe Projectinator do
       allow(@file_wrapper).to receive(:exist?).with('first/path/my_mixin.yml').and_return(false)
       allow(@file_wrapper).to receive(:exist?).with('second/path/my_mixin.yml').and_return(true)
 
-      result = @projectinator.lookup_mixins(
+      result = @mixin_resolvinator.lookup_mixins(
         mixins:         ['my_mixin'],
         load_paths:     ['first/path', 'second/path'],
         yaml_extension: yaml_extension
@@ -257,7 +249,7 @@ describe Projectinator do
       allow(@path_validator).to receive(:filepath?).with('unresolved_name').and_return(false)
       allow(@file_wrapper).to receive(:exist?).and_return(false)
 
-      result = @projectinator.lookup_mixins(
+      result = @mixin_resolvinator.lookup_mixins(
         mixins:         ['unresolved_name'],
         load_paths:     ['support/mixins'],
         yaml_extension: yaml_extension
@@ -270,7 +262,7 @@ describe Projectinator do
       allow(@path_validator).to receive(:filepath?).with('named_mixin').and_return(false)
       allow(@file_wrapper).to receive(:exist?).with('support/named_mixin.yml').and_return(true)
 
-      result = @projectinator.lookup_mixins(
+      result = @mixin_resolvinator.lookup_mixins(
         mixins:         ['explicit.yml', 'named_mixin'],
         load_paths:     ['support'],
         yaml_extension: yaml_extension
@@ -287,7 +279,7 @@ describe Projectinator do
       allow(@path_validator).to receive(:filepath?).with('path/to/mixin.yml').and_return(true)
       allow(@file_wrapper).to receive(:exist?).with('path/to/mixin.yml').and_return(true)
 
-      result = @projectinator.validate_mixins(
+      result = @mixin_resolvinator.validate_mixins(
         mixins:         ['path/to/mixin.yml'],
         load_paths:     [],
         source:         'Test',
@@ -305,7 +297,7 @@ describe Projectinator do
         anything
       )
 
-      result = @projectinator.validate_mixins(
+      result = @mixin_resolvinator.validate_mixins(
         mixins:         ['missing/mixin.yml'],
         load_paths:     [],
         source:         'Test',
@@ -318,7 +310,7 @@ describe Projectinator do
       allow(@path_validator).to receive(:filepath?).with('my_mixin').and_return(false)
       allow(@file_wrapper).to receive(:exist?).with('support/my_mixin.yml').and_return(true)
 
-      result = @projectinator.validate_mixins(
+      result = @mixin_resolvinator.validate_mixins(
         mixins:         ['my_mixin'],
         load_paths:     ['support'],
         source:         'Test',
@@ -336,7 +328,7 @@ describe Projectinator do
         anything
       )
 
-      result = @projectinator.validate_mixins(
+      result = @mixin_resolvinator.validate_mixins(
         mixins:         ['unknown_mixin'],
         load_paths:     ['support'],
         source:         'Test',
@@ -354,7 +346,7 @@ describe Projectinator do
 
       allow(@loginator).to receive(:log)
 
-      result = @projectinator.validate_mixins(
+      result = @mixin_resolvinator.validate_mixins(
         mixins:         ['good/mixin.yml', 'bad/mixin.yml'],
         load_paths:     [],
         source:         'Test',

--- a/spec/units/bin/projectinator_spec.rb
+++ b/spec/units/bin/projectinator_spec.rb
@@ -11,8 +11,8 @@ require 'ceedling/constants'
 require 'ceedling/exceptions'
 
 # Covers Projectinator's namesake responsibility -- discovering and loading the
-# project file itself -- as opposed to projectinator_mixin_spec.rb, which
-# covers its :mixins section handling.
+# project file itself. Its former :mixins section handling now lives on
+# MixinResolvinator (see mixin_resolvinator_spec.rb).
 describe Projectinator do
   before(:each) do
     @loginator = double('loginator')
@@ -29,16 +29,11 @@ describe Projectinator do
 
     @yaml_wrapper = double('yaml_wrapper')
 
-    @system_wrapper = double('system_wrapper')
-    @ruby_expandinator = double('ruby_expandinator')
-
     @projectinator = described_class.new({
       :file_wrapper      => @file_wrapper,
       :path_validator    => @path_validator,
       :yaml_wrapper      => @yaml_wrapper,
       :loginator         => @loginator,
-      :system_wrapper    => @system_wrapper,
-      :ruby_expandinator => @ruby_expandinator,
     })
   end
 

--- a/spec/units/bin/projectinator_spec.rb
+++ b/spec/units/bin/projectinator_spec.rb
@@ -45,11 +45,16 @@ describe Projectinator do
   # =========================================================================
   describe '#load' do
     it 'loads from an explicit filepath argument at highest priority' do
-      allow(@yaml_wrapper).to receive(:load).with('/abs/custom.yml').and_return({:project => {}})
+      # A leading `/` is already absolute on POSIX but means "root of the
+      # current drive" on Windows, so File.expand_path prepends a drive
+      # letter there -- compute the real expanded value instead of assuming
+      # the input string is left unchanged.
+      expanded = File.expand_path('/abs/custom.yml')
+      allow(@yaml_wrapper).to receive(:load).with(expanded).and_return({:project => {}})
 
       filepath, config = @projectinator.load( filepath: '/abs/custom.yml', env: {'CEEDLING_PROJECT_FILE' => 'ignored.yml'} )
 
-      expect(filepath).to eq('/abs/custom.yml')
+      expect(filepath).to eq(expanded)
       expect(config[:project]).to eq({})
     end
 
@@ -66,11 +71,14 @@ describe Projectinator do
     end
 
     it 'falls back to the environment variable when no filepath argument is given' do
-      allow(@yaml_wrapper).to receive(:load).with('/abs/env_project.yml').and_return({:project => {}})
+      # Same platform-dependent File.expand_path behavior as the cmdline
+      # argument case above.
+      expanded = File.expand_path('/abs/env_project.yml')
+      allow(@yaml_wrapper).to receive(:load).with(expanded).and_return({:project => {}})
 
       filepath, config = @projectinator.load( env: {'CEEDLING_PROJECT_FILE' => '/abs/env_project.yml'} )
 
-      expect(filepath).to eq('/abs/env_project.yml')
+      expect(filepath).to eq(expanded)
       expect(config[:history][:config].first[:mechanism]).to eq(:project)
     end
 


### PR DESCRIPTION
## Summary

Phase 3 (final phase) of the `bin/` code review, refactoring, and test coverage plan. Four commits:

1. **Fix Windows-specific test failure from `File.expand_path` drive letters** — carried over from PR #1231, which merged before this fix could be added (CI had already gone green on Linux/macOS). Two `Projectinator#load` unit tests hardcoded `/abs/...` fixture paths assuming POSIX `File.expand_path` semantics; on Windows a leading `/` gets a drive letter prepended instead of being left alone. Both tests now compute the expected value via `File.expand_path` in the test itself.
2. **Split `Projectinator`'s mixin-lookup responsibilities into `MixinResolvinator`** — `Projectinator` had two unrelated jobs: loading the project file itself, and resolving/validating mixin references. The mixin-lookup half (`extract_mixins`, `validate_mixin_load_paths`, `validate_mixins`, `lookup_mixins`) now lives on its own class. Also drops two constructor dependencies `Projectinator` never actually used in its own body (`:system_wrapper`, dead regardless of this split; `:ruby_expandinator`, which moves with `extract_mixins`). Pure structural move — existing test coverage carries through unchanged.
3. **Collapse `MixinStandardizer`'s `:defines`/`:flags` traversal into one helper** — the two methods were near-identical, differing only in nesting depth (`:defines` is one category level deep, `:flags` is two). Replaced with a single depth-parameterized helper. Behavior-preserving.
4. **Replace `deep_merge` gem usage in `Composinator#default_tasks`** — the gem's `config.deep_merge({...})` was used for what's really just setting one known key at a known shallow path, and mutates in place despite its non-bang name. Replaced with plain Ruby. Behavior-preserving; the gem itself remains a dependency (still used elsewhere in `lib/ceedling`).

This closes out the `bin/` code review effort's three-phase plan (Phase 1: CLI layer, PR #1230; Phase 2: mixins bug fixes and cleanup, PR #1231; Phase 3: this PR).

## Test plan
- [x] Full unit suite (`bundle exec rspec spec/units`) — 2711 examples, 0 failures
- [x] Targeted system-test verification via `throwtheswitch/madsciencelab-plugins:v1.1.4` (mixin ordering, CLI surface, gem/vendor deployment) — 179 examples, 0 failures
- [x] Manual smoke tests confirming the `MixinResolvinator` DI wiring resolves real mixins end-to-end (including built-in toolchain targets) and the `default_tasks` fallback runs correctly with no `deep_merge` gem involved
- [ ] Full CI (unit + system, all platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)