### PR TITLE
preprocess/: Phase 2 — test coverage

### DIFF
--- a/spec/units/preprocess/preprocessinator_bare_includes_extractor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_bare_includes_extractor_spec.rb
@@ -1,0 +1,114 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/preprocess/preprocessinator_bare_includes_extractor'
+require 'ceedling/includes/includes'
+
+# Pure, stateless parser -- no IO, no fixtures needed, just real make-rule
+# text as GCC's `-M -MG -MP` output would actually contain it.
+describe PreprocessinatorBareIncludesExtractor do
+  describe '.extract_includes' do
+    it 'returns an empty list for a self-referential rule with no dependencies' do
+      make_rules = "widget.o: widget.h\n"
+
+      includes = described_class.extract_includes( make_rules )
+
+      expect( includes ).to eq( [] )
+    end
+
+    it 'extracts a single include from its own phony rule line' do
+      make_rules = <<~MAKE
+        widget.o: widget.h fstd_types.h
+        fstd_types.h:
+      MAKE
+
+      includes = described_class.extract_includes( make_rules )
+
+      expect( includes.map(&:filepath) ).to eq( ['fstd_types.h'] )
+    end
+
+    it 'extracts multiple includes, each from its own phony rule line' do
+      make_rules = <<~MAKE
+        os.o: ../../src/app/task/os/os.h fstd_types.h FreeRTOS.h queue.h
+        fstd_types.h:
+        FreeRTOS.h:
+        queue.h:
+      MAKE
+
+      includes = described_class.extract_includes( make_rules )
+
+      expect( includes.map(&:filepath) ).to eq( ['fstd_types.h', 'FreeRTOS.h', 'queue.h'] )
+    end
+
+    it 'deduplicates a phony rule line that appears more than once' do
+      make_rules = <<~MAKE
+        widget.o: widget.h fstd_types.h
+        fstd_types.h:
+        fstd_types.h:
+      MAKE
+
+      includes = described_class.extract_includes( make_rules )
+
+      expect( includes.map(&:filepath) ).to eq( ['fstd_types.h'] )
+    end
+
+    it 'extracts both .h and .c dependencies' do
+      make_rules = <<~MAKE
+        widget.o: widget.h helper.c
+        helper.c:
+        widget.h:
+      MAKE
+
+      includes = described_class.extract_includes( make_rules )
+
+      expect( includes.map(&:filepath) ).to eq( ['helper.c', 'widget.h'] )
+    end
+
+    it 'extracts a dependency with a relative directory path' do
+      make_rules = <<~MAKE
+        os.o: ../../src/app/task/os/os.h
+        ../../src/app/task/os/os.h:
+      MAKE
+
+      includes = described_class.extract_includes( make_rules )
+
+      expect( includes.map(&:filepath) ).to eq( ['../../src/app/task/os/os.h'] )
+    end
+
+    it 'ignores trailing compiler error output after the phony rules' do
+      make_rules = <<~MAKE
+        os.o: ../../src/app/task/os/os.h stdbool.h
+        stdbool.h:
+        ../../src/app/task/os/os.h:72:21: error: no include path in which to search for stdbool.h
+           72 | #include <stdbool.h>
+              |                     ^
+      MAKE
+
+      includes = described_class.extract_includes( make_rules )
+
+      expect( includes.map(&:filepath) ).to eq( ['stdbool.h'] )
+    end
+
+    it 'returns an empty list for input with no phony rule lines at all' do
+      includes = described_class.extract_includes( '' )
+
+      expect( includes ).to eq( [] )
+    end
+
+    it 'returns plain Include objects, not a subclass' do
+      make_rules = <<~MAKE
+        widget.o: widget.h fstd_types.h
+        fstd_types.h:
+      MAKE
+
+      includes = described_class.extract_includes( make_rules )
+
+      expect( includes.first.class ).to eq( Include )
+    end
+  end
+end

--- a/spec/units/preprocess/preprocessinator_file_assembler_spec.rb
+++ b/spec/units/preprocess/preprocessinator_file_assembler_spec.rb
@@ -509,4 +509,157 @@ RSpec.describe PreprocessinatorFileAssembler do
 
   end
 
+
+  # ===========================================================================
+  describe '#collect_file_contents_from_directives_only_preprocessing' do
+  # ===========================================================================
+
+    it 'extracts file content from the raw directives-only preprocessor output' do
+      source_filepath = 'test/test_widget.c'
+      allow(@file_path_utils).to receive(:form_preprocessed_file_raw_directives_only_filepath)
+        .with(source_filepath, 'test_widget')
+        .and_return('/build/directives_only/raw_test_widget.c')
+
+      file_contents = [
+        "# 1 \"#{source_filepath}\" 99999",
+        'void test_ShouldDoSomething(void) {}'
+      ].join("\n")
+      stub_file_open('/build/directives_only/raw_test_widget.c', file_contents, 'r')
+
+      result = subject.collect_file_contents_from_directives_only_preprocessing(
+        source_filepath: source_filepath, test: 'test_widget'
+      )
+
+      expect(result).to eq(['void test_ShouldDoSomething(void) {}'])
+    end
+
+  end
+
+
+  # ===========================================================================
+  describe '#collect_file_contents_from_full_expansion' do
+  # ===========================================================================
+
+    it 'extracts file content from the full-expansion preprocessor output' do
+      source_filepath = 'src/module.c'
+      allow(@file_path_utils).to receive(:form_preprocessed_file_full_expansion_filepath)
+        .with(source_filepath, 'test_module')
+        .and_return('/build/full_expansion/module.c')
+
+      file_contents = [
+        "# 1 \"#{source_filepath}\" 99999",
+        'void Module_Init(void) {}'
+      ].join("\n")
+      stub_file_open('/build/full_expansion/module.c', file_contents, 'r')
+
+      result = subject.collect_file_contents_from_full_expansion(
+        source_filepath: source_filepath, test: 'test_module'
+      )
+
+      expect(result).to eq(['void Module_Init(void) {}'])
+    end
+
+  end
+
+
+  # ===========================================================================
+  describe '#collect_macros_and_pragmas_fallback' do
+  # ===========================================================================
+
+    let(:source_filepath) { '/src/module.h' }
+
+    it 'extracts pragmas and macro definitions, excluding the include guard\'s own #define' do
+      allow(@file_wrapper).to receive(:read).with(source_filepath, 2048).and_return(
+        "#ifndef MODULE_H\n#define MODULE_H\n"
+      )
+      content = <<~C
+        #ifndef MODULE_H
+        #define MODULE_H
+        #pragma pack(1)
+        #define MAX_SIZE 10
+        void foo(void);
+        #endif
+      C
+      stub_file_open(source_filepath, content, 'rb')
+
+      result = subject.collect_macros_and_pragmas_fallback(source_filepath: source_filepath)
+
+      expect(result).to include('#pragma pack(1)')
+      expect(result).to include('#define MAX_SIZE 10')
+      expect(result).not_to include('#define MODULE_H')
+    end
+
+    it 'filters out macros inside an inactive conditional block' do
+      allow(@file_wrapper).to receive(:read).with(source_filepath, 2048).and_return('')
+      content = <<~C
+        #ifdef FEATURE_X
+        #define FEATURE_MACRO 1
+        #endif
+        #define ALWAYS_MACRO 2
+      C
+      stub_file_open(source_filepath, content, 'rb')
+
+      result = subject.collect_macros_and_pragmas_fallback(source_filepath: source_filepath, defines: [])
+
+      expect(result).not_to include('#define FEATURE_MACRO 1')
+      expect(result).to include('#define ALWAYS_MACRO 2')
+    end
+
+  end
+
+
+  # ===========================================================================
+  describe '#collect_test_file_contents' do
+  # ===========================================================================
+
+    let(:filepath) { 'test/test_widget.c' }
+
+    before do
+      allow(@file_path_utils).to receive(:form_preprocessed_file_full_expansion_filepath).and_return('/build/full_expansion/test_widget.c')
+      allow(@configurator).to receive(:tools_test_file_full_preprocessor).and_return({})
+      allow(@tool_executor).to receive(:build_command_line).and_return({})
+      allow(@tool_executor).to receive(:exec)
+
+      full_expansion = [
+        "# 1 \"#{filepath}\" 99999",
+        'void test_ShouldDoSomething(void) {}'
+      ].join("\n")
+      stub_file_open('/build/full_expansion/test_widget.c', full_expansion, 'r')
+    end
+
+    it 'extracts contents from the full expansion and test directives via the fallback text scan when fallback: true' do
+      original_content = <<~C
+        TEST_SOURCE_FILE("other.c")
+        void test_ShouldDoSomething(void) {}
+      C
+      stub_file_open(filepath, original_content, 'rb')
+
+      contents, test_directives = subject.collect_test_file_contents(
+        test: 'test_widget', filepath: filepath, directives_only_filepath: '/build/directives_only/test_widget.c',
+        fallback: true, flags: [], defines: [], include_paths: []
+      )
+
+      expect(contents).to include('void test_ShouldDoSomething(void) {}')
+      expect(test_directives).to include('TEST_SOURCE_FILE("other.c")')
+    end
+
+    it 'extracts test directives from the directives-only output when fallback: false' do
+      directives_only_content = [
+        "# 1 \"#{filepath}\" 99999",
+        'TEST_SOURCE_FILE("other.c")',
+        'void test_ShouldDoSomething(void) {}'
+      ].join("\n")
+      stub_file_open('/build/directives_only/test_widget.c', directives_only_content, 'r')
+
+      contents, test_directives = subject.collect_test_file_contents(
+        test: 'test_widget', filepath: filepath, directives_only_filepath: '/build/directives_only/test_widget.c',
+        fallback: false, flags: [], defines: [], include_paths: []
+      )
+
+      expect(contents).to include('void test_ShouldDoSomething(void) {}')
+      expect(test_directives).to include('TEST_SOURCE_FILE("other.c")')
+    end
+
+  end
+
 end

--- a/spec/units/preprocess/preprocessinator_includes_handler_spec.rb
+++ b/spec/units/preprocess/preprocessinator_includes_handler_spec.rb
@@ -484,4 +484,135 @@ RSpec.describe PreprocessinatorIncludesHandler do
 
   end
 
+
+  # ===========================================================================
+  describe '#extract_user_includes_preprocess' do
+  # ===========================================================================
+
+    let(:filepath) { '/src/module.c' }
+
+    it 'delegates to the line-marker extractor with USER type, no depth limit, and the test name' do
+      expect(@preprocessinator_line_marker_includes_extractor).to receive(:extract_includes_from_file).with(
+        '/build/directives_only/module.c',
+        PreprocessinatorLineMarkerIncludesExtractor::USER,
+        test: 'test'
+      ).and_return( [ UserInclude.new('widget.h') ] )
+
+      result = subject.extract_user_includes_preprocess(
+        name: 'test', filepath: filepath, preprocessed_filepath: '/build/directives_only/module.c'
+      )
+
+      expect(result.map(&:filename)).to eq(['widget.h'])
+    end
+
+    it 'removes a self-referential entry matching the file being processed' do
+      allow(@preprocessinator_line_marker_includes_extractor).to receive(:extract_includes_from_file).and_return(
+        [ UserInclude.new(filepath), UserInclude.new('widget.h') ]
+      )
+
+      result = subject.extract_user_includes_preprocess(
+        name: 'test', filepath: filepath, preprocessed_filepath: '/build/directives_only/module.c'
+      )
+
+      expect(result.map(&:filename)).to eq(['widget.h'])
+    end
+
+  end
+
+
+  # ===========================================================================
+  describe '#extract_system_includes_preprocess' do
+  # ===========================================================================
+
+    let(:filepath) { '/src/module.c' }
+
+    it 'delegates to the line-marker extractor with SYSTEM type and a practical max depth of 5' do
+      expect(@preprocessinator_line_marker_includes_extractor).to receive(:extract_includes_from_file).with(
+        '/build/directives_only/module.c',
+        PreprocessinatorLineMarkerIncludesExtractor::SYSTEM,
+        5
+      ).and_return( [ SystemInclude.new('stdint.h') ] )
+
+      result = subject.extract_system_includes_preprocess(
+        name: 'test', filepath: filepath, preprocessed_filepath: '/build/directives_only/module.c'
+      )
+
+      expect(result.map(&:filename)).to eq(['stdint.h'])
+    end
+
+    it 'removes a self-referential entry matching the file being processed' do
+      allow(@preprocessinator_line_marker_includes_extractor).to receive(:extract_includes_from_file).and_return(
+        [ SystemInclude.new(filepath), SystemInclude.new('stdint.h') ]
+      )
+
+      result = subject.extract_system_includes_preprocess(
+        name: 'test', filepath: filepath, preprocessed_filepath: '/build/directives_only/module.c'
+      )
+
+      expect(result.map(&:filename)).to eq(['stdint.h'])
+    end
+
+  end
+
+
+  # ===========================================================================
+  describe '#write_includes_list' do
+  # ===========================================================================
+
+    it 'dumps the includes list, converted to hashes, to the given filepath' do
+      captured = nil
+      allow(@yaml_wrapper).to receive(:dump) { |filepath, hashes| captured = [filepath, hashes] }
+
+      subject.write_includes_list( '/build/includes/module.c.yml', [ UserInclude.new('widget.h') ] )
+
+      expect(captured[0]).to eq('/build/includes/module.c.yml')
+      expect(captured[1]).to eq( Includes.to_hashes( [ UserInclude.new('widget.h') ] ) )
+    end
+
+  end
+
+
+  # ===========================================================================
+  describe '#load_includes_list' do
+  # ===========================================================================
+
+    it 'loads and converts a hash list back into Include objects' do
+      allow(@yaml_wrapper).to receive(:load).and_return(
+        [ { 'type' => 'user', 'filepath' => 'widget.h' } ]
+      )
+
+      result = subject.load_includes_list( '/build/includes/module.c.yml' )
+
+      expect(result.map(&:filename)).to eq(['widget.h'])
+      expect(result.first).to be_a(UserInclude)
+    end
+
+    it 'treats nil YAML content (an empty cache file) as an empty list, not nil' do
+      allow(@yaml_wrapper).to receive(:load).and_return(nil)
+
+      result = subject.load_includes_list( '/build/includes/module.c.yml' )
+
+      expect(result).to eq([])
+    end
+
+    it 'wraps a YamlLoadException with a clearer message, preserving reason/source/original_error' do
+      original_error = StandardError.new('boom')
+      allow(@yaml_wrapper).to receive(:load).and_raise(
+        YamlLoadException.new( reason: :syntax, source: '/build/includes/module.c.yml', original_error: original_error, message: 'line 3: bad indentation' )
+      )
+
+      expect {
+        subject.load_includes_list( '/build/includes/module.c.yml' )
+      }.to raise_error do |error|
+        expect(error).to be_a(YamlLoadException)
+        expect(error.reason).to eq(:syntax)
+        expect(error.source).to eq('/build/includes/module.c.yml')
+        expect(error.original_error).to eq(original_error)
+        expect(error.message).to match(/Cached #include list is corrupted or unreadable/)
+        expect(error.message).to match(/line 3: bad indentation/)
+      end
+    end
+
+  end
+
 end

--- a/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
@@ -1,0 +1,191 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/preprocess/preprocessinator_line_marker_includes_extractor'
+require 'ceedling/includes/includes'
+
+# Built entirely on #extract_includes_from_string -- a StringIO wrapper around the
+# same private #extract_includes every production call eventually reaches, so no
+# real files or fixtures are needed for full coverage of this parser's branching.
+describe PreprocessinatorLineMarkerIncludesExtractor do
+  before(:each) do
+    @include_factory = double('include_factory')
+    @file_wrapper     = double('file_wrapper')
+
+    allow(@include_factory).to receive(:user_include_from_filepath) do |filepath, test: nil|
+      UserInclude.new(filepath)
+    end
+    allow(@include_factory).to receive(:system_include_from_filepath) do |filepath|
+      SystemInclude.new(filepath)
+    end
+
+    @extractor = described_class.new(
+      :include_factory => @include_factory,
+      :file_wrapper    => @file_wrapper
+    )
+  end
+
+  def paths_of(includes)
+    includes.map(&:filepath)
+  end
+
+  describe '#extract_includes_from_string' do
+    it 'raises for an invalid type argument' do
+      expect {
+        @extractor.extract_includes_from_string( "# 1 \"test.c\"\n", 'test.c', :bogus )
+      }.to raise_error( CeedlingException, /Invalid type argument/ )
+    end
+
+    it 'skips <built-in> and <command-line> markers regardless of initial-file state' do
+      content = <<~OUTPUT
+        # 1 "<built-in>"
+        # 1 "<command-line>" 2
+        # 1 "test.c"
+        # 1 "widget.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['widget.h'] )
+    end
+
+    it 'ignores line markers before the initial file is found, even at line 1' do
+      # A `# 1` marker for some other file (e.g. from an early command-line define)
+      # must not be mistaken for the real source file's own opening marker.
+      content = <<~OUTPUT
+        # 1 "something_else.h"
+        # 1 "test.c"
+        # 1 "widget.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['widget.h'] )
+    end
+
+    it 'extracts only non-system (flag 3 absent) includes for USER type' do
+      content = <<~OUTPUT
+        # 1 "test.c"
+        # 1 "widget.h" 1
+        # 1 "/usr/include/stdint.h" 1 3 4
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['widget.h'] )
+      expect( includes.first ).to be_a( UserInclude )
+    end
+
+    it 'extracts only system (flag 3 present) includes for SYSTEM type' do
+      content = <<~OUTPUT
+        # 1 "test.c"
+        # 1 "widget.h" 1
+        # 1 "/usr/include/stdint.h" 1 3 4
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::SYSTEM )
+
+      expect( paths_of(includes) ).to eq( ['/usr/include/stdint.h'] )
+      expect( includes.first ).to be_a( SystemInclude )
+    end
+
+    it 'threads the test: keyword argument into user_include_from_filepath' do
+      content = <<~OUTPUT
+        # 1 "test.c"
+        # 1 "widget.h" 1
+      OUTPUT
+
+      expect(@include_factory).to receive(:user_include_from_filepath).with('widget.h', test: 'test_widget')
+
+      @extractor.extract_includes_from_string( content, 'test.c', described_class::USER, test: 'test_widget' )
+    end
+
+    it 'increments depth entering a nested file and decrements when returning' do
+      # widget.h (depth 2) includes nested.h (depth 3); control then returns to
+      # test.c (flag 2, depth back to 1) before a sibling top-level include
+      # (also depth 2) -- confirms depth tracking survives a return.
+      content = <<~OUTPUT
+        # 1 "test.c"
+        # 1 "widget.h" 1
+        # 1 "nested.h" 1
+        # 9 "widget.h" 2
+        # 2 "test.c" 2
+        # 1 "sibling.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['widget.h', 'nested.h', 'sibling.h'] )
+    end
+
+    it 'excludes a file beyond max_depth while keeping shallower ones' do
+      # The source file itself is depth 1, so its own top-level includes (widget.h)
+      # are depth 2 -- max_depth: 2 keeps those while excluding anything nested deeper.
+      content = <<~OUTPUT
+        # 1 "test.c"
+        # 1 "widget.h" 1
+        # 1 "nested.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER, 2 )
+
+      expect( paths_of(includes) ).to eq( ['widget.h'] )
+    end
+
+    it 'applies no depth limit when max_depth is nil' do
+      content = <<~OUTPUT
+        # 1 "test.c"
+        # 1 "widget.h" 1
+        # 1 "nested.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER, nil )
+
+      expect( paths_of(includes) ).to eq( ['widget.h', 'nested.h'] )
+    end
+
+    it 'deduplicates a path reached more than once (e.g. via an include guard)' do
+      content = <<~OUTPUT
+        # 1 "test.c"
+        # 1 "shared.h" 1
+        # 2 "test.c" 2
+        # 1 "shared.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['shared.h'] )
+    end
+  end
+
+  describe '#extract_includes_from_file' do
+    it 'opens the file in binary mode and extracts the same way as from a string' do
+      # The initial-marker match is by basename against the filepath argument itself
+      # (there is no separate "original source" argument) -- the fixture path here
+      # must share a basename with the marker for extraction to find its start.
+      content = <<~OUTPUT
+        # 1 "test.c"
+        # 1 "widget.h" 1
+      OUTPUT
+
+      allow(@file_wrapper).to receive(:open).with('build/test.c', 'rb').and_yield( StringIO.new(content) )
+
+      includes = @extractor.extract_includes_from_file( 'build/test.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['widget.h'] )
+    end
+
+    it 'wraps an underlying failure in a CeedlingException identifying the file and type' do
+      allow(@file_wrapper).to receive(:open).and_raise( StandardError.new('file vanished') )
+
+      expect {
+        @extractor.extract_includes_from_file( 'directives_only.txt', described_class::SYSTEM )
+      }.to raise_error( CeedlingException, /directives_only\.txt/ )
+    end
+  end
+end

--- a/spec/units/preprocess/preprocessinator_spec.rb
+++ b/spec/units/preprocess/preprocessinator_spec.rb
@@ -192,6 +192,343 @@ RSpec.describe Preprocessinator do
       expect(result).to be_nil
     end
 
+    it "returns the full expansion filepath and assembles the code file on success" do
+      allow(@tool_executor).to receive(:exec).and_return({ exit_code: 0 })
+      allow(@file_assembler).to receive(:collect_file_contents_from_full_expansion).and_return(['expanded line'])
+
+      captured = nil
+      allow(@file_assembler).to receive(:assemble_preprocessed_code_file) { |**kwargs| captured = kwargs }
+
+      result = call_it()
+
+      expect(result).to eq('/build/full_expansion/module.c')
+      expect(captured[:contents]).to eq(['expanded line'])
+      expect(captured[:includes]).to eq([])
+      expect(captured[:extras]).to eq([])
+    end
+
+    it "reaches the same success behavior via preprocess_partial_source_expand_macros too" do
+      allow(@tool_executor).to receive(:exec).and_return({ exit_code: 0 })
+      allow(@file_assembler).to receive(:collect_file_contents_from_full_expansion).and_return(['expanded line'])
+      allow(@file_assembler).to receive(:assemble_preprocessed_code_file)
+
+      result = call_it(method: :preprocess_partial_source_expand_macros)
+
+      expect(result).to eq('/build/full_expansion/module.c')
+    end
+
+  end
+
+  # ===========================================================================
+  describe '#generate_directives_only_output' do
+  # ===========================================================================
+
+    let(:filepath) { '/src/module.c' }
+
+    def call_it
+      subject.generate_directives_only_output(
+        filepath:      filepath,
+        test:          'test',
+        flags:         [],
+        include_paths: [],
+        vendor_paths:  [],
+        defines:       []
+      )
+    end
+
+    before do
+      allow(@file_path_utils).to receive(:form_preprocessed_file_raw_directives_only_filepath).and_return('/build/directives_only/module.c')
+      allow(@file_path_utils).to receive(:form_preprocessed_file_compacted_directives_only_filepath).and_return('/build/directives_only/module_compacted.c')
+      allow(@configurator).to receive(:tools_test_file_directives_only_preprocessor).and_return({})
+      allow(@tool_executor).to receive(:build_command_line).and_return({ options: {} })
+      allow(@comment_stripper).to receive(:strip_file)
+      allow(@reconstructor).to receive(:compact_file_from_expansion)
+    end
+
+    it "sets boom: false on the command before invoking the directives-only preprocessor" do
+      captured_command = nil
+      allow(@tool_executor).to receive(:exec) do |command|
+        captured_command = command
+        { exit_code: 0 }
+      end
+
+      call_it()
+
+      expect(captured_command[:options][:boom]).to eq(false)
+    end
+
+    it "on success, strips comments, compacts the expansion, and returns the raw filepath" do
+      allow(@tool_executor).to receive(:exec).and_return({ exit_code: 0 })
+
+      result = call_it()
+
+      expect(@comment_stripper).to have_received(:strip_file).with('/build/directives_only/module.c')
+      expect(@reconstructor).to have_received(:compact_file_from_expansion).with(
+        input_filepath:  '/build/directives_only/module.c',
+        source_filepath: filepath,
+        output_filepath: '/build/directives_only/module_compacted.c'
+      )
+      expect(result).to eq('/build/directives_only/module.c')
+    end
+
+    it "returns nil without stripping or compacting when the preprocessor fails" do
+      allow(@tool_executor).to receive(:exec).and_return({ exit_code: 1 })
+
+      result = call_it()
+
+      expect(@comment_stripper).to_not have_received(:strip_file)
+      expect(@reconstructor).to_not have_received(:compact_file_from_expansion)
+      expect(result).to be_nil
+    end
+
+  end
+
+  # ===========================================================================
+  describe '#store_includes_list / #load_includes_list' do
+  # ===========================================================================
+
+    let(:filepath) { '/src/module.h' }
+
+    before do
+      allow(@file_path_utils).to receive(:form_preprocessed_includes_list_filepath).and_return('/build/includes/module.h.yml')
+    end
+
+    it "writes includes to the path computed from filepath/test" do
+      captured = nil
+      allow(@includes_handler).to receive(:write_includes_list) { |path, includes| captured = [path, includes] }
+
+      subject.store_includes_list( test: 'test', filepath: filepath, includes: [ UserInclude.new('a.h') ] )
+
+      expect(captured[0]).to eq('/build/includes/module.h.yml')
+      expect(captured[1].map(&:filename)).to eq(['a.h'])
+    end
+
+    it "loads includes from the same computed path" do
+      loaded = [ UserInclude.new('a.h') ]
+      allow(@includes_handler).to receive(:load_includes_list).with('/build/includes/module.h.yml').and_return(loaded)
+
+      result = subject.load_includes_list( test: 'test', filepath: filepath )
+
+      expect(result).to eq(loaded)
+    end
+
+  end
+
+  # ===========================================================================
+  describe '#preprocess_mockable_header_file' do
+  # ===========================================================================
+
+    let(:filepath) { '/src/module.h' }
+
+    def call_it(extras: false)
+      subject.preprocess_mockable_header_file(
+        test:                      'test',
+        filepath:                  filepath,
+        directives_only_filepath:  '/build/directives_only/module.h',
+        fallback:                  false,
+        flags:                     [],
+        include_paths:             [],
+        vendor_paths:              [],
+        defines:                   [],
+        extras:                    extras
+      )
+    end
+
+    before do
+      allow(@file_path_utils).to receive(:form_preprocessed_file_filepath).and_return('/build/preprocessed/module.h')
+      allow(@file_path_utils).to receive(:form_preprocessed_includes_list_filepath).and_return('/build/includes/module.h.yml')
+      allow(@includes_handler).to receive(:extract_bare_includes).and_return([])
+      allow(@includes_handler).to receive(:extract_bare_includes_from_text).and_return([])
+      allow(@includes_handler).to receive(:extract_user_includes_preprocess).and_return([])
+      allow(@includes_handler).to receive(:extract_system_includes_preprocess).and_return([])
+      allow(@includes_handler).to receive(:write_includes_list)
+      allow(@file_assembler).to receive(:collect_mockable_header_file_contents).and_return([['content'], [], nil])
+      allow(@file_assembler).to receive(:assemble_preprocessed_header_file)
+      allow(@plugin_manager).to receive(:pre_mock_preprocess)
+      allow(@plugin_manager).to receive(:post_mock_preprocess)
+    end
+
+    it "returns the preprocessed filepath" do
+      expect(call_it()).to eq('/build/preprocessed/module.h')
+    end
+
+    it "fires pre_mock_preprocess before assembling and post_mock_preprocess after" do
+      order = []
+      allow(@plugin_manager).to receive(:pre_mock_preprocess) { order << :pre }
+      allow(@file_assembler).to receive(:assemble_preprocessed_header_file) { order << :assemble }
+      allow(@plugin_manager).to receive(:post_mock_preprocess) { order << :post }
+
+      call_it()
+
+      expect(order).to eq([:pre, :assemble, :post])
+    end
+
+    it "passes extracted contents, extras, and include guard through to assemble_preprocessed_header_file" do
+      allow(@file_assembler).to receive(:collect_mockable_header_file_contents).and_return([['line1'], ['extra1'], 'MODULE_H'])
+
+      captured = nil
+      allow(@file_assembler).to receive(:assemble_preprocessed_header_file) { |**kwargs| captured = kwargs }
+
+      call_it()
+
+      expect(captured[:contents]).to eq(['line1'])
+      expect(captured[:extras]).to eq(['extra1'])
+      expect(captured[:include_guard]).to eq('MODULE_H')
+      expect(captured[:filename]).to eq('module.h')
+    end
+
+  end
+
+  # ===========================================================================
+  describe '#preprocess_partial_header_file_preserve_macros / #preprocess_partial_source_file_preserve_macros' do
+  # ===========================================================================
+
+    let(:filepath) { '/src/module.h' }
+
+    def call_it(method:, fallback:)
+      subject.send(
+        method,
+        test:                      'test',
+        filepath:                  filepath,
+        directives_only_filepath:  '/build/directives_only/module.h',
+        fallback:                  fallback,
+        flags:                     [],
+        include_paths:             [],
+        vendor_paths:              [],
+        defines:                   []
+      )
+    end
+
+    before do
+      allow(@file_path_utils).to receive(:form_preprocessed_file_filepath).and_return('/build/preprocessed/module.h')
+      allow(@file_path_utils).to receive(:form_preprocessed_includes_list_filepath).and_return('/build/includes/module.h.yml')
+      allow(@includes_handler).to receive(:extract_bare_includes).and_return([])
+      allow(@includes_handler).to receive(:extract_bare_includes_from_text).and_return([])
+      allow(@includes_handler).to receive(:extract_user_includes_preprocess).and_return([])
+      allow(@includes_handler).to receive(:extract_user_includes_from_text).and_return([])
+      allow(@includes_handler).to receive(:extract_system_includes_preprocess).and_return([])
+      allow(@includes_handler).to receive(:extract_system_includes_from_text).and_return([])
+      allow(@includes_handler).to receive(:write_includes_list)
+      allow(@file_assembler).to receive(:collect_file_contents_fallback).and_return(['fallback content'])
+      allow(@file_assembler).to receive(:collect_file_contents_from_directives_only_preprocessing).and_return(['directives content'])
+      allow(@file_assembler).to receive(:collect_macros_and_pragmas_fallback).and_return(['macro'])
+      allow(@file_assembler).to receive(:assemble_preprocessed_header_file)
+      allow(@file_assembler).to receive(:assemble_preprocessed_code_file)
+    end
+
+    it "uses the fallback content-source and re-extracts macros/pragmas when fallback: true (header)" do
+      captured = nil
+      allow(@file_assembler).to receive(:assemble_preprocessed_header_file) { |**kwargs| captured = kwargs }
+
+      call_it(method: :preprocess_partial_header_file_preserve_macros, fallback: true)
+
+      expect(@file_assembler).to have_received(:collect_file_contents_fallback)
+      expect(@file_assembler).to_not have_received(:collect_file_contents_from_directives_only_preprocessing)
+      expect(captured[:contents]).to eq(['fallback content'])
+      expect(captured[:extras]).to eq(['macro'])
+    end
+
+    it "uses directives-only content and empty extras when fallback: false (header)" do
+      captured = nil
+      allow(@file_assembler).to receive(:assemble_preprocessed_header_file) { |**kwargs| captured = kwargs }
+
+      call_it(method: :preprocess_partial_header_file_preserve_macros, fallback: false)
+
+      expect(@file_assembler).to have_received(:collect_file_contents_from_directives_only_preprocessing)
+      expect(@file_assembler).to_not have_received(:collect_file_contents_fallback)
+      expect(captured[:contents]).to eq(['directives content'])
+      expect(captured[:extras]).to eq([])
+    end
+
+    it "uses the fallback content-source for the source-file variant too" do
+      captured = nil
+      allow(@file_assembler).to receive(:assemble_preprocessed_code_file) { |**kwargs| captured = kwargs }
+
+      call_it(method: :preprocess_partial_source_file_preserve_macros, fallback: true)
+
+      expect(captured[:contents]).to eq(['fallback content'])
+      expect(captured[:extras]).to eq(['macro'])
+    end
+
+    it "returns the preprocessed filepath and the discovered includes" do
+      preprocessed_filepath, includes = call_it(method: :preprocess_partial_header_file_preserve_macros, fallback: false)
+
+      expect(preprocessed_filepath).to eq('/build/preprocessed/module.h')
+      expect(includes).to eq([])
+    end
+
+  end
+
+  # ===========================================================================
+  describe '#preprocess_test_file' do
+  # ===========================================================================
+
+    let(:filepath) { '/test/test_module.c' }
+
+    def call_it
+      subject.preprocess_test_file(
+        test:                      'test',
+        filepath:                  filepath,
+        directives_only_filepath:  '/build/directives_only/test_module.c',
+        fallback:                  false,
+        includes:                  [],
+        flags:                     [],
+        include_paths:             [],
+        vendor_paths:              [],
+        defines:                   []
+      )
+    end
+
+    before do
+      allow(@file_path_utils).to receive(:form_preprocessed_file_filepath).and_return('/build/preprocessed/test_module.c')
+      allow(@file_assembler).to receive(:collect_test_file_contents).and_return([['content'], ['extra']])
+      allow(@file_assembler).to receive(:assemble_preprocessed_code_file)
+      allow(@plugin_manager).to receive(:pre_test_preprocess)
+      allow(@plugin_manager).to receive(:post_test_preprocess)
+    end
+
+    it "returns the preprocessed filepath" do
+      expect(call_it()).to eq('/build/preprocessed/test_module.c')
+    end
+
+    it "fires pre_test_preprocess before assembling and post_test_preprocess after" do
+      order = []
+      allow(@plugin_manager).to receive(:pre_test_preprocess) { order << :pre }
+      allow(@file_assembler).to receive(:assemble_preprocessed_code_file) { order << :assemble }
+      allow(@plugin_manager).to receive(:post_test_preprocess) { order << :post }
+
+      call_it()
+
+      expect(order).to eq([:pre, :assemble, :post])
+    end
+
+    it "does not extract includes again -- the caller already supplied them" do
+      expect(@includes_handler).to_not receive(:extract_bare_includes)
+
+      call_it()
+    end
+
+    it "passes the given includes straight through to assemble_preprocessed_code_file" do
+      given_includes = [ UserInclude.new('a.h') ]
+
+      captured = nil
+      allow(@file_assembler).to receive(:assemble_preprocessed_code_file) { |**kwargs| captured = kwargs }
+
+      subject.preprocess_test_file(
+        test:                      'test',
+        filepath:                  filepath,
+        directives_only_filepath:  '/build/directives_only/test_module.c',
+        fallback:                  false,
+        includes:                  given_includes,
+        flags:                     [],
+        include_paths:             [],
+        vendor_paths:              [],
+        defines:                   []
+      )
+
+      expect(captured[:includes]).to eq(given_includes)
+    end
+
   end
 
 end


### PR DESCRIPTION
## Summary
Phase 2 of the 3-phase `lib/ceedling/preprocess/` review (Phase 1: cosmetic cleanup & bug fixes, merged as #1234; Phase 3: refactor, to follow). Pure test-coverage work — no production code changes.

- New `spec/units/preprocess/preprocessinator_bare_includes_extractor_spec.rb` — zero prior coverage for this stateless make-rule parser. Covers no-dependency self-referential rules, single/multiple/duplicate phony lines, mixed `.h`/`.c` dependencies, relative directory paths, trailing compiler-error noise, and the plain `Include` return type.
- New `spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb` — zero prior coverage for this stateful line-marker walker despite real branching logic. Covers USER/SYSTEM type filtering, `max_depth` limiting (including unlimited `nil`), `seen_paths` dedup across a return-then-reenter, initial-file detection, `<built-in>`/`<command-line>` skipping, depth increment/decrement, `test:` keyword threading, an invalid `type:` argument, and both the string- and file-based entry points (via a `StringIO`-yielding `@file_wrapper` double, no real file IO).
- Substantially extends `spec/units/preprocess/preprocessinator_spec.rb` — previously the thinnest-covered file relative to its size and centrality as the façade every other subsystem depends on. Adds coverage for `generate_directives_only_output`, `store_includes_list`/`load_includes_list`, `preprocess_mockable_header_file`, `preprocess_partial_header_file_preserve_macros`/`preprocess_partial_source_file_preserve_macros`, `preprocess_test_file`, and the success path of `preprocess_partial_header_expand_macros`/`_source_expand_macros`.
- Fills remaining narrow gaps in `preprocessinator_includes_handler_spec.rb` (`extract_user_includes_preprocess`, `extract_system_includes_preprocess`, `write_includes_list`, `load_includes_list`) and `preprocessinator_file_assembler_spec.rb` (`collect_file_contents_from_directives_only_preprocessing`, `collect_file_contents_from_full_expansion`, `collect_macros_and_pragmas_fallback`, `collect_test_file_contents`).

All new tests avoid real file IO per the established testing approach for this effort — either a class's existing string-based sibling method, or a `StringIO`-yielding `@file_wrapper` double.

## Test plan
- [x] `bundle exec rspec spec/units/preprocess` — 275 examples, 0 failures
- [x] `bundle exec rspec spec/units` (full suite) — 2789 examples, 0 failures
- [x] Docker-verified system tests (`preprocessing_encoding_spec.rb`, `preprocessing_fallback_conditionals_spec.rb`, `preprocessing_locale_spec.rb`, `preprocessing_parameterized_tests_spec.rb`) — 15 examples, 0 failures