### PR TITLE
Precompile strip_compiler_extensions' bare-keyword regex

### DIFF
--- a/lib/ceedling/c_extractor/c_extractor_code_text.rb
+++ b/lib/ceedling/c_extractor/c_extractor_code_text.rb
@@ -12,6 +12,26 @@ class CExtractorCodeText
 
   include CExtractorConstants
 
+  # Bare (no-argument-list) keywords strip_compiler_extensions strips verbatim,
+  # as a single precompiled alternation rather than a fresh Regexp.escape'd
+  # Regexp per keyword per scanner position (a profiled hotspot: this loop
+  # runs once per character of every function signature/declaration scanned,
+  # trying up to 14 keywords at each position that isn't a known extension --
+  # a stackprof flame graph attributed the vast majority of
+  # strip_compiler_extensions' cost to exactly this repeated Array#any?/regex-
+  # compilation combination). `\b` on both ends is load-bearing, not
+  # decorative: StringScanner#scan is already position-anchored, but without
+  # the trailing `\b` a short keyword would match as a mere prefix of a
+  # longer identifier starting the same way (e.g. matching "__cdecl" inside
+  # "__cdeclFoo"), and alternation order among keywords that prefix one
+  # another (e.g. __inline vs. __inline__) is safe either way -- Ruby's
+  # regex engine backtracks to a longer alternative when the shorter one's
+  # trailing \b fails to hold (both sides would still be \w characters).
+  BARE_STRIP_KEYWORDS = (
+    MSVC_CALLING_CONVENTIONS + ['__forceinline', '__inline__', '__inline'] + C11_SPECIFIER_KEYWORDS
+  ).freeze unless const_defined?(:BARE_STRIP_KEYWORDS, false)
+  BARE_STRIP_REGEX = /\b(?:#{BARE_STRIP_KEYWORDS.map { |kw| Regexp.escape(kw) }.join('|')})\b/.freeze unless const_defined?(:BARE_STRIP_REGEX, false)
+
   # Collect the full text of a balanced delimiter pair starting AT open_char.
   # Nested pairs, string literals (verbatim), and comments (replaced with a
   # single space) are handled correctly.
@@ -242,10 +262,6 @@ class CExtractorCodeText
     scanner = StringScanner.new(text)
     result  = +""
 
-    bare_strip = MSVC_CALLING_CONVENTIONS +
-                 ['__forceinline', '__inline__', '__inline'] +
-                 C11_SPECIFIER_KEYWORDS
-
     until scanner.eos?
       # __word__(…) — any double-underscore attribute form including __attribute__((…))
       if scanner.check(/__\w+__\s*\(/)
@@ -264,13 +280,9 @@ class CExtractorCodeText
       end
 
       # Whitelisted bare keywords (calling conventions, inline hints, C11 specifiers)
-      stripped = bare_strip.any? do |kw|
-        if scanner.check(/#{Regexp.escape(kw)}\b/)
-          scanner.skip(/#{Regexp.escape(kw)}/)
-          true
-        end
+      if scanner.scan(BARE_STRIP_REGEX)
+        next
       end
-      next if stripped
 
       result << scanner.getch
     end


### PR DESCRIPTION
## Summary
- `CExtractorCodeText#strip_compiler_extensions`'s whitelisted-bare-keyword check rebuilt a `Regexp` via `Regexp.escape` for each of 14 keywords, at every scanner position that wasn't already a known `__word__(…)`/`__declspec(…)` extension — i.e. once per character of every function signature/declaration CMock extracts. A stackprof flame graph attributed 90%+ of `strip_compiler_extensions`' cost to this `Array#any?`/repeated-regex-compilation combination (2.6% of total profiled build time on a full `rake "profile:run[wondrous_forest,clobber test:all]"` run — the next-highest item on the performance list after the encoding fixes in #1243/#1244).
- Replaced with a single precompiled alternation regex built once from the same keyword list, matched via one `scanner.scan` call. `\b` on both ends preserves the original whitelist-prefix-safety behavior; alternation order among prefix-related keywords (`__inline` vs. `__inline__`) doesn't matter since Ruby's regex engine backtracks to the longer alternative when a shorter one's trailing `\b` fails to hold.

## Test plan
- [x] `bundle exec rspec spec/units/` — 2800 examples, 0 failures
- [x] `bundle exec rspec spec/units/c_extractor/` — 781 examples, 0 failures (includes the dedicated `#strip_compiler_extensions` section)
- [x] Before/after stackprof numbers: `strip_compiler_extensions` drops from 2.6% to 0.1% of total build time on a full `test:all` run, and from 0.7% to effectively 0% on a single-test-file scenario — `Array#any?`/`Regexp.escape` no longer appear as callees at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)