### PR TITLE
preprocess/: Phase 3 — refactor

### DIFF
--- a/lib/ceedling/preprocess/preprocessinator_code_finder.rb
+++ b/lib/ceedling/preprocess/preprocessinator_code_finder.rb
@@ -122,8 +122,6 @@ class PreprocessinatorCodeFinder
     return (content[0, match_pos].count("\n")) + 1
   end
 
-  private
-
   def whitespace_insensitive_search(content, code)
     # Collapse whitespace to a unique token
     _code = code.gsub(/\s+/, WHITESPACE_MARKER)

--- a/lib/ceedling/preprocess/preprocessinator_file_assembler.rb
+++ b/lib/ceedling/preprocess/preprocessinator_file_assembler.rb
@@ -235,10 +235,10 @@ class PreprocessinatorFileAssembler
 
       # Add in any macro defintions or prgamas
       extras.each do |ex|
-        if ex.class == String
+        if ex.is_a?( String )
           file << ex + "\n"
 
-        elsif ex.class == Array
+        elsif ex.is_a?( Array )
           ex.each { |line| file << line + "\n" }
         end
 
@@ -379,9 +379,9 @@ class PreprocessinatorFileAssembler
 
       # Add in any extras like test directive macros or preserved macro definitions
       extras.each do |ex|
-        if ex.class == String
+        if ex.is_a?( String )
           file << ex + "\n"
-        elsif ex.class == Array
+        elsif ex.is_a?( Array )
           ex.each { |line| file << line + "\n" }
         end
       end

--- a/lib/ceedling/preprocess/preprocessinator_file_assembler.rb
+++ b/lib/ceedling/preprocess/preprocessinator_file_assembler.rb
@@ -88,32 +88,18 @@ class PreprocessinatorFileAssembler
         filename: File.basename(filepath)
       )
       @loginator.log( msg, Verbosity::OBNOXIOUS, LogLabels::WARNING )
-
-      # Open in binary mode + clean encoding: source files may contain non-ASCII bytes
-      # in comments (e.g. © symbols) that cause encoding errors under non-C locale.
-      @file_wrapper.open( filepath, 'rb' ) do |file|
-        # TODO: Modify to process line-at-a-time for memory savings & performance boost
-        _contents = file.read.clean_encoding
-
-        # Filter out inactive conditional blocks before extraction so that only
-        # pragmas and macros that are active for the current defines list are returned.
-        _contents = _filter_conditionals( _contents, defines )
-
-        # Extract pragmas and macros from
-        pragmas = @preprocessinator_reconstructor.extract_pragmas( _contents )
-        macro_defs = @preprocessinator_reconstructor.extract_macro_defs( _contents, include_guard )
-      end
-    else
-      @file_wrapper.open( directives_only_filepath, 'r' ) do |file|
-        # Get code contents of preprocessed directives-only file as a string
-        # TODO: Modify to process line-at-a-time for memory savings & performance boost
-        _contents = @preprocessinator_reconstructor.extract_file_as_string_from_expansion( file, filepath )
-
-        # Extract pragmas and macros from 
-        pragmas = @preprocessinator_reconstructor.extract_pragmas( _contents )
-        macro_defs = @preprocessinator_reconstructor.extract_macro_defs( _contents, include_guard )
-      end
     end
+
+    _contents = _active_content_for(
+      fallback:                 fallback,
+      filepath:                 filepath,
+      directives_only_filepath: directives_only_filepath,
+      defines:                  defines
+    )
+
+    # Extract pragmas and macros from the active content
+    pragmas = @preprocessinator_reconstructor.extract_pragmas( _contents )
+    macro_defs = @preprocessinator_reconstructor.extract_macro_defs( _contents, include_guard )
 
     return contents, (pragmas + macro_defs), include_guard
   end
@@ -140,15 +126,9 @@ class PreprocessinatorFileAssembler
       @file_wrapper.read( source_filepath, 2048 ).clean_encoding
     )
 
-    pragmas = []
-    macro_defs = []
-
-    @file_wrapper.open( source_filepath, 'rb' ) do |file|
-      _contents = file.read.clean_encoding
-      _contents = _filter_conditionals( _contents, defines )
-      pragmas    = @preprocessinator_reconstructor.extract_pragmas( _contents )
-      macro_defs = @preprocessinator_reconstructor.extract_macro_defs( _contents, include_guard )
-    end
+    _contents = _active_content_for( fallback: true, filepath: source_filepath, defines: defines )
+    pragmas    = @preprocessinator_reconstructor.extract_pragmas( _contents )
+    macro_defs = @preprocessinator_reconstructor.extract_macro_defs( _contents, include_guard )
 
     return pragmas + macro_defs
   end
@@ -296,38 +276,23 @@ class PreprocessinatorFileAssembler
         filename: File.basename(filepath)
       )
       @loginator.log( msg, Verbosity::OBNOXIOUS, LogLabels::WARNING )
-
-      # Open in binary mode + clean encoding: source files may contain non-ASCII bytes
-      # in comments (e.g. © symbols) that cause encoding errors under non-C locale.
-      @file_wrapper.open( filepath, 'rb' ) do |file|
-        _contents = file.read.clean_encoding
-
-        # Filter out inactive conditional blocks before extraction so that only
-        # test directives that are active for the current defines list are returned.
-        _contents = _filter_conditionals( _contents, defines )
-
-        # Extract TEST_SOURCE_FILE() and TEST_INCLUDE_PATH()
-        test_directives = @preprocessinator_reconstructor.extract_test_directive_macro_calls( _contents )
-
-        # Extract TEST_CASE()/TEST_RANGE()/TEST_MATRIX() calls paired with the test function
-        # they immediately precede -- these vanish from `contents` above because they're real
-        # (empty-expanding) Unity macros erased by full preprocessor expansion, so we must
-        # recover them from this macro-preserving text instead.
-        test_case_directives = @preprocessinator_reconstructor.extract_test_case_directives( _contents )
-      end
-    else
-      @file_wrapper.open( directives_only_filepath, 'r' ) do |file|
-        # Get code contents of preprocessed directives-only file as a string
-        _contents = @preprocessinator_reconstructor.extract_file_as_string_from_expansion( file, filepath )
-
-        # Extract TEST_SOURCE_FILE() and TEST_INCLUDE_PATH()
-        test_directives = @preprocessinator_reconstructor.extract_test_directive_macro_calls( _contents )
-
-        # Extract TEST_CASE()/TEST_RANGE()/TEST_MATRIX() calls paired with the test function
-        # they immediately precede (see comment in the fallback branch above)
-        test_case_directives = @preprocessinator_reconstructor.extract_test_case_directives( _contents )
-      end
     end
+
+    _contents = _active_content_for(
+      fallback:                 fallback,
+      filepath:                 filepath,
+      directives_only_filepath: directives_only_filepath,
+      defines:                  defines
+    )
+
+    # Extract TEST_SOURCE_FILE() and TEST_INCLUDE_PATH()
+    test_directives = @preprocessinator_reconstructor.extract_test_directive_macro_calls( _contents )
+
+    # Extract TEST_CASE()/TEST_RANGE()/TEST_MATRIX() calls paired with the test function
+    # they immediately precede -- these vanish from `contents` above because they're real
+    # (empty-expanding) Unity macros erased by full preprocessor expansion, so we must
+    # recover them from this macro-preserving text instead.
+    test_case_directives = @preprocessinator_reconstructor.extract_test_case_directives( _contents )
 
     # Reinsert TEST_CASE()/TEST_RANGE()/TEST_MATRIX() calls immediately ahead of their test
     # function in `contents` -- full expansion erased them in place with no trace (not even a
@@ -344,6 +309,33 @@ class PreprocessinatorFileAssembler
   ### Private ###
 
   private
+
+  # Returns the content string used to extract pragmas, macro definitions, and
+  # test directives -- either by binary-mode-reading and conditional-filtering
+  # the original file (fallback mode) or by reading the already directives-only
+  # preprocessed output (non-fallback mode). Shared by
+  # collect_mockable_header_file_contents, collect_macros_and_pragmas_fallback,
+  # and collect_test_file_contents, which each then run their own distinct
+  # extraction calls against the string this returns.
+  def _active_content_for(fallback:, filepath:, directives_only_filepath: nil, defines: [])
+    if fallback
+      # Open in binary mode + clean encoding: source files may contain non-ASCII bytes
+      # in comments (e.g. © symbols) that cause encoding errors under non-C locale.
+      @file_wrapper.open( filepath, 'rb' ) do |file|
+        # TODO: Modify to process line-at-a-time for memory savings & performance boost
+        _contents = file.read.clean_encoding
+
+        # Filter out inactive conditional blocks so only content active for the
+        # current defines list is returned.
+        _filter_conditionals( _contents, defines )
+      end
+    else
+      @file_wrapper.open( directives_only_filepath, 'r' ) do |file|
+        # TODO: Modify to process line-at-a-time for memory savings & performance boost
+        @preprocessinator_reconstructor.extract_file_as_string_from_expansion( file, filepath )
+      end
+    end
+  end
 
   # Filters `file_contents` string through CPreprocessorConditionals, returning
   # only lines in active conditional blocks. Uses code_lines internally so

--- a/spec/units/preprocess/preprocessinator_file_assembler_spec.rb
+++ b/spec/units/preprocess/preprocessinator_file_assembler_spec.rb
@@ -445,6 +445,35 @@ RSpec.describe PreprocessinatorFileAssembler do
       expect(output.string).to include(content_line_with_crlf)
     end
 
+    it 'writes a String extra as a single line' do
+      output = stub_file_write(preprocessed_filepath)
+
+      subject.assemble_preprocessed_header_file(
+        filename:              'module.h',
+        preprocessed_filepath: preprocessed_filepath,
+        contents:              [],
+        extras:                ['#define FOO 1'],
+        includes:              []
+      )
+
+      expect(output.string).to include("#define FOO 1\n")
+    end
+
+    it 'writes each line of an Array extra' do
+      output = stub_file_write(preprocessed_filepath)
+
+      subject.assemble_preprocessed_header_file(
+        filename:              'module.h',
+        preprocessed_filepath: preprocessed_filepath,
+        contents:              [],
+        extras:                [ ['#define FOO(x) \\', '  (x + 1)'] ],
+        includes:              []
+      )
+
+      expect(output.string).to include("#define FOO(x) \\\n")
+      expect(output.string).to include("  (x + 1)\n")
+    end
+
   end
 
 
@@ -505,6 +534,35 @@ RSpec.describe PreprocessinatorFileAssembler do
       )
 
       expect(output.string).to include(content_line_with_crlf)
+    end
+
+    it 'writes a String extra as a single line' do
+      output = stub_file_write(preprocessed_filepath)
+
+      subject.assemble_preprocessed_code_file(
+        filename:              'module.c',
+        preprocessed_filepath: preprocessed_filepath,
+        contents:              [],
+        extras:                ['TEST_SOURCE_FILE("other.c")'],
+        includes:              []
+      )
+
+      expect(output.string).to include("TEST_SOURCE_FILE(\"other.c\")\n")
+    end
+
+    it 'writes each line of an Array extra' do
+      output = stub_file_write(preprocessed_filepath)
+
+      subject.assemble_preprocessed_code_file(
+        filename:              'module.c',
+        preprocessed_filepath: preprocessed_filepath,
+        contents:              [],
+        extras:                [ ['TEST_CASE(1, 2)', 'TEST_CASE(3, 4)'] ],
+        includes:              []
+      )
+
+      expect(output.string).to include("TEST_CASE(1, 2)\n")
+      expect(output.string).to include("TEST_CASE(3, 4)\n")
     end
 
   end


### PR DESCRIPTION
## Summary
Phase 3 (final) of the 3-phase `lib/ceedling/preprocess/` review (Phase 1: cosmetic cleanup & bug fixes, #1234; Phase 2: test coverage, #1239, both merged). Behavior-preserving refactor only — Phase 2's new tests plus each file's pre-existing tests serve as the regression safety net; the acceptance bar for every commit here is "full suite stays green with zero changes."

- Replaces `ex.class == String` / `ex.class == Array` with `is_a?` in `PreprocessinatorFileAssembler#assemble_preprocessed_header_file` and `#assemble_preprocessed_code_file` (4 call sites). Also adds direct test coverage for the String/Array extras-formatting branches in both methods, since every existing example previously passed `extras: []` and never exercised either branch — a real gap discovered while touching this code, added as a safety net before the refactor.
- Extracts a shared `_active_content_for` private helper in `PreprocessinatorFileAssembler`, consolidating the repeated "read the raw file in binary mode + clean_encoding + `_filter_conditionals` in fallback mode, or read the directives-only output via the reconstructor otherwise" shape previously duplicated across `collect_mockable_header_file_contents`, `collect_macros_and_pragmas_fallback`, and `collect_test_file_contents`. Migrated one call site at a time, running the full suite after each, per the plan's own instruction to isolate any regression immediately to the call site that introduced it.
- Collapses a duplicated `private` declaration in `PreprocessinatorCodeFinder` (cosmetic, zero behavioral effect).

## Test plan
- [x] `bundle exec rspec spec/units/preprocess/preprocessinator_file_assembler_spec.rb` and `preprocessinator_code_finder_spec.rb` — green after every commit, zero test changes needed for the two refactor commits
- [x] `bundle exec rspec spec/units` (full suite) — 2793 examples, 0 failures
- [x] Docker-verified system tests (`preprocessing_encoding_spec.rb`, `preprocessing_fallback_conditionals_spec.rb`, `preprocessing_locale_spec.rb`, `preprocessing_parameterized_tests_spec.rb`, `example_wondrous_forest_spec.rb`, `conditional_include_macro_visibility_spec.rb`) — 24 examples, 0 failures