### PR TITLE
preprocess/: Phase 1 — cosmetic cleanup & bug fixes

### DIFF
--- a/assets/fixtures/tests_with_fallback_conditionals/src/conditional_module.c
+++ b/assets/fixtures/tests_with_fallback_conditionals/src/conditional_module.c
@@ -14,5 +14,15 @@ void ConditionalModule_Init(void)
   /* Call optional dep only when feature active — Ünïcödé-safe comment. */
 #ifdef CONDITIONAL_FEATURE
   OptionalDep_DoWork();
+
+  /* Regression coverage for a compound `#if defined(A) && defined(B)` condition
+   * in fallback mode. NEVER_DEFINED_FEATURE is never defined by any test config
+   * for this fixture. A misparse that evaluates only the first macro name (A)
+   * instead of falling through to the conservative "complex expression ->
+   * active" treatment would read this line as `defined(NEVER_DEFINED_FEATURE)`
+   * alone -- always false -- and wrongly exclude this call from the partial. */
+#if defined(NEVER_DEFINED_FEATURE) && defined(CONDITIONAL_FEATURE)
+  OptionalDep_DoWork();
+#endif
 #endif
 }

--- a/assets/fixtures/tests_with_fallback_conditionals/test/test_conditionals.c
+++ b/assets/fixtures/tests_with_fallback_conditionals/test/test_conditionals.c
@@ -29,10 +29,17 @@ void tearDown(void)
 {
 }
 
-/* Test with feature enabled: partial includes OptionalDep_DoWork() call — naïve test. */
+/* Test with feature enabled: partial includes OptionalDep_DoWork() call — naïve test.
+ * Two expected calls, not one: conditional_module.c's ConditionalModule_Init() has a
+ * second, compound-guarded `#if defined(NEVER_DEFINED_FEATURE) && defined(CONDITIONAL_FEATURE)`
+ * call to OptionalDep_DoWork() alongside the plain `#ifdef CONDITIONAL_FEATURE` one.
+ * NEVER_DEFINED_FEATURE is never defined by any test config here -- a misparse
+ * reading only the first macro name would evaluate that compound condition as
+ * inactive (excluding the second call) instead of conservatively active. */
 #ifdef CONDITIONAL_FEATURE
 void test_init_calls_optional_dep(void)
 {
+  OptionalDep_DoWork_Expect();
   OptionalDep_DoWork_Expect();
   ConditionalModule_Init();
 }

--- a/lib/ceedling/partials/partializer_utils.rb
+++ b/lib/ceedling/partials/partializer_utils.rb
@@ -162,7 +162,7 @@ class PartializerUtils
   # @param preprocessed_filepath [String] Path to the preprocessed directives-only file
   # @return [Integer, nil] 1-indexed source line number, or nil if not found
   def locate_function_via_preprocessed(code_block:, filepath:, preprocessed_filepath:)
-    line_num = @code_finder.find_in_preprpocessed_file(preprocessed_filepath, code_block)
+    line_num = @code_finder.find_in_preprocessed_file(preprocessed_filepath, code_block)
     return line_num unless line_num.nil?
 
     msg = "Using fallback C function location search for #{filepath}"

--- a/lib/ceedling/preprocess/c_preprocessor_conditionals.rb
+++ b/lib/ceedling/preprocess/c_preprocessor_conditionals.rb
@@ -32,6 +32,12 @@ require 'ceedling/encodinator'
 ##   #endif                 → pops the innermost stack frame
 ##   Complex #if expression → treated as active (conservative: include the block)
 ##
+## The `defined(MACRO)`/`!defined(MACRO)` rules above match only that exact,
+## single-macro directive. Anything else on the same line -- a compound
+## expression like `#if defined(A) && defined(B)`, for instance -- falls
+## through to the conservative "complex expression" treatment rather than
+## being evaluated against just the one captured macro name.
+##
 ## Expects lines pre-cleaned by `code_lines` / `clean_encoding` (comments
 ## stripped, continuations joined). Does not raise on multi-byte characters.
 ##
@@ -65,20 +71,20 @@ class CPreprocessorConditionals
     when /^#\s*if\s+1\b/
       push( true )
 
-    when /^#\s*if\s+!\s*defined\s*\(\s*(\w+)\s*\)/
+    when /^#\s*if\s+!\s*defined\s*\(\s*(\w+)\s*\)\s*$/
       push( !macro_defined?($1) )
 
-    when /^#\s*if\s+defined\s*\(\s*(\w+)\s*\)/
+    when /^#\s*if\s+defined\s*\(\s*(\w+)\s*\)\s*$/
       push( macro_defined?($1) )
 
     when /^#\s*if\b/
       # Complex or unrecognized #if expression — treat as active (conservative)
       push( true )
 
-    when /^#\s*elif\s+!\s*defined\s*\(\s*(\w+)\s*\)/
+    when /^#\s*elif\s+!\s*defined\s*\(\s*(\w+)\s*\)\s*$/
       handle_elif( !macro_defined?($1) )
 
-    when /^#\s*elif\s+defined\s*\(\s*(\w+)\s*\)/
+    when /^#\s*elif\s+defined\s*\(\s*(\w+)\s*\)\s*$/
       handle_elif( macro_defined?($1) )
 
     when /^#\s*elif\s+0\b/

--- a/lib/ceedling/preprocess/preprocessinator.rb
+++ b/lib/ceedling/preprocess/preprocessinator.rb
@@ -513,6 +513,11 @@ class Preprocessinator
       defines,
       (include_paths + vendor_paths)
     )
+    # Without this, ToolExecutor#exec's default boom: true raises ShellException
+    # on a nonzero exit code before the graceful-fallback check below ever runs,
+    # crashing the build instead of falling back to directives-only signatures
+    # as documented.
+    command[:options][:boom] = false
     result = @tool_executor.exec( command )
 
     if result[:exit_code] != 0

--- a/lib/ceedling/preprocess/preprocessinator_code_finder.rb
+++ b/lib/ceedling/preprocess/preprocessinator_code_finder.rb
@@ -19,7 +19,7 @@ class PreprocessinatorCodeFinder
   # Open a GCC preprocessor output file and search it for code.
   # Returns the 1-indexed source line number of the match, or nil if not found.
   # Intended for production use where preprocessor output resides on disk.
-  def find_in_preprpocessed_file(filepath, code)
+  def find_in_preprocessed_file(filepath, code)
     @file_wrapper.open( filepath, 'r' ) do |file|
       return find_in_preprocessed_content( io: file, search: code )
     end
@@ -29,7 +29,7 @@ class PreprocessinatorCodeFinder
   # Wrap a GCC preprocessor output string in a StringIO and search it for code.
   # Returns the 1-indexed source line number of the match, or nil if not found.
   # Intended for test use so that specs require no temporary files.
-  def find_in_preprpocessed_string(content, code)
+  def find_in_preprocessed_string(content, code)
     buffer = StringIO.new( content )
     return find_in_preprocessed_content( io: buffer, search: code )
   end

--- a/spec/system/preprocessing_fallback_conditionals_spec.rb
+++ b/spec/system/preprocessing_fallback_conditionals_spec.rb
@@ -39,6 +39,15 @@ require 'spec_system_helper'
 ##   - test_conditionals.c: uses TEST_PARTIAL_ALL_MODULE to pull in the
 ##     partial; conditionally includes mock_optional_dep.h and selects
 ##     test cases based on CONDITIONAL_FEATURE
+##   - conditional_module.c's ConditionalModule_Init() also has a second,
+##     compound-guarded `#if defined(NEVER_DEFINED_FEATURE) && defined(CONDITIONAL_FEATURE)`
+##     call to OptionalDep_DoWork() nested inside the plain `#ifdef
+##     CONDITIONAL_FEATURE` block -- regression coverage for a misparse that
+##     evaluated only the first macro name (always false here, since
+##     NEVER_DEFINED_FEATURE is never defined by any test config) instead of
+##     conservatively treating the whole compound expression as active. The
+##     "with CONDITIONAL_FEATURE" scenario below expects two calls for this
+##     reason, not one.
 ##   - Files contain UTF-8 multi-byte characters in comments to exercise
 ##     encoding safety of the conditional-tracking path
 ##
@@ -113,7 +122,11 @@ ceedling_system_tests do
       # so OptionalDep_DoWork() is included in the partial. The test file's
       # corresponding #ifdef generates the mock. The #ifdef test case runs and
       # passes (ConditionalModule_Init() calls OptionalDep_DoWork() in the
-      # partial; the mock satisfies the expectation).
+      # partial; the mock satisfies the expectation). Two calls, not one: the
+      # nested compound-guarded call must also be conservatively included (see
+      # header comment above) -- a misparse of that compound condition would
+      # leave only one real call, one short of the two expectations, failing
+      # the test via an unmet CMock expectation rather than a raw crash.
       # -----------------------------------------------------------------------
       it "should include active #ifdef block and run #ifdef test case" do
         @c.with_context do

--- a/spec/units/partials/partializer_utils_spec.rb
+++ b/spec/units/partials/partializer_utils_spec.rb
@@ -511,7 +511,7 @@ describe PartializerUtils do
     let(:code_block)            { 'void foo(void) {}' }
 
     it "returns line number from preprocessed file when found there" do
-      expect(@code_finder).to receive(:find_in_preprpocessed_file)
+      expect(@code_finder).to receive(:find_in_preprocessed_file)
         .with(preprocessed_filepath, code_block)
         .and_return(10)
       expect(@code_finder).not_to receive(:find_in_c_file)
@@ -525,7 +525,7 @@ describe PartializerUtils do
     end
 
     it "falls back to C source when not found in preprocessed file" do
-      allow(@code_finder).to receive(:find_in_preprpocessed_file).and_return(nil)
+      allow(@code_finder).to receive(:find_in_preprocessed_file).and_return(nil)
       expect(@code_finder).to receive(:find_in_c_file).with(filepath, code_block).and_return(25)
 
       result = @utils.locate_function_via_preprocessed(
@@ -537,7 +537,7 @@ describe PartializerUtils do
     end
 
     it "returns nil when found in neither preprocessed nor C source" do
-      allow(@code_finder).to receive(:find_in_preprpocessed_file).and_return(nil)
+      allow(@code_finder).to receive(:find_in_preprocessed_file).and_return(nil)
       allow(@code_finder).to receive(:find_in_c_file).and_return(nil)
 
       result = @utils.locate_function_via_preprocessed(
@@ -549,7 +549,7 @@ describe PartializerUtils do
     end
 
     it "forwards correct arguments to both code_finder methods" do
-      expect(@code_finder).to receive(:find_in_preprpocessed_file)
+      expect(@code_finder).to receive(:find_in_preprocessed_file)
         .with('/exact/preproc.i', 'exact block')
         .and_return(nil)
       expect(@code_finder).to receive(:find_in_c_file)

--- a/spec/units/preprocess/c_preprocessor_conditionals_spec.rb
+++ b/spec/units/preprocess/c_preprocessor_conditionals_spec.rb
@@ -175,6 +175,21 @@ RSpec.describe CPreprocessorConditionals do
       expect(t.active?).to be true
     end
 
+    it 'treats #if defined(A) && defined(B) as active even when A is not defined' do
+      # A coincidentally-passing version of this case with A defined exists above --
+      # it can't distinguish "correctly conservative" from "matched defined(A) alone
+      # and A happens to be true." Only an undefined first macro tells them apart.
+      t = CPreprocessorConditionals.new([])
+      t.process_directive('#if defined(A) && defined(B)')
+      expect(t.active?).to be true
+    end
+
+    it 'treats #if !defined(A) || defined(B) as active even when A is defined' do
+      t = CPreprocessorConditionals.new(['A'])
+      t.process_directive('#if !defined(A) || defined(B)')
+      expect(t.active?).to be true
+    end
+
   end
 
 
@@ -267,6 +282,13 @@ RSpec.describe CPreprocessorConditionals do
       t = CPreprocessorConditionals.new([])
       t.process_directive('#if 0')
       t.process_directive('#elif VERSION > 3')
+      expect(t.active?).to be true
+    end
+
+    it 'treats #elif defined(A) && defined(B) as active when prior branch inactive, even when A is not defined' do
+      t = CPreprocessorConditionals.new([])
+      t.process_directive('#if 0')
+      t.process_directive('#elif defined(A) && defined(B)')
       expect(t.active?).to be true
     end
 

--- a/spec/units/preprocess/preprocessinator_code_finder_spec.rb
+++ b/spec/units/preprocess/preprocessinator_code_finder_spec.rb
@@ -15,14 +15,14 @@ describe PreprocessinatorCodeFinder do
     @finder = described_class.new({ file_wrapper: @file_wrapper })
   end
 
-  context "#find_in_preprpocessed_string" do
+  context "#find_in_preprocessed_string" do
 
     # -----------------------------------------------------------------------
     # nil cases
     # -----------------------------------------------------------------------
 
     it "returns nil for empty content" do
-      expect( @finder.find_in_preprpocessed_string( "", "int foo(void);" ) ).to be_nil
+      expect( @finder.find_in_preprocessed_string( "", "int foo(void);" ) ).to be_nil
     end
 
     it "returns nil when the search string is not present in the content" do
@@ -31,7 +31,7 @@ describe PreprocessinatorCodeFinder do
         int foo(void) { return 0; }
       PREPROCESSED
 
-      expect( @finder.find_in_preprpocessed_string( content, "int bar(void);" ) ).to be_nil
+      expect( @finder.find_in_preprocessed_string( content, "int bar(void);" ) ).to be_nil
     end
 
     it "returns nil when no line marker precedes the match" do
@@ -42,7 +42,7 @@ describe PreprocessinatorCodeFinder do
         int bar(void) { return 1; }
       PREPROCESSED
 
-      expect( @finder.find_in_preprpocessed_string( content, "int foo(void) { return 0; }" ) ).to be_nil
+      expect( @finder.find_in_preprocessed_string( content, "int foo(void) { return 0; }" ) ).to be_nil
     end
 
     # -----------------------------------------------------------------------
@@ -55,7 +55,7 @@ describe PreprocessinatorCodeFinder do
         int foo(void) { return 0; }
       PREPROCESSED
 
-      expect( @finder.find_in_preprpocessed_string( content, "int foo(void) { return 0; }" ) ).to eq 5
+      expect( @finder.find_in_preprocessed_string( content, "int foo(void) { return 0; }" ) ).to eq 5
     end
 
     it "returns the marker line number when code immediately follows the marker" do
@@ -64,7 +64,7 @@ describe PreprocessinatorCodeFinder do
         int foo(void) { return 0; }
       PREPROCESSED
 
-      expect( @finder.find_in_preprpocessed_string( content, "int foo(void) { return 0; }" ) ).to eq 5
+      expect( @finder.find_in_preprocessed_string( content, "int foo(void) { return 0; }" ) ).to eq 5
     end
 
     it "handles a line marker carrying a single flag" do
@@ -73,7 +73,7 @@ describe PreprocessinatorCodeFinder do
         void process(void);
       PREPROCESSED
 
-      expect( @finder.find_in_preprpocessed_string( content, "void process(void);" ) ).to eq 7
+      expect( @finder.find_in_preprocessed_string( content, "void process(void);" ) ).to eq 7
     end
 
     it "handles a line marker carrying multiple flags" do
@@ -84,7 +84,7 @@ describe PreprocessinatorCodeFinder do
         void init(uint32_t value);
       PREPROCESSED
 
-      expect( @finder.find_in_preprpocessed_string( content, "void init(uint32_t value);" ) ).to eq 4
+      expect( @finder.find_in_preprocessed_string( content, "void init(uint32_t value);" ) ).to eq 4
     end
 
     # -----------------------------------------------------------------------
@@ -105,7 +105,7 @@ describe PreprocessinatorCodeFinder do
         }
       PREPROCESSED
 
-      expect( @finder.find_in_preprpocessed_string( content, "int compute(int x) { return x * 2; }" ) ).to eq 12
+      expect( @finder.find_in_preprocessed_string( content, "int compute(int x) { return x * 2; }" ) ).to eq 12
     end
 
     # -----------------------------------------------------------------------
@@ -121,7 +121,7 @@ describe PreprocessinatorCodeFinder do
       PREPROCESSED
 
       # The second marker (line 20) is the last one before the match
-      expect( @finder.find_in_preprpocessed_string( content, "int foo(void) { return 0; }" ) ).to eq 20
+      expect( @finder.find_in_preprocessed_string( content, "int foo(void) { return 0; }" ) ).to eq 20
     end
 
     it "ignores line markers that appear after the match position" do
@@ -133,7 +133,7 @@ describe PreprocessinatorCodeFinder do
       PREPROCESSED
 
       # The # 10 marker follows the match and must not influence the result
-      expect( @finder.find_in_preprpocessed_string( content, "int found_here(void);" ) ).to eq 3
+      expect( @finder.find_in_preprocessed_string( content, "int found_here(void);" ) ).to eq 3
     end
 
     it "handles large line numbers correctly" do
@@ -144,7 +144,7 @@ describe PreprocessinatorCodeFinder do
         static void internal_helper(void) {}
       PREPROCESSED
 
-      expect( @finder.find_in_preprpocessed_string( content, "static void internal_helper(void) {}" ) ).to eq 247
+      expect( @finder.find_in_preprocessed_string( content, "static void internal_helper(void) {}" ) ).to eq 247
     end
 
     # -----------------------------------------------------------------------
@@ -167,7 +167,7 @@ describe PreprocessinatorCodeFinder do
         }
       FUNCTION
 
-      expect( @finder.find_in_preprpocessed_string( content, func ) ).to eq 15
+      expect( @finder.find_in_preprocessed_string( content, func ) ).to eq 15
     end
 
     it "reports the correct offset for a multiline match several lines after the marker" do
@@ -189,7 +189,7 @@ describe PreprocessinatorCodeFinder do
         }
       FUNCTION
 
-      expect( @finder.find_in_preprpocessed_string( content, func ) ).to eq 32
+      expect( @finder.find_in_preprocessed_string( content, func ) ).to eq 32
     end
 
     # -----------------------------------------------------------------------
@@ -214,7 +214,7 @@ describe PreprocessinatorCodeFinder do
       PREPROCESSED
 
       # After "# 5 "source.c" 2": line 5 = #include, line 6 = counter, line 7 = increment
-      expect( @finder.find_in_preprpocessed_string( content, "void increment(uint32_t *p) { (*p)++; }" ) ).to eq 7
+      expect( @finder.find_in_preprocessed_string( content, "void increment(uint32_t *p) { (*p)++; }" ) ).to eq 7
     end
 
   end
@@ -359,12 +359,12 @@ describe PreprocessinatorCodeFinder do
 
   end
 
-  context "#find_in_preprpocessed_file" do
+  context "#find_in_preprocessed_file" do
     it "opens the file through FileWrapper in read mode and delegates to the string search" do
       content = "# 1 \"source.c\"\nint foo(void) { return 0; }\n"
       allow(@file_wrapper).to receive(:open).with('source.c', 'r').and_yield(StringIO.new(content))
 
-      expect( @finder.find_in_preprpocessed_file( 'source.c', 'int foo(void) { return 0; }' ) ).to eq 1
+      expect( @finder.find_in_preprocessed_file( 'source.c', 'int foo(void) { return 0; }' ) ).to eq 1
     end
   end
 

--- a/spec/units/preprocess/preprocessinator_comment_stripper_spec.rb
+++ b/spec/units/preprocess/preprocessinator_comment_stripper_spec.rb
@@ -132,9 +132,9 @@ RSpec.describe PreprocessinatorCommentStripper do
 
         # Verify source-line mapping via PreprocessinatorCodeFinder round-trip.
         # #define SENSOR_H: marker # 1 + 4 newlines = line 5.
-        expect(@finder.find_in_preprpocessed_string(result, '#define SENSOR_H')).to eq(5)
+        expect(@finder.find_in_preprocessed_string(result, '#define SENSOR_H')).to eq(5)
         # #define MAX_CHANNELS 16: unchanged marker # 7 + 0 newlines = line 7.
-        expect(@finder.find_in_preprpocessed_string(result, '#define MAX_CHANNELS 16')).to eq(7)
+        expect(@finder.find_in_preprocessed_string(result, '#define MAX_CHANNELS 16')).to eq(7)
       end
 
       it 'handles a large realistic module header with multi-line block comment' do
@@ -174,10 +174,10 @@ RSpec.describe PreprocessinatorCommentStripper do
         # All markers # 8 through # 14 are unchanged.
         # Each # N "file" marker is immediately followed by its directive (0 newlines),
         # so code finder returns N+0=N for each.
-        expect(@finder.find_in_preprpocessed_string(result, '#ifndef BUFFER_H')).to eq(8)
-        expect(@finder.find_in_preprpocessed_string(result, '#define BUFFER_H')).to eq(9)
-        expect(@finder.find_in_preprpocessed_string(result, '#define BUFFER_MAX_SIZE 512')).to eq(10)
-        expect(@finder.find_in_preprpocessed_string(result, 'void buffer_init(Buffer *b);')).to eq(13)
+        expect(@finder.find_in_preprocessed_string(result, '#ifndef BUFFER_H')).to eq(8)
+        expect(@finder.find_in_preprocessed_string(result, '#define BUFFER_H')).to eq(9)
+        expect(@finder.find_in_preprocessed_string(result, '#define BUFFER_MAX_SIZE 512')).to eq(10)
+        expect(@finder.find_in_preprocessed_string(result, 'void buffer_init(Buffer *b);')).to eq(13)
       end
 
       it 'replaces multiple multi-line comments with blank lines preserving line markers' do
@@ -209,9 +209,9 @@ RSpec.describe PreprocessinatorCommentStripper do
         # FIRST: # 1 + 2 newlines (\n replacement + original \n after */) = 3.
         # SECOND: # 5 + 2 newlines = 7.
         # THIRD: # 9 + 0 newlines = 9.
-        expect(@finder.find_in_preprpocessed_string(result, '#define FIRST 1')).to eq(3)
-        expect(@finder.find_in_preprpocessed_string(result, '#define SECOND 2')).to eq(7)
-        expect(@finder.find_in_preprpocessed_string(result, '#define THIRD 3')).to eq(9)
+        expect(@finder.find_in_preprocessed_string(result, '#define FIRST 1')).to eq(3)
+        expect(@finder.find_in_preprocessed_string(result, '#define SECOND 2')).to eq(7)
+        expect(@finder.find_in_preprocessed_string(result, '#define THIRD 3')).to eq(9)
       end
 
       it 'replaces a multi-line comment before any line marker with equivalent blank lines' do
@@ -226,7 +226,7 @@ RSpec.describe PreprocessinatorCommentStripper do
         expect(result).not_to include('/*')
         # Marker unchanged; code finder: # 3 + 0 newlines = 3.
         expect(result).to include('# 3 "foo.c"')
-        expect(@finder.find_in_preprpocessed_string(result, '#define FOO 1')).to eq(3)
+        expect(@finder.find_in_preprocessed_string(result, '#define FOO 1')).to eq(3)
       end
 
       it 'handles an inline single-line /* */ block comment without changing markers' do
@@ -272,8 +272,8 @@ RSpec.describe PreprocessinatorCommentStripper do
         expect(result).not_to include('/*')
         # int result = 0: marker # 1 + 0 newlines = 1.
         # result += 1: marker # 1 + 3 newlines (code \n + \n replacement + original \n after */) = 4.
-        expect(@finder.find_in_preprpocessed_string(result, 'int result = 0;')).to eq(1)
-        expect(@finder.find_in_preprpocessed_string(result, 'result += 1;')).to eq(4)
+        expect(@finder.find_in_preprocessed_string(result, 'int result = 0;')).to eq(1)
+        expect(@finder.find_in_preprocessed_string(result, 'result += 1;')).to eq(4)
       end
 
       it 'maps code before a comment and code after when a subsequent marker exists' do
@@ -295,9 +295,9 @@ RSpec.describe PreprocessinatorCommentStripper do
         # int result = 0: marker # 1 + 0 newlines = 1.
         # result += 1: marker # 1 + 3 newlines = 4 (original source line 4).
         # return result: unchanged marker # 6 + 0 newlines = 6.
-        expect(@finder.find_in_preprpocessed_string(result, 'int result = 0;')).to eq(1)
-        expect(@finder.find_in_preprpocessed_string(result, 'result += 1;')).to eq(4)
-        expect(@finder.find_in_preprpocessed_string(result, 'return result;')).to eq(6)
+        expect(@finder.find_in_preprocessed_string(result, 'int result = 0;')).to eq(1)
+        expect(@finder.find_in_preprocessed_string(result, 'result += 1;')).to eq(4)
+        expect(@finder.find_in_preprocessed_string(result, 'return result;')).to eq(6)
       end
 
       it 'maps multiple code lines before a comment and code after' do
@@ -322,10 +322,10 @@ RSpec.describe PreprocessinatorCommentStripper do
         # int port = 0:   marker # 1 + 1 newline = 2.
         # port = GPIO_BASE: marker # 1 + 5 newlines (void, int port, \n\n replacement, original \n) = 6.
         # gpio_write: unchanged marker # 8 + 0 = 8.
-        expect(@finder.find_in_preprpocessed_string(result, 'void gpio_init(void) {')).to eq(1)
-        expect(@finder.find_in_preprpocessed_string(result, 'int port = 0;')).to eq(2)
-        expect(@finder.find_in_preprpocessed_string(result, 'port = GPIO_BASE;')).to eq(6)
-        expect(@finder.find_in_preprpocessed_string(result, 'gpio_write(port);')).to eq(8)
+        expect(@finder.find_in_preprocessed_string(result, 'void gpio_init(void) {')).to eq(1)
+        expect(@finder.find_in_preprocessed_string(result, 'int port = 0;')).to eq(2)
+        expect(@finder.find_in_preprocessed_string(result, 'port = GPIO_BASE;')).to eq(6)
+        expect(@finder.find_in_preprocessed_string(result, 'gpio_write(port);')).to eq(8)
       end
 
       it 'maps code correctly when blank lines surround a comment within code' do
@@ -351,9 +351,9 @@ RSpec.describe PreprocessinatorCommentStripper do
         # uint32_t result: marker # 1 + 6 newlines
         #   (data \n, blank \n, \n\n replacement, original \n after */, blank \n) = 7.
         # process: unchanged marker # 9 + 0 = 9.
-        expect(@finder.find_in_preprpocessed_string(result, 'uint8_t data;')).to eq(1)
-        expect(@finder.find_in_preprpocessed_string(result, 'uint32_t result;')).to eq(7)
-        expect(@finder.find_in_preprpocessed_string(result, 'process(result);')).to eq(9)
+        expect(@finder.find_in_preprocessed_string(result, 'uint8_t data;')).to eq(1)
+        expect(@finder.find_in_preprocessed_string(result, 'uint32_t result;')).to eq(7)
+        expect(@finder.find_in_preprocessed_string(result, 'process(result);')).to eq(9)
       end
 
       it 'accumulates correct newline count for two comments under the same marker' do
@@ -379,10 +379,10 @@ RSpec.describe PreprocessinatorCommentStripper do
         # int y: marker # 1 + 3 newlines (x \n, \n replacement, original \n) = 4.
         # int z: marker # 1 + 6 newlines (x, repl, orig, y \n, repl, orig) = 7.
         # int w: unchanged marker # 9 + 0 = 9.
-        expect(@finder.find_in_preprpocessed_string(result, 'int x = 0;')).to eq(1)
-        expect(@finder.find_in_preprpocessed_string(result, 'int y = 0;')).to eq(4)
-        expect(@finder.find_in_preprpocessed_string(result, 'int z = 0;')).to eq(7)
-        expect(@finder.find_in_preprpocessed_string(result, 'int w = 0;')).to eq(9)
+        expect(@finder.find_in_preprocessed_string(result, 'int x = 0;')).to eq(1)
+        expect(@finder.find_in_preprocessed_string(result, 'int y = 0;')).to eq(4)
+        expect(@finder.find_in_preprocessed_string(result, 'int z = 0;')).to eq(7)
+        expect(@finder.find_in_preprocessed_string(result, 'int w = 0;')).to eq(9)
       end
 
       it 'handles // and /* */ comments interleaved with code under the same marker' do
@@ -406,9 +406,9 @@ RSpec.describe PreprocessinatorCommentStripper do
         # int x: marker # 1 + 0 = 1.
         # int y: marker # 1 + 3 newlines (x-line \n, \n replacement, original \n) = 4.
         # int z: unchanged marker # 6 + 0 = 6.
-        expect(@finder.find_in_preprpocessed_string(result, 'int x;')).to eq(1)
-        expect(@finder.find_in_preprpocessed_string(result, 'int y;')).to eq(4)
-        expect(@finder.find_in_preprpocessed_string(result, 'int z;')).to eq(6)
+        expect(@finder.find_in_preprocessed_string(result, 'int x;')).to eq(1)
+        expect(@finder.find_in_preprocessed_string(result, 'int y;')).to eq(4)
+        expect(@finder.find_in_preprocessed_string(result, 'int z;')).to eq(6)
       end
 
       it 'maps all code correctly in realistic function-level output with multiple comment types' do
@@ -455,13 +455,13 @@ RSpec.describe PreprocessinatorCommentStripper do
         #   (status-line \n + \n replacement + original \n after retry comment) = 10.
         # initialized = status: unchanged marker # 12 + 0 = 12.
         # }: unchanged marker # 13 + 0 = 13.
-        expect(@finder.find_in_preprpocessed_string(result, '#include <stdint.h>')).to eq(1)
-        expect(@finder.find_in_preprpocessed_string(result, 'static int initialized = 0;')).to eq(5)
-        expect(@finder.find_in_preprpocessed_string(result, 'void module_init(void) {')).to eq(6)
-        expect(@finder.find_in_preprpocessed_string(result, 'int status = 0;')).to eq(7)
-        expect(@finder.find_in_preprpocessed_string(result, 'status = do_init();')).to eq(10)
-        expect(@finder.find_in_preprpocessed_string(result, 'initialized = status;')).to eq(12)
-        expect(@finder.find_in_preprpocessed_string(result, '}')).to eq(13)
+        expect(@finder.find_in_preprocessed_string(result, '#include <stdint.h>')).to eq(1)
+        expect(@finder.find_in_preprocessed_string(result, 'static int initialized = 0;')).to eq(5)
+        expect(@finder.find_in_preprocessed_string(result, 'void module_init(void) {')).to eq(6)
+        expect(@finder.find_in_preprocessed_string(result, 'int status = 0;')).to eq(7)
+        expect(@finder.find_in_preprocessed_string(result, 'status = do_init();')).to eq(10)
+        expect(@finder.find_in_preprocessed_string(result, 'initialized = status;')).to eq(12)
+        expect(@finder.find_in_preprocessed_string(result, '}')).to eq(13)
       end
 
     end
@@ -506,13 +506,13 @@ RSpec.describe PreprocessinatorCommentStripper do
         # All markers # 7 through # 16 are unchanged.
         # Directives immediately follow their respective # N "file" markers (0 newlines
         # between), so code finder returns N+0=N for each.
-        expect(@finder.find_in_preprpocessed_string(result, '#ifndef PLATFORM_H')).to eq(7)
-        expect(@finder.find_in_preprpocessed_string(result, '#define PLATFORM_H')).to eq(8)
-        expect(@finder.find_in_preprpocessed_string(result, '#define CPU_FREQ_HZ  168000000UL')).to eq(9)
-        expect(@finder.find_in_preprpocessed_string(result, '#define FLASH_SIZE   0x100000UL')).to eq(10)
-        expect(@finder.find_in_preprpocessed_string(result, '#define RAM_SIZE     0x020000UL')).to eq(11)
-        expect(@finder.find_in_preprpocessed_string(result, 'typedef unsigned int uint32_t;')).to eq(12)
-        expect(@finder.find_in_preprpocessed_string(result, '#endif')).to eq(16)
+        expect(@finder.find_in_preprocessed_string(result, '#ifndef PLATFORM_H')).to eq(7)
+        expect(@finder.find_in_preprocessed_string(result, '#define PLATFORM_H')).to eq(8)
+        expect(@finder.find_in_preprocessed_string(result, '#define CPU_FREQ_HZ  168000000UL')).to eq(9)
+        expect(@finder.find_in_preprocessed_string(result, '#define FLASH_SIZE   0x100000UL')).to eq(10)
+        expect(@finder.find_in_preprocessed_string(result, '#define RAM_SIZE     0x020000UL')).to eq(11)
+        expect(@finder.find_in_preprocessed_string(result, 'typedef unsigned int uint32_t;')).to eq(12)
+        expect(@finder.find_in_preprocessed_string(result, '#endif')).to eq(16)
       end
 
     end
@@ -571,9 +571,9 @@ RSpec.describe PreprocessinatorCommentStripper do
         expect(result).not_to match(%r{^/}m)
 
         # Markers unchanged; code finder verifies byte-accurate replacement
-        expect(@finder.find_in_preprpocessed_string(result, '#define MODULE_H')).to eq(4)
-        expect(@finder.find_in_preprpocessed_string(result, '#define VERSION 1')).to eq(5)
-        expect(@finder.find_in_preprpocessed_string(result, 'int init(void);')).to eq(6)
+        expect(@finder.find_in_preprocessed_string(result, '#define MODULE_H')).to eq(4)
+        expect(@finder.find_in_preprocessed_string(result, '#define VERSION 1')).to eq(5)
+        expect(@finder.find_in_preprocessed_string(result, 'int init(void);')).to eq(6)
       end
 
     end

--- a/spec/units/preprocess/preprocessinator_spec.rb
+++ b/spec/units/preprocess/preprocessinator_spec.rb
@@ -133,4 +133,65 @@ RSpec.describe Preprocessinator do
 
   end
 
+  # ===========================================================================
+  describe '#preprocess_partial_header_expand_macros / #preprocess_partial_source_expand_macros' do
+  # ===========================================================================
+  # Both public methods funnel through the same private _preprocess_partial_expand_macros.
+
+    let(:filepath) { '/src/module.c' }
+
+    def call_it(method: :preprocess_partial_header_expand_macros)
+      subject.send(
+        method,
+        filepath:      filepath,
+        test:          'test',
+        flags:         [],
+        include_paths: [],
+        vendor_paths:  [],
+        defines:       []
+      )
+    end
+
+    before do
+      allow(@file_path_utils).to receive(:form_preprocessed_file_full_expansion_filepath).and_return('/build/full_expansion/module.c')
+      allow(@configurator).to receive(:tools_test_file_full_preprocessor).and_return({})
+      allow(@tool_executor).to receive(:build_command_line).and_return({ options: {} })
+    end
+
+    # This is the actual bug: without boom: false, the real ToolExecutor#exec
+    # (not this double) raises ShellException on a nonzero exit code before
+    # the "if result[:exit_code] != 0 ... return nil" fallback below it ever
+    # runs, crashing the build instead of gracefully degrading as documented.
+    it "sets boom: false on the command before invoking the full preprocessor" do
+      captured_command = nil
+      allow(@tool_executor).to receive(:exec) do |command|
+        captured_command = command
+        { exit_code: 0 }
+      end
+      allow(@file_assembler).to receive(:collect_file_contents_from_full_expansion).and_return([])
+      allow(@file_assembler).to receive(:assemble_preprocessed_code_file)
+
+      call_it()
+
+      expect(captured_command[:options][:boom]).to eq(false)
+    end
+
+    it "returns nil without raising when the full preprocessor invocation fails" do
+      allow(@tool_executor).to receive(:exec).and_return({ exit_code: 1 })
+
+      result = nil
+      expect { result = call_it() }.to_not raise_error
+      expect(result).to be_nil
+    end
+
+    it "returns nil without raising via preprocess_partial_source_expand_macros too" do
+      allow(@tool_executor).to receive(:exec).and_return({ exit_code: 1 })
+
+      result = nil
+      expect { result = call_it(method: :preprocess_partial_source_expand_macros) }.to_not raise_error
+      expect(result).to be_nil
+    end
+
+  end
+
 end


### PR DESCRIPTION
## Summary
Phase 1 of a 3-phase review of `lib/ceedling/preprocess/` (Phase 2: test coverage, Phase 3: refactor — to follow in separate PRs). Cosmetic cleanup plus two confirmed, narrow bugs found during an exploratory code review, both fixed test-first.

- Renames `PreprocessinatorCodeFinder#find_in_preprpocessed_file`/`#find_in_preprpocessed_string` (typo'd "preprpocessed") to the correct spelling — shipped public API, not test-only, so fixed along with its one caller (`partializer_utils.rb`) and every spec reference.
- Fixes `CPreprocessorConditionals` misparsing compound `defined()` conditions: `#if defined(A) && defined(B)` matched the single-macro regex (capturing only `A`, silently ignoring `&& defined(B)`) instead of falling through to the documented conservative "complex expression → treat as active" catch-all. An existing unit test for this case happened to use a defined first macro, which coincidentally agreed with the buggy narrow reading — it never actually exercised the divergence. New unit tests use an undefined first macro to catch it; a new system-test scenario (nesting a second, compound-guarded call in a Partial source file, verified to fail pre-fix via an unmet CMock expectation and pass post-fix) confirms the fix end-to-end.
- Fixes a dead graceful-fallback path in `Preprocessinator#_preprocess_partial_expand_macros`: the full-preprocessor invocation never set `command[:options][:boom] = false`, so `ToolExecutor#exec`'s default `boom: true` raised `ShellException` and crashed the build on any nonzero exit code — before the very next lines' documented fallback ("directives-only signatures will be used", return `nil`) could ever run. `generate_directives_only_output` earlier in the same file already sets `boom: false` correctly; this method appears to have simply omitted it.

## Test plan
- [x] `bundle exec rspec spec/units/preprocess` and `bundle exec rspec spec/units` (full suite) — 2732 examples, 0 failures
- [x] Docker-verified system tests (`preprocessing_encoding_spec.rb`, `preprocessing_fallback_conditionals_spec.rb`, `preprocessing_locale_spec.rb`, `preprocessing_parameterized_tests_spec.rb`, `example_wondrous_forest_spec.rb`, `example_cipher_quest_spec.rb`) — 36 examples, 0 failures
- [x] Both bug-fix regressions manually verified to fail against pre-fix code and pass against post-fix code (unit-level for both; system-level for the compound `defined()` fix)