### PR TITLE
Clean ParsingParcels input once per buffer instead of per line

### DIFF
--- a/lib/ceedling/encodinator.rb
+++ b/lib/ceedling/encodinator.rb
@@ -8,12 +8,16 @@
 # Patch the string class so that we have a nice shortcut for cleaning string encodings
 class String
   # Clean up any oddball characters in an otherwise ASCII document. Hoisted to a
-  # frozen constant rather than rebuilt on every clean_encoding call -- this is
-  # called per-line across large swaths of preprocessing, so a fresh Hash literal
-  # every call was a measurable, needless allocation. Only :replace varies by
-  # caller (default '' vs. e.g. '_' from defineinator.rb), so the common,
-  # default-safe_char case reuses this constant untouched; a non-default
-  # safe_char still allocates one small merged Hash, same as before.
+  # frozen constant rather than rebuilt on every clean_encoding call -- a fresh
+  # Hash literal every call was a measurable, needless allocation back when the
+  # two highest-volume callers (ParsingParcels#code_lines_with_num,
+  # PreprocessinatorReconstructor#_scan_expansion_for_file) each called this
+  # per line; both now clean a whole buffer once instead, but the remaining
+  # per-line fallback-path callers (e.g. CPreprocessorConditionals#process_directive)
+  # still benefit. Only :replace varies by caller (default '' vs. e.g. '_' from
+  # defineinator.rb), so the common, default-safe_char case reuses this
+  # constant untouched; a non-default safe_char still allocates one small
+  # merged Hash, same as before.
   DEFAULT_CLEAN_ENCODING_OPTIONS = {
     :invalid           => :replace,  # Replace invalid byte sequences
     :undef             => :replace,  # Replace anything not defined in ASCII

--- a/lib/ceedling/parsing_parcels.rb
+++ b/lib/ceedling/parsing_parcels.rb
@@ -11,9 +11,9 @@ require 'ceedling/encodinator'
 class ParsingParcels
 
   # This parser accepts a collection of lines which it will sweep through and tidy, giving the purified
-  # lines to the block (one line at a time) for further analysis. It analyzes a single line at a time, 
-  # which is far more memory efficient and faster for large files. However, this requires it to also 
-  # handle backslash line continuations as a single line at this point.
+  # lines to the block (one line at a time) for further analysis. Encoding cleanup happens once against
+  # the whole buffer up front; comment-stripping and backslash line continuations are still handled one
+  # logical line at a time after that.
   # @param input [IO, File, String] The input source to parse line by line
   # @yield [line] Gives each cleaned line to the block
   # @yieldparam line [String] The cleaned code line
@@ -22,9 +22,9 @@ class ParsingParcels
   end
 
   # This parser accepts a collection of lines which it will sweep through and tidy, giving the purified
-  # lines to the block (one line at a time) for further analysis along with the line number. It analyzes 
-  # a single line at a time, which is far more memory efficient and faster for large files. However, this 
-  # requires it to also handle backslash line continuations as a single line at this point.
+  # lines to the block (one line at a time) for further analysis along with the line number. Encoding
+  # cleanup happens once against the whole buffer up front; comment-stripping and backslash line
+  # continuations are still handled one logical line at a time after that.
   #
   # @param input [IO, File, String] The input source to parse line by line
   # @yield [line, line_num] Gives each cleaned line and its line number to the block
@@ -37,10 +37,21 @@ class ParsingParcels
     full_line = ''
     line_num = 0
     continuation_start_line = 0
-    
-    input.each_line do |line|
+
+    # Clean the whole buffer once instead of per line -- clean_encoding's cost
+    # (a double ASCII/UTF-8 transcode) scales with call count as much as with
+    # content size, and this method is the single most fanned-out consumer of
+    # clean_encoding in the codebase. `input` may be an IO (slurp via #read)
+    # or already a String (some callers, e.g. PreprocessinatorReconstructor's
+    # extract_tokens_by_regex_list, pass file contents already in memory) --
+    # either way, the rest of this method works identically off the resulting
+    # String's own #each_line, exactly as it did off the IO's #each_line
+    # before.
+    content = ( input.respond_to?( :read ) ? input.read : input ).clean_encoding
+
+    content.each_line do |line|
       line_num += 1
-      m = line.clean_encoding.match /(.*)\\\s*$/
+      m = line.match /(.*)\\\s*$/
       if (!m.nil?)
         full_line += m[1]
         continuation_start_line = line_num if full_line == m[1]
@@ -59,7 +70,14 @@ class ParsingParcels
   private ######################################################################
 
   def clean_code_line(line, comment_block)
-    _line = line.clean_encoding
+    # `line` is already clean_encoding'd content by the time it gets here (see
+    # code_lines_with_num) -- dup rather than re-clean, since this method
+    # mutates _line in place via gsub! below and must not mutate the caller's
+    # string (both call sites -- a bare line from content.each_line, and
+    # full_line + line -- happen to already hand over a fresh, safely-mutable
+    # String today, but dup keeps that an explicit guarantee, not an
+    # incidental one).
+    _line = line.dup
 
     # Remove line comments
     _line.gsub!(/\/\/.*$/, '')

--- a/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
@@ -135,8 +135,9 @@ class PreprocessinatorIncludesHandler
   def extract_bare_includes_from_text(filepath:)
     includes = []
 
-    # Open in binary mode: code_lines applies clean_encoding per-line, but each_line
-    # itself can raise on invalid byte sequences before clean_encoding is reached.
+    # Open in binary mode: code_lines cleans the whole buffer via clean_encoding
+    # before ever splitting into lines, but a text-mode read could itself raise
+    # on invalid byte sequences before clean_encoding gets the chance.
     @file_wrapper.open(filepath, 'rb') do |input|
       @parsing_parcels.code_lines( input ) do |line|
         _include = @include_factory.user_include_from_directive( line ) ||
@@ -185,8 +186,9 @@ class PreprocessinatorIncludesHandler
 
     cond_tracker = CPreprocessorConditionals.new( defines )
 
-    # Open in binary mode: code_lines applies clean_encoding per-line, but each_line
-    # itself can raise on invalid byte sequences before clean_encoding is reached.
+    # Open in binary mode: code_lines cleans the whole buffer via clean_encoding
+    # before ever splitting into lines, but a text-mode read could itself raise
+    # on invalid byte sequences before clean_encoding gets the chance.
     @file_wrapper.open(filepath, 'rb') do |input|
       @parsing_parcels.code_lines( input ) do |line|
         cond_tracker.process_directive( line )
@@ -235,8 +237,9 @@ class PreprocessinatorIncludesHandler
 
     cond_tracker = CPreprocessorConditionals.new( defines )
 
-    # Open in binary mode: code_lines applies clean_encoding per-line, but each_line
-    # itself can raise on invalid byte sequences before clean_encoding is reached.
+    # Open in binary mode: code_lines cleans the whole buffer via clean_encoding
+    # before ever splitting into lines, but a text-mode read could itself raise
+    # on invalid byte sequences before clean_encoding gets the chance.
     @file_wrapper.open(filepath, 'rb') do |input|
       @parsing_parcels.code_lines( input ) do |line|
         cond_tracker.process_directive( line )


### PR DESCRIPTION
## Summary
- `ParsingParcels#code_lines_with_num` called `String#clean_encoding` (a double ASCII/UTF-8 transcode) on every line, plus a second redundant clean inside `clean_code_line` on that same line. This is the single most fanned-out `clean_encoding` consumer in the codebase — test context extraction, include scanning, conditional-directive fallback parsing, and test runner line remapping all funnel through it.
- Cleans the whole input buffer once up front instead of per line; `clean_code_line` now `dup`s rather than re-cleans, since its input is already clean by the time it arrives.
- `input` may be an IO (most callers) or an already-in-memory String (e.g. `PreprocessinatorReconstructor#extract_tokens_by_regex_list`) — handled via `input.respond_to?(:read)` since `String` has no `#read` of its own.
- Combined with #1243 (the prior `PreprocessinatorReconstructor` fix), this takes `String#encode` from **28.9% to 0.7%** of total profiled time on a full `rake "profile:run[wondrous_forest,clobber test:all]"` build — effectively eliminating the hotspot this encoding-performance effort set out to address.

Phase 3 of the multi-phase encoding-performance effort (see #1243 for Phase 2).

## Test plan
- [x] `bundle exec rspec spec/units/` — 2800 examples, 0 failures
- [x] `bundle exec rspec spec/units/parsing_parcels_spec.rb` — 6 examples, 0 failures (including the emoji-encoding-sanitizing and continuation-joining cases)
- [x] `bundle exec rspec spec/system/encoding_stress_spec.rb spec/system/preprocessing_encoding_spec.rb` — 9 passing/5 pending (Linux-only) + 4 passing — the correctness backstop for this code path
- [x] Before/after stackprof numbers captured via `rake "profile:run[wondrous_forest,clobber test:all]"` (28.9% → 0.7%)
- [x] Confirmed every call site of `code_lines`/`code_lines_with_num` (both IO and String inputs) still resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)