### PR TITLE
Fix #1236: generated test runner loses system-include directory/brackets

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,10 +12,15 @@ This changelog is complemented by three other documents:
 
 # [1.1.6] — Prerelease
 
+## 🌟 Added
+
+- Latest patch releases of Unity, CMock, and CException.
+
 ## 💪 Fixed
 
 - [#1223](https://github.com/ThrowTheSwitch/Ceedling/issues/1223) Fixed a conditional `#include` silently dropping out of generated code derived from preprocessed code, breaking compilation with an undeclared identifier error. The specific case involves a macro defined by another header included earlier in the same file.
 - [#1216](https://github.com/ThrowTheSwitch/Ceedling/issues/1216) Fixed self-test issue that caused docs-related failures when the local documentation was unavailable (generated in CI but not necessarily present during self tests).
+- [#1236](https://github.com/ThrowTheSwitch/Ceedling/issues/1236) Fixed an issue that converted system includes extracted from a test C file into user includes when generating a test runner (e.g. `#include <sys/stat.h>` became `#include "stat.h"`) and also stripped relative paths of all includes injected into a test runner.
 
 ### Partials
 

--- a/lib/ceedling/generators/generator_test_runner.rb
+++ b/lib/ceedling/generators/generator_test_runner.rb
@@ -7,6 +7,7 @@
 
 require 'generate_test_runner' # Unity's test runner generator
 require 'ceedling/parsing_parcels'
+require 'ceedling/includes/includes'
 
 class GeneratorTestRunner
 
@@ -38,7 +39,30 @@ class GeneratorTestRunner
       @test_cases_internal,
       # Small hack for mock subdirectory support until include paths fully supported
       mocks.map{ |include| include.filepath },
-      includes.map{ |include| include.filename }
+      # Unity's own generator emits a string verbatim if it contains '<' and otherwise
+      # wraps it in double quotes -- each entry here must therefore already be in its
+      # final, exact form.
+      #
+      # System includes only: use the full, bracketed spelling (include_path, a
+      # reconciled SystemInclude's original as-written directive text -- e.g.
+      # "sys/stat.h" -- when set, else the directory-preserving filepath). A bare
+      # filename here drops both the directory component and the '<>' delimiters a
+      # system header's own search path depends on (issue #1236).
+      #
+      # User includes: bare filename, same as always. Unlike mocks (whose subdirectory
+      # is a real, dedicated build/test/mocks/<test>/ path -- hence their own
+      # directory-preserving filepath usage above) or a system header (whose directory
+      # is meaningful to the system include search path), a project's own directories
+      # are exposed to the compiler as a flat list of -I search paths, not nested to
+      # match whatever directory component a captured UserInclude's filepath happens to
+      # carry -- rendering the full path here breaks resolution instead of fixing it.
+      includes.map do |include|
+        if include.is_a?(SystemInclude)
+          "<#{include.include_path || include.filepath}>"
+        else
+          include.filename
+        end
+      end
     )
   end
 

--- a/spec/system/test_runner_system_include_spec.rb
+++ b/spec/system/test_runner_system_include_spec.rb
@@ -1,0 +1,90 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+
+##
+## Generated Runner Preserves System #include Directory/Brackets (issue #1236)
+## =============================================================================
+##
+## A test file directly #include-ing a system header with a directory component
+## (e.g. `#include <sys/stat.h>`) previously produced a generated runner containing
+## `#include "stat.h"` -- the directory component and the system-include `<>`
+## delimiters were both lost, since GeneratorTestRunner#generate rendered every
+## include (mocks aside) down to its bare basename with no `<>` for system headers.
+## The test file itself compiled fine; only the separately generated runner file
+## failed, with a "No such file or directory" error on the mangled include.
+##
+
+TEST_RUNNER_SYSTEM_INCLUDE_C = <<~C
+  #include <sys/stat.h>
+
+  #include "unity.h"
+
+  void setUp(void) {}
+  void tearDown(void) {}
+
+  void test_runner_preserves_system_include_path(void)
+  {
+    struct stat value;
+    TEST_ASSERT_EQUAL_UINT(sizeof(value), sizeof(struct stat));
+  }
+C
+
+ceedling_system_tests do
+
+  before :all do
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  before { @proj_name = unique_proj_name("runner_sys_inc") }
+
+  describe "Deployed as a gem" do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new #{@proj_name}")
+      end
+    end
+
+    before do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          File.write('test/test_runner_system_include.c', TEST_RUNNER_SYSTEM_INCLUDE_C)
+        end
+      end
+    end
+
+    it "preserves a system include's directory component and angle brackets in the generated runner" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_build_exec("test:all")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/TESTED:\s+1/)
+          expect(output).to match(/PASSED:\s+1/)
+          expect(output).to match(/FAILED:\s+0/)
+
+          # The generated runner is what actually failed to compile in the reported
+          # issue -- assert on its content directly rather than just overall build
+          # success, since only the runner (not the test file itself) was affected.
+          runner_path = Dir.glob('build/test/runners/*_runner.c').first
+          expect(runner_path).not_to be_nil
+
+          runner_contents = File.read(runner_path)
+          expect(runner_contents).to include('#include <sys/stat.h>')
+          expect(runner_contents).not_to include('#include "stat.h"')
+        end
+      end
+    end
+  end
+
+end

--- a/spec/units/generators/generator_test_runner_spec.rb
+++ b/spec/units/generators/generator_test_runner_spec.rb
@@ -8,6 +8,7 @@
 require 'spec_helper'
 require 'ceedling/generators/generator_test_runner'
 require 'ceedling/parsing_parcels'
+require 'ceedling/includes/includes'
 
 describe GeneratorTestRunner do
   before(:each) do
@@ -139,6 +140,74 @@ describe GeneratorTestRunner do
           { test: 'test_value_out_of_range_good(-1, 1)',   symbol: 'runner_args2_test_value_out_of_range_good', line_number: 6 }
         ]
       )
+    end
+  end
+
+  # ===========================================================================
+  describe '#generate' do
+  # ===========================================================================
+    # Regression coverage for https://github.com/ThrowTheSwitch/Ceedling/issues/1236:
+    # a system #include with a directory component (e.g. <sys/stat.h>) was rendered
+    # into the generated runner as a bare, unbracketed basename ("stat.h"), losing
+    # both the directory and the user/system distinction, breaking runner compilation.
+    #
+    # @unity_runner_generator is a real UnityTestRunnerGenerator, constructed directly
+    # inside #initialize rather than injected -- swapped out for a double here so these
+    # specs assert on exactly what GeneratorTestRunner itself hands off, independent of
+    # Unity's own generated file formatting.
+    def build_and_capture_includes(includes:, mocks: [])
+      runner = build_runner( test_file_contents: "void test_Thing(void) {}\n" )
+
+      captured = nil
+      fake_generator = double('unity_runner_generator')
+      allow(fake_generator).to receive(:generate) do |*args|
+        captured = args[4]
+      end
+      runner.instance_variable_set(:@unity_runner_generator, fake_generator)
+
+      runner.generate(
+        module_name: 'test_thing',
+        runner_filepath: '/build/test/runners/test_thing_runner.c',
+        mocks: mocks,
+        includes: includes
+      )
+
+      return captured
+    end
+
+    it 'renders a system include with a directory component in angle brackets, directory intact' do
+      captured = build_and_capture_includes( includes: [ SystemInclude.new('sys/stat.h') ] )
+
+      expect( captured ).to eq( ['<sys/stat.h>'] )
+    end
+
+    it 'prefers a reconciled system include\'s include_path over its resolved filepath' do
+      # Mirrors what Includes.reconcile actually produces: filepath is the real,
+      # resolved (possibly absolute) location; include_path is the original,
+      # as-written directive text that must be what's rendered.
+      reconciled = SystemInclude.new('/usr/include/sys/stat.h', include_path: 'sys/stat.h')
+
+      captured = build_and_capture_includes( includes: [ reconciled ] )
+
+      expect( captured ).to eq( ['<sys/stat.h>'] )
+    end
+
+    it 'renders a user include with a directory component down to its bare filename, unchanged from prior behavior' do
+      # Unlike a system header, a project's own directories are exposed to the
+      # compiler as a flat list of -I search paths -- rendering a user include's
+      # own directory component here breaks resolution rather than fixing anything,
+      # so this behavior is intentionally unchanged by the issue #1236 fix.
+      captured = build_and_capture_includes( includes: [ UserInclude.new('sub/header.h') ] )
+
+      expect( captured ).to eq( ['header.h'] )
+    end
+
+    it 'renders a mixed list of system and user includes each in their own correct form' do
+      captured = build_and_capture_includes(
+        includes: [ SystemInclude.new('sys/stat.h'), UserInclude.new('sub/header.h') ]
+      )
+
+      expect( captured ).to eq( ['<sys/stat.h>', 'header.h'] )
     end
   end
 end


### PR DESCRIPTION
## Summary
Fixes #1236. A test file directly including a system header with a directory component (`#include <sys/stat.h>`) produced a generated test runner containing `#include "stat.h"` — directory component and system-include `<>` delimiters both lost, breaking runner compilation even though the test file itself compiled fine.

- `GeneratorTestRunner#generate` rendered every include (mocks aside) down to its bare basename via `Include#filename`, with no distinction between user and system includes. Unity's own runner generator expects each entry already in its final, exact output form — a string containing `<` is emitted verbatim, anything else gets wrapped in quotes.
- Fixed narrowly, **system includes only**: prefer a reconciled `SystemInclude`'s `include_path` (the original, as-written directive text already recovered by `Includes.reconcile` for issue #1194's sake) over its resolved `filepath`, wrapped in `<>`.
- User includes deliberately keep rendering as a bare filename, unchanged. An earlier, broader version of this fix also preserved user includes' directory components and broke `temp_sensor`'s `#include "src/Types.h"` — Ceedling exposes project directories to the compiler as a flat list of `-I` search paths, not nested to match an arbitrary captured directory component. Caught by running the full local system-test suite before finalizing, not by the new regression test itself.

## Test plan
- [x] 4 new unit examples in `spec/units/generators/generator_test_runner_spec.rb` covering system includes (with and without a reconciled `include_path`), user includes, and a mixed list — each confirmed to fail against pre-fix code and pass post-fix
- [x] New `spec/system/test_runner_system_include_spec.rb`, modeled directly on the issue's own repro (`#include <sys/stat.h>` + a trivial test using `struct stat`) — asserts on the generated runner file's actual content, not just overall build success; confirmed to fail pre-fix (`fatal error: 'stat.h' file not found`) and pass post-fix
- [x] `bundle exec rspec spec/units` — 1975 examples, 0 failures, 1 pre-existing unrelated pending
- [x] Full local system-test run (75 examples: the new spec plus `conditional_include_macro_visibility_spec.rb`, `example_temp_sensor_spec.rb`, `example_wondrous_forest_spec.rb`, `mixin_ordering_spec.rb`) — 0 failures, confirming no regression in the shared mock/include-generation code path