### PR TITLE
Batchinator: documentation, refactor, and test coverage

### DIFF
--- a/lib/ceedling/batchinator.rb
+++ b/lib/ceedling/batchinator.rb
@@ -70,6 +70,7 @@ class Batchinator
 
     batch_results = []
     sum_elapsed = 0.0
+    start_times = {}
 
     all_elapsed = Benchmark.realtime do
       # Determine number of worker threads to run
@@ -89,18 +90,18 @@ class Batchinator
         raise ::ArgumentError.new("Unrecognized batch workload type: #{workload}")
       end
 
-      # Perform the actual parallelized work and collect the results and timing
-      batch_results = Parallel.map(things, in_threads: workers) do |key, value| 
-        this_results = ''
-        this_elapsed = Benchmark.realtime { this_results = job_block.call(key, value) }
-        [this_results, this_elapsed]
-      end
-
-      # Separate the elapsed time and results
-      if batch_results.size > 0
-        batch_results, batch_elapsed = batch_results.transpose
-        sum_elapsed = batch_elapsed.sum()
-      end
+      # Perform the actual parallelized work. Per-item timing rides along on
+      # the `parallel` gem's own start:/finish: callbacks instead of wrapping
+      # each job block call in a separate Benchmark.realtime -- the gem calls
+      # these under its own internal mutex, so summing into sum_elapsed here
+      # needs no synchronization of our own. batch_results ends up as the job
+      # block's own per-item return values, nothing wrapped around them.
+      batch_results = Parallel.map(
+        things,
+        in_threads: workers,
+        start:  ->(_item, index) { start_times[index] = Time.now },
+        finish: ->(_item, index, _result) { sum_elapsed += (Time.now - start_times[index]) }
+      ) { |key, value| job_block.call(key, value) }
     end
 
     # Report the timing if requested

--- a/lib/ceedling/batchinator.rb
+++ b/lib/ceedling/batchinator.rb
@@ -5,6 +5,16 @@
 #   SPDX-License-Identifier: MIT
 # =========================================================================
 
+# Batchinator is Ceedling's one chokepoint for parallel work. Every worker
+# thread the build spins up, for compiling or for running tests, passes
+# through here. Keeping that in one small file makes the parallel handling
+# easy to find and easy to reason about, instead of scattered thread-pool
+# code wherever a build step happens to need parallelism.
+#
+# Actually running things in parallel is handled by the `parallel` gem.
+# Batchinator's job is just the Ceedling-specific parts on top: picking a
+# worker count from project configuration, and reporting timing.
+
 require 'benchmark'
 require 'parallel'
 
@@ -29,11 +39,37 @@ class Batchinator
     yield # Execute build step block
   end
 
-  # Parallelize work to be done:
-  #  - Enqueue things (thread-safe)
-  #  - Spin up a number of worker threads within constraints of project file config and amount of work
-  #  - Each worker thread consumes one item from queue and runs the block against its details
-  #  - When the queue is empty, the worker threads wind down
+  # Run a block once per item in `things`, spread across worker threads.
+  #
+  # `workload:` picks how many worker threads to use. Compiling and running
+  # tests are configured with independent thread counts (`:project ↳
+  # :compile_threads` and `:project ↳ :test_threads`), since the two
+  # workloads have different performance characteristics and a project may
+  # want to tune them separately. `workload:` says which of the two
+  # settings applies to this call.
+  #
+  # `things:` is whatever collection of work items needs processing. It can
+  # be a plain Array (`job_block` receives one item, e.g. `|object|`) or a
+  # Hash (`job_block` receives a key/value pair, e.g. `|name, testable|`).
+  # Both work through the same `|key, value|` block signature below because
+  # of two ordinary Ruby behaviors, not anything Batchinator does itself:
+  # the `parallel` gem converts any `things` collection to an Array of
+  # items first, and Ruby auto-splats a 2-element Array item (a Hash pair)
+  # into two block parameters. A plain Array item just becomes `key`, with
+  # `value` left `nil`.
+  #
+  # Thread safety is the caller's responsibility, not Batchinator's.
+  # `job_block` runs concurrently on multiple threads. If it reads or
+  # writes anything shared across those calls (a counter, an entry in a
+  # shared results object), that access needs its own synchronization,
+  # typically a `Mutex` the caller owns and passes in via closure. Nothing
+  # about calling `exec` makes shared state safe on its own.
+  #
+  # If `job_block` raises, already-running items keep running to
+  # completion. No new items start once an exception has been seen. Once
+  # every thread is done, the first exception raised is re-raised here, in
+  # the calling thread. This is the `parallel` gem's own default behavior
+  # for thread-based work, not something Batchinator changes.
   def exec(workload:, things:, &job_block)
 
     batch_results = []

--- a/lib/ceedling/batchinator.rb
+++ b/lib/ceedling/batchinator.rb
@@ -22,12 +22,8 @@ class Batchinator
 
   constructor :configurator, :loginator, :reportinator
 
-  def setup
-    @queue = Queue.new
-  end
-
   # Neaten up a build step with progress message and some scope encapsulation
-  def build_step(msg, heading: true, &block)
+  def build_step(msg, heading: true)
     if heading
       msg = @reportinator.generate_heading( @loginator.decorate( msg, LogLabels::RUN ) )
     else # Progress message

--- a/lib/ceedling/batchinator.rb
+++ b/lib/ceedling/batchinator.rb
@@ -84,7 +84,13 @@ class Batchinator
       when :test
         workers = @configurator.project_test_threads
       else
-        raise NameError.new("Unrecognized batch workload type: #{workload}")
+        # Explicit ::ArgumentError, not the bare name: this class mixes in
+        # the `constructor` gem's Constructor module, which defines its own
+        # Constructor::ArgumentError ahead of the real one in this class's
+        # ancestor chain. A bare ArgumentError reference here would silently
+        # resolve to that one instead, which expects an Array and not a
+        # String and breaks accordingly.
+        raise ::ArgumentError.new("Unrecognized batch workload type: #{workload}")
       end
 
       # Perform the actual parallelized work and collect the results and timing

--- a/spec/system/pinned_thread_count_spec.rb
+++ b/spec/system/pinned_thread_count_spec.rb
@@ -1,0 +1,102 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+
+# Every other system test either leaves :compile_threads/:test_threads at
+# their default of 1 (fully serial, no real thread pool spun up at all) or
+# relies on :auto (a worker count derived from the host machine's own CPU
+# count, different on every runner). Neither setup ever deterministically
+# exercises Batchinator's real multi-thread path -- a genuine concurrency
+# bug (e.g. a caller forgetting to synchronize shared state under
+# state.lock) could regress without any existing system test ever seeing
+# more than one worker thread active, or seeing a worker count that varies
+# machine to machine.
+#
+# This test pins both thread counts to a small, fixed value greater than
+# one so real parallel compilation and real parallel test execution both
+# happen on every run, everywhere, and asserts on correctness of the
+# result (right pass/fail counts, right modules run) -- not just "the
+# build didn't crash." wondrous_forest is reused as the multi-file fixture
+# since its correct, fully-passing counts are already an established
+# baseline elsewhere (see example_wondrous_forest_spec.rb).
+ceedling_system_tests do
+  before :all do
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  describe "Parallel work with a small, fixed thread count (wondrous_forest)" do
+    before do
+      @c.with_context do
+        output = @c.ceedling_appcmd_exec("example wondrous_forest")
+        expect(output).to match(/created/)
+
+        Dir.chdir "wondrous_forest" do
+          @c.ceedling_build_exec("clobber")
+        end
+      end
+    end
+
+    it "builds and runs every test correctly with :compile_threads and :test_threads both pinned to 2" do
+      @c.with_context do
+        Dir.chdir "wondrous_forest" do
+          @c.merge_project_yml_for_test({
+            :project => { :compile_threads => 2, :test_threads => 2 }
+          })
+
+          output = @c.ceedling_build_exec("test:all")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/TESTED:\s+68/)
+          expect(output).to match(/PASSED:\s+68/)
+          expect(output).to match(/FAILED:\s+0/)
+        end
+      end
+    end
+
+    it "builds and runs every test correctly with asymmetric small :compile_threads and :test_threads values" do
+      @c.with_context do
+        Dir.chdir "wondrous_forest" do
+          @c.merge_project_yml_for_test({
+            :project => { :compile_threads => 3, :test_threads => 2 }
+          })
+
+          output = @c.ceedling_build_exec("test:all")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/TESTED:\s+68/)
+          expect(output).to match(/PASSED:\s+68/)
+          expect(output).to match(/FAILED:\s+0/)
+        end
+      end
+    end
+
+    it "attributes results to the correct module when testing a pattern subset under pinned threads" do
+      @c.with_context do
+        Dir.chdir "wondrous_forest" do
+          @c.merge_project_yml_for_test({
+            :project => { :compile_threads => 2, :test_threads => 2 }
+          })
+
+          output = @c.ceedling_build_exec("test:pattern[Sensor]")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/PASSED/)
+          expect(output).to match(/FAILED:\s+0/)
+          expect(output).to match(/TemperatureSensor\.out/i)
+          expect(output).to match(/HumiditySensor\.out/i)
+          expect(output).to match(/LightSensor\.out/i)
+        end
+      end
+    end
+  end
+end

--- a/spec/units/batchinator_spec.rb
+++ b/spec/units/batchinator_spec.rb
@@ -1,0 +1,128 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/batchinator'
+require 'ceedling/constants'
+
+# Parallel.map is stubbed to a plain serial map throughout this file. That
+# strips out real threading entirely, so these specs exercise Batchinator's
+# own decision logic -- worker count lookup, item dispatch, error handling --
+# without testing Ruby's or the parallel gem's own thread scheduling, which
+# isn't Batchinator's job to get right and isn't practical to assert on
+# deterministically. A small number of real-threading smoke tests exist
+# separately to catch a broken Parallel integration this stub would hide.
+describe Batchinator do
+  before(:each) do
+    @configurator = double('configurator')
+
+    @loginator = double('loginator')
+    allow(@loginator).to receive(:log)
+    allow(@loginator).to receive(:lazy)
+    allow(@loginator).to receive(:decorate) {|msg, _label| msg }
+
+    @reportinator = double('reportinator')
+    allow(@reportinator).to receive(:generate_heading) {|msg| msg }
+    allow(@reportinator).to receive(:generate_progress) {|msg| msg }
+
+    @batchinator = described_class.new({
+      :configurator => @configurator,
+      :loginator    => @loginator,
+      :reportinator => @reportinator,
+    })
+
+    allow(Parallel).to receive(:map) do |things, **_opts, &block|
+      things.map(&block)
+    end
+  end
+
+  # =========================================================================
+  describe '#exec' do
+    it 'uses project_compile_threads as the worker count for :compile workload' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(3)
+
+      captured_workers = nil
+      allow(Parallel).to receive(:map) do |things, in_threads:, &block|
+        captured_workers = in_threads
+        things.map(&block)
+      end
+
+      @batchinator.exec(workload: :compile, things: [1]) {|item| item }
+
+      expect(captured_workers).to eq(3)
+    end
+
+    it 'uses project_test_threads as the worker count for :test workload' do
+      allow(@configurator).to receive(:project_test_threads).and_return(7)
+
+      captured_workers = nil
+      allow(Parallel).to receive(:map) do |things, in_threads:, &block|
+        captured_workers = in_threads
+        things.map(&block)
+      end
+
+      @batchinator.exec(workload: :test, things: [1]) {|item| item }
+
+      expect(captured_workers).to eq(7)
+    end
+
+    it 'passes every item to the job block exactly once, in input order' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(2)
+
+      processed = []
+      @batchinator.exec(workload: :compile, things: [1, 2, 3]) do |item|
+        processed << item
+      end
+
+      expect(processed).to eq([1, 2, 3])
+    end
+
+    it 'auto-splats a Hash pair into key and value block parameters' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(2)
+
+      captured = []
+      @batchinator.exec(workload: :compile, things: {a: 1, b: 2}) do |key, value|
+        captured << [key, value]
+      end
+
+      expect(captured).to eq([[:a, 1], [:b, 2]])
+    end
+
+    it 'does not raise for an empty things collection' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(2)
+
+      expect {
+        @batchinator.exec(workload: :compile, things: []) {|item| item }
+      }.to_not raise_error
+    end
+  end
+
+  # =========================================================================
+  describe '#build_step' do
+    it 'logs a heading message by default' do
+      expect(@reportinator).to receive(:generate_heading)
+      expect(@loginator).to receive(:log)
+
+      @batchinator.build_step('Doing a thing') { }
+    end
+
+    it 'logs a progress message when heading: false' do
+      expect(@reportinator).to receive(:generate_progress)
+      expect(@loginator).to receive(:log)
+
+      @batchinator.build_step('Doing a thing', heading: false) { }
+    end
+
+    it 'executes the given block' do
+      executed = false
+
+      @batchinator.build_step('Doing a thing') { executed = true }
+
+      expect(executed).to eq(true)
+    end
+  end
+end

--- a/spec/units/batchinator_spec.rb
+++ b/spec/units/batchinator_spec.rb
@@ -99,6 +99,12 @@ describe Batchinator do
         @batchinator.exec(workload: :compile, things: []) {|item| item }
       }.to_not raise_error
     end
+
+    it 'raises ArgumentError for an unrecognized workload' do
+      expect {
+        @batchinator.exec(workload: :bogus, things: [1]) {|item| item }
+      }.to raise_error(ArgumentError, /Unrecognized batch workload type/)
+    end
   end
 
   # =========================================================================

--- a/spec/units/batchinator_spec.rb
+++ b/spec/units/batchinator_spec.rb
@@ -35,8 +35,19 @@ describe Batchinator do
       :reportinator => @reportinator,
     })
 
-    allow(Parallel).to receive(:map) do |things, **_opts, &block|
-      things.map(&block)
+    # Mirrors the real gem's contract closely enough for these specs: runs
+    # serially (no real threading), calls the given block once per item in
+    # order, and invokes start:/finish: around each call the same way the
+    # real gem does, if given. block.call(item) (not block.call(*item)) so
+    # Ruby's own proc auto-splat -- not this stub -- is what decomposes a
+    # Hash pair into |key, value|, same as production.
+    allow(Parallel).to receive(:map) do |things, in_threads: nil, start: nil, finish: nil, &block|
+      things.to_a.each_with_index.map do |item, index|
+        start.call( item, index ) if start
+        result = block.call( item )
+        finish.call( item, index, result ) if finish
+        result
+      end
     end
   end
 
@@ -46,7 +57,7 @@ describe Batchinator do
       allow(@configurator).to receive(:project_compile_threads).and_return(3)
 
       captured_workers = nil
-      allow(Parallel).to receive(:map) do |things, in_threads:, &block|
+      allow(Parallel).to receive(:map) do |things, in_threads:, **_opts, &block|
         captured_workers = in_threads
         things.map(&block)
       end
@@ -60,7 +71,7 @@ describe Batchinator do
       allow(@configurator).to receive(:project_test_threads).and_return(7)
 
       captured_workers = nil
-      allow(Parallel).to receive(:map) do |things, in_threads:, &block|
+      allow(Parallel).to receive(:map) do |things, in_threads:, **_opts, &block|
         captured_workers = in_threads
         things.map(&block)
       end
@@ -104,6 +115,58 @@ describe Batchinator do
       expect {
         @batchinator.exec(workload: :bogus, things: [1]) {|item| item }
       }.to raise_error(ArgumentError, /Unrecognized batch workload type/)
+    end
+
+    it 'returns the job block per-item results directly, with no timing wrapper' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(2)
+
+      result = @batchinator.exec(workload: :compile, things: [1, 2, 3]) {|item| item * 10 }
+
+      expect(result).to eq([10, 20, 30])
+    end
+
+    it 'times each item using Parallel.map start:/finish: callbacks, once per item' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(2)
+
+      start_indexes = []
+      finish_indexes = []
+      allow(Parallel).to receive(:map) do |things, in_threads:, start:, finish:, &block|
+        things.each_with_index.map do |item, index|
+          start.call( item, index )
+          start_indexes << index
+          result = block.call( item )
+          finish.call( item, index, result )
+          finish_indexes << index
+          result
+        end
+      end
+
+      @batchinator.exec(workload: :compile, things: [10, 20, 30]) {|item| item }
+
+      expect(start_indexes).to eq([0, 1, 2])
+      expect(finish_indexes).to eq([0, 1, 2])
+    end
+
+    it 'logs a well-formed batch elapsed summary after processing' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(2)
+
+      logged_message = nil
+      allow(@loginator).to receive(:lazy) {|_verbosity, &blk| logged_message = blk.call }
+
+      @batchinator.exec(workload: :compile, things: [1, 2]) {|item| item }
+
+      expect(logged_message).to match(/Batch Elapsed: \(All: [\d.]+sec Sum: [\d.]+sec\)/)
+    end
+
+    it 'logs a sane batch elapsed summary for an empty things collection' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(2)
+
+      logged_message = nil
+      allow(@loginator).to receive(:lazy) {|_verbosity, &blk| logged_message = blk.call }
+
+      @batchinator.exec(workload: :compile, things: []) {|item| item }
+
+      expect(logged_message).to match(/Batch Elapsed: \(All: [\d.]+sec Sum: 0\.000sec\)/)
     end
   end
 

--- a/spec/units/batchinator_spec.rb
+++ b/spec/units/batchinator_spec.rb
@@ -171,6 +171,44 @@ describe Batchinator do
   end
 
   # =========================================================================
+  # Real threading, no Parallel.map stub. These exist only to catch a broken
+  # integration with the actual `parallel` gem -- something the Layer 1 stub
+  # above can't see, since it never touches real threads at all. On purpose,
+  # these assert only outcomes that hold true no matter how the threads
+  # happen to get scheduled: every item processed once, results in input
+  # order, elapsed time not negative. They never assert exact timing values
+  # or the order threads actually ran in, since both are inherently
+  # nondeterministic.
+  describe '#exec real threading (smoke)' do
+    before(:each) do
+      allow(Parallel).to receive(:map).and_call_original
+    end
+
+    it 'processes every item exactly once and returns results in input order' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(4)
+
+      result = @batchinator.exec(workload: :compile, things: [1, 2, 3, 4, 5]) do |item|
+        item * 10
+      end
+
+      expect(result).to eq([10, 20, 30, 40, 50])
+    end
+
+    it 'reports a non-negative elapsed summary' do
+      allow(@configurator).to receive(:project_compile_threads).and_return(4)
+
+      logged_message = nil
+      allow(@loginator).to receive(:lazy) {|_verbosity, &blk| logged_message = blk.call }
+
+      @batchinator.exec(workload: :compile, things: [1, 2, 3, 4, 5]) {|item| item }
+
+      all_sec, sum_sec = logged_message.match(/All: ([\d.]+)sec Sum: ([\d.]+)sec/).captures.map(&:to_f)
+      expect(all_sec).to be >= 0
+      expect(sum_sec).to be >= 0
+    end
+  end
+
+  # =========================================================================
   describe '#build_step' do
     it 'logs a heading message by default' do
       expect(@reportinator).to receive(:generate_heading)


### PR DESCRIPTION
## Summary
Batchinator (`lib/ceedling/batchinator.rb`) is Ceedling's single chokepoint for parallel compile/test worker threads and had zero prior test coverage. This adds that coverage, documents its configuration/mechanics/thread-safety contract, fixes a validation bug, removes dead code, and replaces vestigial manual timing machinery with the `parallel` gem's own `:start`/`:finish` callbacks.

- Documents `exec`'s `workload:`/`things:` contract, the caller-owned thread-safety obligation (`state.lock`), and the intentional job-block exception behavior — no behavior change.
- Adds baseline unit specs (`spec/units/batchinator_spec.rb`) with `Parallel.map` stubbed to plain serial execution, exercising Batchinator's own decision logic in isolation.
- Fixes `workload:` validation to raise `ArgumentError` instead of `NameError` for an unrecognized workload symbol — while doing so, uncovered and worked around a footgun where the `constructor` gem's `Constructor::ArgumentError` shadows Ruby's built-in `ArgumentError` in this class's ancestor chain (documented inline with `::ArgumentError`).
- Removes confirmed dead code: `@queue = Queue.new` (a leftover from a pre-`parallel`-gem hand-rolled thread pool) and `build_step`'s unused `&block` capture.
- Replaces the manual `Benchmark.realtime`-per-item + tuple-packing + `.transpose` pattern with the `parallel` gem's `:start`/`:finish` callbacks (internally mutex-protected by the gem). `exec` now returns the job block's own per-item results directly.
- Adds real-threading smoke tests (no stubbing) asserting only scheduling-independent outcomes.
- Adds a new system test (`spec/system/pinned_thread_count_spec.rb`) pinning `:compile_threads`/`:test_threads` to small fixed values against the `wondrous_forest` example — every other system test relies on the default of 1 or on `:auto`, neither of which deterministically exercises real multi-thread execution.

## Test plan
- [x] `bundle exec rspec spec/units/batchinator_spec.rb` — 15 examples, 0 failures
- [x] `bundle exec rspec spec/units` (full suite) — 2726 examples, 0 failures
- [x] Docker-verified system tests (`pinned_thread_count_spec.rb`, `example_wondrous_forest_spec.rb`, `example_cipher_quest_spec.rb`, `shuffle_tests_spec.rb`, `delta_builds_spec.rb`) — 42 examples, 0 failures
- [x] Manual sanity check: `ceedling test:all --verbosity=obnoxious` against `wondrous_forest` with `:compile_threads: 3`, `:test_threads: 2` — correct `68 TESTED / 68 PASSED / 0 FAILED` and a well-formed `Batch Elapsed: (All: ...sec Sum: ...sec)` summary line