### PR TITLE
Close four delta-build dependency-tracking metadata gaps

### DIFF
--- a/lib/ceedling/config/configurator.rb
+++ b/lib/ceedling/config/configurator.rb
@@ -33,6 +33,10 @@ class Configurator
     # :unity_use_param_tests) and no longer holds a :unity section of its own to read back.
     @unity_config = {} # Default empty hash, replaced by reference below
 
+    # Partials config reference -- same reason as the Unity config above, and needed
+    # as a single value dependency-tracker meta can hash wholesale for Partials targets.
+    @partials_config = {} # Default empty hash, replaced by reference below
+
     # Note: project_config_hash is an instance variable so constants and accessors created
     # in eval() statements in build() have something of proper scope and persistence to reference
     @project_config_hash = {}
@@ -319,6 +323,17 @@ class Configurator
   end
 
 
+  def populate_partials_config(config)
+    # Save Partials config reference -- no transformation needed, unlike Unity/CMock/the
+    # test runner above, since nothing else derives values from or into this section.
+    @partials_config = config[:partials]
+
+    @loginator.lazy( Verbosity::DEBUG ) do
+      "Partials configuration >> #{config[:partials]}"
+    end
+  end
+
+
   def populate_cmock_config(config)
     # Save CMock config reference
     @cmock_config = config[:cmock]
@@ -426,6 +441,12 @@ class Configurator
   def get_unity_config
     # Clone for the same reason as get_runner_config/get_cmock_config above.
     return @unity_config.clone
+  end
+
+
+  def get_partials_config
+    # Clone for the same reason as get_runner_config/get_cmock_config above.
+    return @partials_config.clone
   end
 
 

--- a/lib/ceedling/dependencies/dependency_tracker.rb
+++ b/lib/ceedling/dependencies/dependency_tracker.rb
@@ -183,7 +183,11 @@ class DependencyTracker
     key = @dependency_path_normalizer.normalize( target )
     rel = @mutex.synchronize { @relationships[key] } || { files: [], meta: {} }
 
-    self_hash = @dependency_hasher.hash_of_file( key )
+    # A target isn't guaranteed to exist -- e.g. a caller conditionally writes one of two
+    # mutually exclusive outcome files -- so this mirrors `stale?`'s own existence check
+    # before ever hashing the target, and the `deps` loop three lines below, which already
+    # extends the same tolerance to each individual dependency.
+    self_hash = @file_wrapper.exist?( key ) ? @dependency_hasher.hash_of_file( key ) : nil
     entry = {
       'self_hash' => self_hash,
       'meta_hash' => @dependency_hasher.hash_of_meta( rel[:meta] ),

--- a/lib/ceedling/release_invoker/release_build_executor.rb
+++ b/lib/ceedling/release_invoker/release_build_executor.rb
@@ -47,7 +47,7 @@ class ReleaseBuildExecutor
     @dependinator.register(
       target,
       files: objects,
-      meta:  { flags: state.link_flags, lib_args: lib_args, lib_paths: lib_paths }
+      meta:  { flags: state.link_flags, lib_args: lib_args, lib_paths: lib_paths, tools: [@configurator.tools_release_linker] }
     )
     stale = @dependinator.stale?( target )
 
@@ -106,7 +106,7 @@ class ReleaseBuildExecutor
 
     if !@configurator.extension_assembly.match?( source )
       flags = state.compile_flags
-      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: state.defines, search_paths: state.search_paths )
+      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: state.defines, search_paths: state.search_paths, tool: @configurator.tools_release_compiler )
 
       return log_compile_skip( source: source ) unless stale
 
@@ -132,7 +132,7 @@ class ReleaseBuildExecutor
       )
     else
       flags = state.assemble_flags
-      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: state.defines, search_paths: state.search_paths )
+      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: state.defines, search_paths: state.search_paths, tool: @configurator.tools_release_assembler )
 
       return log_compile_skip( source: source ) unless stale
 
@@ -177,8 +177,8 @@ class ReleaseBuildExecutor
   # and reports whether it needs (re)building. The previous run's `.d` file is
   # the only header list available before this run's compile has happened --
   # if headers changed, that's exactly what makes this stale.
-  def register_and_check_object_staleness(object:, source:, dependencies:, flags:, defines:, search_paths:)
-    @dependinator.register( object, files: [source], meta: { flags: flags, defines: defines, search_paths: search_paths } )
+  def register_and_check_object_staleness(object:, source:, dependencies:, flags:, defines:, search_paths:, tool:)
+    @dependinator.register( object, files: [source], meta: { flags: flags, defines: defines, search_paths: search_paths, tools: [tool] } )
     @dependinator.register_gcc_deps_file( dependencies ) if @file_wrapper.exist?( dependencies )
     @dependinator.stale?( object )
   end

--- a/lib/ceedling/setupinator.rb
+++ b/lib/ceedling/setupinator.rb
@@ -124,6 +124,9 @@ class Setupinator
     # Populate CMock configuration with values to tie vendor tool configurations together
     @configurator.populate_cmock_config( config_hash )
 
+    # Populate Partials configuration reference for dependency-tracker meta
+    @configurator.populate_partials_config( config_hash )
+
     # Configure test runner generation
     @configurator.populate_test_runner_generation_config( config_hash )
 

--- a/lib/ceedling/test_invoker/partials_manager.rb
+++ b/lib/ceedling/test_invoker/partials_manager.rb
@@ -100,10 +100,13 @@ class PartialsManager
       # before it reaches path normalization, which expects real paths only.
       antecedent_files = [config.header.filepath, config.source.filepath].compact
       antecedent_meta  = {
-        flags:                          testable.preprocess_flags,
-        defines:                        testable.preprocess_defines,
-        search_paths:                   testable.search_paths,
-        partials_max_extraction_length: @configurator.partials_max_extraction_length
+        flags:        testable.preprocess_flags,
+        defines:      testable.preprocess_defines,
+        search_paths: testable.search_paths,
+        # No shell tool runs in this stage -- Partial generation is pure Ruby (below) --
+        # so there's nothing to add here beyond the whole :partials config.
+        tools:        [],
+        partials:     @configurator.get_partials_config
       }
 
       # Generated once and shared by the implementation and interface headers below (via
@@ -287,7 +290,15 @@ class PartialsManager
       @dependinator.register(
         target,
         files: [config.filepath],
-        meta:  dependency_meta( flags: testable.preprocess_flags, defines: testable.preprocess_defines, search_paths: testable.search_paths )
+        meta:  dependency_meta(
+          flags: testable.preprocess_flags, defines: testable.preprocess_defines, search_paths: testable.search_paths,
+          tools: [
+            @configurator.tools_test_file_directives_only_preprocessor,
+            @configurator.tools_test_bare_includes_preprocessor,
+            @configurator.tools_test_file_full_preprocessor
+          ],
+          partials: @configurator.get_partials_config
+        )
       )
 
       details.preprocessed_target = target

--- a/lib/ceedling/test_invoker/test_build_executor.rb
+++ b/lib/ceedling/test_invoker/test_build_executor.rb
@@ -469,9 +469,17 @@ class TestBuildExecutor
   # (Unity's generated `main()` reshuffles on every invocation), not at compile
   # or link time, so an executable that's otherwise unchanged still needs to
   # actually run again for shuffling to have any effect at all.
+  #
+  # The dependency tracker gives a third reason to rerun, alongside those two:
+  # `testable.executable` unchanged says nothing about whether the *tool* that
+  # actually runs it -- :tools ↳ :test_fixture -- changed since the last run.
+  # This target is registered separately from stage 16's own executable target
+  # (not reusing it) so a tool-only change reruns the fixture without also
+  # marking the executable itself stale and forcing an unnecessary relink.
   def stage_execute(state)
     skipped = 0
     force_rerun = @configurator.force_test_rerun || @configurator.unity_shuffle_tests
+    fixture_tool = @configurator.tools_test_fixture
 
     overridden = state.testables.values.count { |t| !t.executable_rebuilt }
 
@@ -486,7 +494,11 @@ class TestBuildExecutor
 
     @batchinator.exec(workload: :test, things: state.testables) do |_, testable|
       begin
-        run_now = testable.executable_rebuilt || force_rerun
+        fixture_target = testable.results_pass
+
+        @dependinator.register( fixture_target, files: [testable.executable], meta: { tools: [fixture_tool] } )
+
+        run_now = testable.executable_rebuilt || force_rerun || @dependinator.stale?( fixture_target )
 
         # Clear out any stale prior result (e.g. a lingering `.fail` from a test
         # that now passes) immediately before an actual (re)run -- not upfront
@@ -514,6 +526,8 @@ class TestBuildExecutor
         }
 
         run_fixture( **arg_hash )
+
+        @dependinator.mark_fresh( fixture_target ) if run_now
 
       ensure
         @plugin_manager.post_test( testable.filepath )

--- a/lib/ceedling/test_invoker/test_build_executor.rb
+++ b/lib/ceedling/test_invoker/test_build_executor.rb
@@ -54,10 +54,12 @@ class TestBuildExecutor
         target,
         files: [details.source],
         meta:  {
-          flags:        testable.preprocess_flags,
-          defines:      testable.preprocess_defines,
-          search_paths: testable.search_paths,
-          extras:       extras
+          flags:                     testable.preprocess_flags,
+          defines:                   testable.preprocess_defines,
+          search_paths:              testable.search_paths,
+          extras:                    extras,
+          tools:                     [@configurator.tools_test_bare_includes_preprocessor, @configurator.tools_test_file_directives_only_preprocessor],
+          preprocess_force_fallback: @configurator.test_build_preprocess_force_fallback
         }
       )
 
@@ -418,7 +420,7 @@ class TestBuildExecutor
       @dependinator.register(
         testable.executable,
         files: testable.objects,
-        meta:  { flags: testable.link_flags, lib_args: lib_args, lib_paths: lib_paths }
+        meta:  { flags: testable.link_flags, lib_args: lib_args, lib_paths: lib_paths, tools: [@configurator.tools_test_linker] }
       )
       stale = @dependinator.stale?( testable.executable )
 
@@ -616,7 +618,7 @@ class TestBuildExecutor
 
     if !@configurator.extension_assembly.match?( source )
       flags = testable.compile_flags
-      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: defines, search_paths: search_paths )
+      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: defines, search_paths: search_paths, tool: @configurator.tools_test_compiler )
 
       return log_compile_skip( test: test, source: source ) unless stale
 
@@ -644,7 +646,7 @@ class TestBuildExecutor
 
     elsif @configurator.test_build_use_assembly
       flags = testable.assembler_flags
-      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: defines, search_paths: search_paths )
+      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: defines, search_paths: search_paths, tool: @configurator.tools_test_assembler )
 
       return log_compile_skip( test: test, source: source ) unless stale
 
@@ -694,8 +696,8 @@ class TestBuildExecutor
   # and reports whether it needs (re)building. The previous run's `.d` file is
   # the only header list available before this run's compile has happened --
   # if headers changed, that's exactly what makes this stale.
-  def register_and_check_object_staleness(object:, source:, dependencies:, flags:, defines:, search_paths:)
-    @dependinator.register( object, files: [source], meta: dependency_meta( flags: flags, defines: defines, search_paths: search_paths ) )
+  def register_and_check_object_staleness(object:, source:, dependencies:, flags:, defines:, search_paths:, tool:)
+    @dependinator.register( object, files: [source], meta: dependency_meta( flags: flags, defines: defines, search_paths: search_paths, tools: [tool] ) )
     @dependinator.register_gcc_deps_file( dependencies ) if @file_wrapper.exist?( dependencies )
     @dependinator.stale?( object )
   end

--- a/lib/ceedling/test_invoker/test_build_executor.rb
+++ b/lib/ceedling/test_invoker/test_build_executor.rb
@@ -476,6 +476,15 @@ class TestBuildExecutor
   # This target is registered separately from stage 16's own executable target
   # (not reusing it) so a tool-only change reruns the fixture without also
   # marking the executable itself stale and forcing an unnecessary relink.
+  #
+  # The target itself is a dedicated marker file, not either outcome-dependent
+  # results file (.pass/.fail) -- which of those two actually gets written
+  # depends on whether the test passes, so neither is guaranteed to exist after
+  # every run, and a target `mark_fresh` can't hash is a crash on a failing
+  # test, while a target `stale?` can't find is permanent, unwanted staleness
+  # for a test that keeps failing the same way. The marker's own content is
+  # irrelevant and never changes -- only its existence (written after every
+  # real run, pass or fail alike) and the registered files/meta drive staleness.
   def stage_execute(state)
     skipped = 0
     force_rerun = @configurator.force_test_rerun || @configurator.unity_shuffle_tests
@@ -494,7 +503,12 @@ class TestBuildExecutor
 
     @batchinator.exec(workload: :test, things: state.testables) do |_, testable|
       begin
-        fixture_target = testable.results_pass
+        # `paths[:results]` is only per-test-unique for a test mirrored into its own
+        # subdirectory -- a test with no mirrored subdir shares that directory with
+        # every other such test, so the marker's own filename (not just its directory)
+        # must be test-specific too, matching clean_test_results' own `test + '.*'`
+        # naming below.
+        fixture_target = File.join( testable.paths[:results], "#{File.basename( testable.name )}.fixture_run" )
 
         @dependinator.register( fixture_target, files: [testable.executable], meta: { tools: [fixture_tool] } )
 
@@ -527,7 +541,10 @@ class TestBuildExecutor
 
         run_fixture( **arg_hash )
 
-        @dependinator.mark_fresh( fixture_target ) if run_now
+        if run_now
+          @file_wrapper.touch( fixture_target )
+          @dependinator.mark_fresh( fixture_target )
+        end
 
       ensure
         @plugin_manager.post_test( testable.filepath )

--- a/lib/ceedling/test_invoker/test_build_setup.rb
+++ b/lib/ceedling/test_invoker/test_build_setup.rb
@@ -246,7 +246,10 @@ class TestBuildSetup
       @dependinator.register(
         target,
         files: [filepath],
-        meta:  dependency_meta( flags: testable.preprocess_flags, defines: testable.preprocess_defines, search_paths: testable.search_paths )
+        meta:  dependency_meta(
+          flags: testable.preprocess_flags, defines: testable.preprocess_defines, search_paths: testable.search_paths,
+          tools: [@configurator.tools_test_bare_includes_preprocessor]
+        )
       )
 
       if @dependinator.stale?( target )
@@ -308,7 +311,10 @@ class TestBuildSetup
       @dependinator.register(
         target,
         files: [filepath],
-        meta:  dependency_meta( flags: testable.preprocess_flags, defines: testable.preprocess_defines, search_paths: testable.search_paths )
+        meta:  dependency_meta(
+          flags: testable.preprocess_flags, defines: testable.preprocess_defines, search_paths: testable.search_paths,
+          tools: [@configurator.tools_test_file_directives_only_preprocessor]
+        )
       )
 
       unless @dependinator.stale?( target )

--- a/lib/ceedling/test_invoker/test_pipeline_helpers.rb
+++ b/lib/ceedling/test_invoker/test_pipeline_helpers.rb
@@ -31,8 +31,25 @@ module TestPipelineHelpers
   # registered with -- flags, defines, and search paths all affect a preprocess or
   # compile target's actual output, so all three ride along as meta everywhere a
   # target derived from any of them is registered.
-  def dependency_meta(flags:, defines:, search_paths:)
-    { flags: flags, defines: defines, search_paths: search_paths }
+  #
+  # `tools:` carries the config for whichever :tools entry (or entries) actually
+  # ran to produce this target -- a repointed :executable, an added argument, a
+  # changed :name or :optional/:stderr_redirect setting should all invalidate the
+  # target the same as a changed flag would, even though none of those live in
+  # `flags`. Defaults to an empty list for a caller with no shell tool of its own.
+  #
+  # `preprocess_force_fallback:` defaults to this run's actual
+  # :test_build ↳ :preprocess_force_fallback setting, so every ordinary caller
+  # picks it up without having to ask for it explicitly -- toggling that setting
+  # between runs, with nothing else changed, should still invalidate whatever a
+  # preprocessing pass produced.
+  #
+  # `partials:` is left out of the returned hash entirely when not given, so a
+  # caller with nothing to do with Partials never carries a meaningless `nil`.
+  def dependency_meta(flags:, defines:, search_paths:, tools: [], preprocess_force_fallback: @configurator.test_build_preprocess_force_fallback, partials: nil)
+    meta = { flags: flags, defines: defines, search_paths: search_paths, tools: tools, preprocess_force_fallback: preprocess_force_fallback }
+    meta[:partials] = partials unless partials.nil?
+    meta
   end
 
   # A preprocessing pass falls back to plain, non-directives-only handling either when

--- a/spec/system/delta_builds_spec.rb
+++ b/spec/system/delta_builds_spec.rb
@@ -278,6 +278,95 @@ ceedling_system_tests do
     end
   end
 
+  # Config-only changes -- no source, header, or test file edited at all -- that
+  # should still invalidate a target because the *tool*, the preprocessing mode,
+  # or the Partials config that produced it changed. Each `:tools` edit below adds
+  # a key Ceedling itself never reads (`:ceedling_delta_probe`), so the resulting
+  # rebuild is attributable purely to the dependency tracker's own meta-hash
+  # comparison -- not to any real behavior change a different flag or executable
+  # might otherwise cause.
+  describe "Delta builds: config-only meta changes (temp_sensor)" do
+    before do
+      @c.with_context do
+        output = @c.ceedling_appcmd_exec("example temp_sensor")
+        expect(output).to match(/created/)
+      end
+    end
+
+    it "recompiles every object when the :tools ↳ :test_compiler configuration changes, with no source edits" do
+      @c.with_context do
+        Dir.chdir "temp_sensor" do
+          @c.ceedling_build_exec("test:all")
+
+          @c.merge_project_yml_for_test({ :tools => { :test_compiler => { :ceedling_delta_probe => true } } })
+
+          rebuild = @c.ceedling_build_exec("test:all")
+
+          # Only Compiling is asserted, not Linking: the inert probe key changes
+          # no real compiler argument, so a deterministic toolchain can (and does
+          # here) produce byte-identical objects, in which case linking is
+          # correctly skipped on its own separate content-hash staleness check --
+          # the same pattern already established elsewhere in this file for a
+          # content change that doesn't alter compiled output.
+          expect(rebuild).to match(/^Compiling /)
+          expect(rebuild).to match(/TESTED:\s+86/)
+          expect(rebuild).to match(/PASSED:\s+86/)
+        end
+      end
+    end
+
+    it "reruns every test when the :tools ↳ :test_fixture configuration changes, with the executable otherwise unchanged" do
+      @c.with_context do
+        Dir.chdir "temp_sensor" do
+          @c.ceedling_build_exec("test:all")
+
+          @c.merge_project_yml_for_test({ :tools => { :test_fixture => { :ceedling_delta_probe => true } } })
+
+          rebuild = @c.ceedling_build_exec("test:all")
+
+          # Nothing about the executable itself changed -- only the tool that runs
+          # it -- so compiling and linking are correctly skipped; only execution
+          # (stage 17's own new target) is invalidated.
+          expect(rebuild).to_not match(/^Compiling /)
+          expect(rebuild).to_not match(/^Linking /)
+          expect(rebuild).to match(/^Running /)
+
+          expect(rebuild).to match(/TESTED:\s+86/)
+          expect(rebuild).to match(/PASSED:\s+86/)
+        end
+      end
+    end
+
+    it "re-extracts #includes for every test file when :test_build ↳ :preprocess_force_fallback toggles" do
+      @c.with_context do
+        Dir.chdir "temp_sensor" do
+          @c.ceedling_build_exec("test:all")
+
+          # Unlike the single-file :preprocess: ↳ :defines matcher scenario above,
+          # this setting has no per-file scope at all -- toggling it changes every
+          # preprocessing target's meta project-wide, so re-extraction isn't
+          # limited to one matched file. Forcing text-based fallback extraction
+          # is also a real procedural switch, not merely a meta-tracked value --
+          # it can discover a different #include set than directives-only
+          # expansion does on a real project, so (unlike the :tools scenarios
+          # above) compiling is deliberately left unasserted here rather than
+          # claimed to be absent.
+          @c.merge_project_yml_for_test({ :test_build => { :preprocess_force_fallback => true } })
+
+          rebuild = @c.ceedling_build_exec("test:all")
+
+          expect(rebuild).to match(/^Extracting #includes from TestAdcModel\.c/)
+          expect(rebuild).to match(/^Extracting #includes from TestUsartModel\.c/)
+          expect(rebuild).to match(/^Extracting #includes from TestTimerModel\.c/)
+          expect(rebuild).to match(/WARNING: Using fallback text-only includes extracted for/)
+
+          expect(rebuild).to match(/TESTED:\s+86/)
+          expect(rebuild).to match(/PASSED:\s+86/)
+        end
+      end
+    end
+  end
+
   # :unity ↳ :shuffle_tests decides test-case execution order at runtime, inside
   # the compiled executable's own main() -- not at compile or link time. So an
   # executable delta builds correctly judge unchanged (same source, same flags,
@@ -459,6 +548,32 @@ ceedling_system_tests do
           expect(rebuild).to_not match(/^Compiling /)
           expect(rebuild).to_not match(/^Linking /)
           expect(rebuild).to_not match(/^Running /)
+
+          expect(rebuild).to match(/TESTED:\s+68/)
+          expect(rebuild).to match(/PASSED:\s+68/)
+        end
+      end
+    end
+
+    it "reprocesses and regenerates every partial when the :partials configuration changes, with no file edits" do
+      @c.with_context do
+        Dir.chdir "wondrous_forest" do
+          @c.ceedling_build_exec("test:all")
+
+          # Unlike the :preprocess: ↳ :defines matcher above, :partials has no
+          # per-file scope -- it applies uniformly, so both the
+          # implementation-only partial (SoilMoisture) and the
+          # implementation+interface partial (ForestMonitor) reprocess and
+          # regenerate.
+          @c.merge_project_yml_for_test({ :partials => { :max_extraction_length => 6000 } })
+
+          rebuild = @c.ceedling_build_exec("test:all")
+
+          expect(rebuild).to match(/Preprocessing partial (header|source) for TestSoilMoisture/)
+          expect(rebuild).to match(/Preprocessing partial (header|source) for TestForestMonitor/)
+          expect(rebuild).to match(/Generating Partial implementation for TestSoilMoisture/)
+          expect(rebuild).to match(/Generating Partial implementation for TestForestMonitor/)
+          expect(rebuild).to match(/Generating Partial mockable interface for TestForestMonitor/)
 
           expect(rebuild).to match(/TESTED:\s+68/)
           expect(rebuild).to match(/PASSED:\s+68/)

--- a/spec/system/delta_builds_spec.rb
+++ b/spec/system/delta_builds_spec.rb
@@ -367,6 +367,66 @@ ceedling_system_tests do
     end
   end
 
+  # Every other scenario in this file uses a project whose tests all pass -- stage
+  # 17's own fixture-tool tracking (see the config-only meta changes above) targets
+  # a dedicated marker file specifically because the test's outcome-dependent result
+  # file (.pass on success, .fail on failure) is not guaranteed to exist either way,
+  # and a persistently *failing* test is exactly the case that would have exposed a
+  # target keyed on the wrong one of those two -- crashing outright if marked fresh
+  # while genuinely missing, or reporting permanent, incorrect staleness if `stale?`
+  # checked for a path that only exists on the *other* outcome.
+  describe "Delta builds: repeated builds of a persistently failing test" do
+    before { @proj_name = unique_proj_name("delta_fail") }
+
+    def deploy_failing_test!
+      @c.ceedling_appcmd_exec("new #{@proj_name}")
+
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file.c"), 'test/'
+      end
+    end
+
+    it "does not crash, and correctly skips recompiling/relinking/rerunning, on a rebuild of a failing test left unchanged" do
+      @c.with_context do
+        deploy_failing_test!
+
+        Dir.chdir @proj_name do
+          baseline = @c.ceedling_build_exec("test:all")
+          expect(baseline).to_not match(/EXCEPTION/)
+          expect(baseline).to match(/FAILED:\s+[1-9]/)
+
+          rebuild = @c.ceedling_build_exec("test:all")
+          expect(rebuild).to_not match(/EXCEPTION/)
+          expect(rebuild).to_not match(/^Compiling /)
+          expect(rebuild).to_not match(/^Linking /)
+          expect(rebuild).to_not match(/^Running /)
+          expect(rebuild).to match(/FAILED:\s+[1-9]/)
+        end
+      end
+    end
+
+    it "reruns a persistently failing test's fixture when :tools ↳ :test_fixture configuration changes, with nothing else changed" do
+      @c.with_context do
+        deploy_failing_test!
+
+        Dir.chdir @proj_name do
+          @c.ceedling_build_exec("test:all")
+
+          @c.merge_project_yml_for_test({ :tools => { :test_fixture => { :ceedling_delta_probe => true } } })
+
+          rebuild = @c.ceedling_build_exec("test:all")
+          expect(rebuild).to_not match(/EXCEPTION/)
+          expect(rebuild).to_not match(/^Compiling /)
+          expect(rebuild).to_not match(/^Linking /)
+          expect(rebuild).to match(/^Running /)
+          expect(rebuild).to match(/FAILED:\s+[1-9]/)
+        end
+      end
+    end
+  end
+
   # :unity ↳ :shuffle_tests decides test-case execution order at runtime, inside
   # the compiled executable's own main() -- not at compile or link time. So an
   # executable delta builds correctly judge unchanged (same source, same flags,

--- a/spec/units/configurator_spec.rb
+++ b/spec/units/configurator_spec.rb
@@ -285,4 +285,30 @@ describe Configurator do
 
   end
 
+  describe "#populate_partials_config / #get_partials_config" do
+
+    it "returns the :partials section handed to populate_partials_config" do
+      config = { partials: { max_extraction_length: 5000 } }
+
+      @configurator.populate_partials_config( config )
+
+      expect( @configurator.get_partials_config ).to eq( { max_extraction_length: 5000 } )
+    end
+
+    it "returns a clone, not the same object populate_partials_config was given -- callers may mutate their own copy freely" do
+      config = { partials: { max_extraction_length: 5000 } }
+      @configurator.populate_partials_config( config )
+
+      returned = @configurator.get_partials_config
+      returned[:max_extraction_length] = 1
+
+      expect( @configurator.get_partials_config[:max_extraction_length] ).to eq( 5000 )
+    end
+
+    it "defaults to an empty hash before populate_partials_config has ever run" do
+      expect( @configurator.get_partials_config ).to eq( {} )
+    end
+
+  end
+
 end

--- a/spec/units/dependencies/dependency_tracker_spec.rb
+++ b/spec/units/dependencies/dependency_tracker_spec.rb
@@ -334,6 +334,27 @@ describe DependencyTracker do
       expect( @tracker.stale?('foo.o') ).to be(true)
     end
 
+    # A target itself is not guaranteed to exist -- a caller may legitimately mark_fresh
+    # something conditionally written (e.g. one of two mutually-exclusive outcome files).
+    # `stale?` and `diagnose` already both check existence before ever hashing the target;
+    # `mark_fresh` extends the same tolerance here, mirroring its own `deps` loop three
+    # lines below, which already skips hashing a dependency that doesn't currently exist.
+    it 'does not raise when the target itself does not exist on disk' do
+      @tracker.register( 'missing.o', files: [] )
+
+      expect { @tracker.mark_fresh('missing.o') }.not_to raise_error
+    end
+
+    it 'reports a target marked fresh while missing as stale once it appears, even with nothing else changed' do
+      @tracker.register( 'missing.o', files: [] )
+      @tracker.mark_fresh( 'missing.o' )
+
+      stub_file( 'missing.o', 'now exists' )
+      @tracker.register( 'missing.o', files: [] )
+
+      expect( @tracker.stale?('missing.o') ).to be(true)
+    end
+
     # These write/read a real (mocked-FileWrapper-backed) DependencyDebugTree
     # snapshot rather than anything embedded in the JSON cache -- Tier 2's
     # capture moved out of the cache entries entirely. A small in-memory

--- a/spec/units/partials_manager_spec.rb
+++ b/spec/units/partials_manager_spec.rb
@@ -26,6 +26,17 @@ describe PartialsManager do
     allow(@reportinator).to receive(:generate_skip_summary).and_return( nil )
     allow(@loginator).to receive(:log)
 
+    @tools_test_bare_includes_preprocessor        = { name: 'fake bare includes preprocessor' }
+    @tools_test_file_directives_only_preprocessor = { name: 'fake directives-only preprocessor' }
+    @tools_test_file_full_preprocessor            = { name: 'fake full preprocessor' }
+    @partials_config                              = { max_extraction_length: 5000 }
+
+    allow(@configurator).to receive(:tools_test_bare_includes_preprocessor).and_return( @tools_test_bare_includes_preprocessor )
+    allow(@configurator).to receive(:tools_test_file_directives_only_preprocessor).and_return( @tools_test_file_directives_only_preprocessor )
+    allow(@configurator).to receive(:tools_test_file_full_preprocessor).and_return( @tools_test_file_full_preprocessor )
+    allow(@configurator).to receive(:test_build_preprocess_force_fallback).and_return( false )
+    allow(@configurator).to receive(:get_partials_config).and_return( @partials_config )
+
     allow(@dependinator).to receive(:register)
     allow(@dependinator).to receive(:stale?).and_return( true )
     allow(@dependinator).to receive(:mark_fresh)
@@ -77,13 +88,18 @@ describe PartialsManager do
       )
     end
 
-    it "registers the header's deterministic target with the header file as sole antecedent and preprocess flags/defines/search paths as meta" do
+    it "registers the header's deterministic target with the header file as sole antecedent and preprocess flags/defines/search paths, preprocessing tools, and :partials config as meta" do
       allow(@configurator).to receive(:test_build_preprocess_directives_only_available).and_return( false )
 
       expect(@dependinator).to receive(:register).with(
         'build/preprocess/Foo.h',
         files: ['src/Foo.h'],
-        meta:  { flags: ['-Wall'], defines: ['TEST'], search_paths: ['src'] }
+        meta:  {
+          flags: ['-Wall'], defines: ['TEST'], search_paths: ['src'],
+          tools: [@tools_test_file_directives_only_preprocessor, @tools_test_bare_includes_preprocessor, @tools_test_file_full_preprocessor],
+          preprocess_force_fallback: false,
+          partials: @partials_config
+        }
       )
 
       @manager.stage_preprocess_partial_headers( @state )
@@ -181,13 +197,18 @@ describe PartialsManager do
       )
     end
 
-    it "registers the source's deterministic target with the source file as sole antecedent and preprocess flags/defines/search paths as meta" do
+    it "registers the source's deterministic target with the source file as sole antecedent and preprocess flags/defines/search paths, preprocessing tools, and :partials config as meta" do
       allow(@configurator).to receive(:test_build_preprocess_directives_only_available).and_return( false )
 
       expect(@dependinator).to receive(:register).with(
         'build/preprocess/Foo.c',
         files: ['src/Foo.c'],
-        meta:  { flags: ['-Wall'], defines: ['TEST'], search_paths: ['src'] }
+        meta:  {
+          flags: ['-Wall'], defines: ['TEST'], search_paths: ['src'],
+          tools: [@tools_test_file_directives_only_preprocessor, @tools_test_bare_includes_preprocessor, @tools_test_file_full_preprocessor],
+          preprocess_force_fallback: false,
+          partials: @partials_config
+        }
       )
 
       @manager.stage_preprocess_partial_sources( @state )
@@ -267,7 +288,6 @@ describe PartialsManager do
       stub_batchinator_exec()
 
       allow(@configurator).to receive(:test_build_preprocess_directives_only_available).and_return( false )
-      allow(@configurator).to receive(:partials_max_extraction_length).and_return( 5 )
 
       @module_contents = double( "CModule",
         function_definitions:    [],
@@ -359,6 +379,19 @@ describe PartialsManager do
 
       expect( @testable.partials.tests ).to eq( ['Foo'] )
       expect( @testable.partials.mocks ).to eq( ['Foo'] )
+    end
+
+    it "registers the whole :partials config as meta, and an empty tools list since this stage runs no shell tool" do
+      allow(@module_contents).to receive(:type_definitions).and_return( [double("TypeDef")] )
+      allow(@partializer).to receive(:extract_implementation_functions).and_return( [double("FunctionDefinition")] )
+      allow(@partializer).to receive(:extract_interface_functions).and_return( [double("FunctionDeclaration")] )
+
+      expect(@dependinator).to receive(:register).at_least(:once) do |_target, files:, meta:|
+        expect( meta[:tools] ).to eq( [] )
+        expect( meta[:partials] ).to eq( @partials_config )
+      end
+
+      @manager.stage_generate_partials( @state )
     end
 
     it "never registers or checks a types-header target when the module has no type or aggregate definitions" do

--- a/spec/units/release_build_executor_spec.rb
+++ b/spec/units/release_build_executor_spec.rb
@@ -151,6 +151,16 @@ describe ReleaseBuildExecutor do
       @executor.compile_objects( @state )
     end
 
+    it "registers the configured compiler tool as meta for a C source, and the configured assembler tool for an assembly source" do
+      allow(@file_finder).to receive(:find_build_input_file).with( filepath: 'build/release/out/foo.o', context: RELEASE_SYM ).and_return( 'src/foo.c' )
+      allow(@file_wrapper).to receive(:extname).with( 'src/foo.c' ).and_return( '.c' )
+      allow(@generator).to receive(:generate_object_file_c)
+
+      expect(@dependinator).to receive(:register).with( 'build/release/out/foo.o', files: ['src/foo.c'], meta: hash_including( tools: [@tools_release_compiler] ) )
+      @state.objects = ['build/release/out/foo.o']
+      @executor.compile_objects( @state )
+    end
+
     it "registers the object's source before checking staleness, and its freshly-written gcc deps file after a real compile" do
       allow(@file_finder).to receive(:find_build_input_file).and_return( 'src/foo.c' )
       allow(@file_wrapper).to receive(:extname).with( 'src/foo.c' ).and_return( '.c' )
@@ -286,7 +296,7 @@ describe ReleaseBuildExecutor do
       expect(@dependinator).to receive(:register).with(
         'build/release/out/project.out',
         files: ['build/release/out/foo.o'],
-        meta:  { flags: ['-Wall'], lib_args: ['-lm'], lib_paths: ['-Lvendor/lib'] }
+        meta:  { flags: ['-Wall'], lib_args: ['-lm'], lib_paths: ['-Lvendor/lib'], tools: [@tools_release_linker] }
       )
 
       @executor.link( @state )

--- a/spec/units/test_build_executor_spec.rb
+++ b/spec/units/test_build_executor_spec.rb
@@ -390,6 +390,12 @@ describe TestBuildExecutor do
       stub_batchinator_exec()
       allow(@plugin_manager).to receive(:post_test)
 
+      # This context's own tests are about executable_rebuilt/force_rerun/shuffle
+      # deciding whether a fixture reruns, so the fixture-target's own staleness
+      # (the tool-config trigger) defaults to fresh here -- see the dedicated
+      # "tool configuration changed" examples below for that case on its own.
+      allow(@dependinator).to receive(:stale?).and_return( false )
+
       @testable = TestInvokerTypes::Testable.new(
         :name         => 'a_test',
         :filepath     => 'test/TestFoo.c',
@@ -486,6 +492,40 @@ describe TestBuildExecutor do
       allow(@reportinator).to receive(:generate_skip_summary).and_return( "Skipping test execution for 1 test (reusing cached results)..." )
 
       expect(@loginator).to receive(:log).with( "Skipping test execution for 1 test (reusing cached results)..." )
+      @executor.stage_execute( @state )
+    end
+
+    it "registers a target separate from the executable, with the executable as antecedent and the test fixture tool as meta" do
+      @testable.executable_rebuilt = false
+      allow(@generator).to receive(:generate_test_results)
+
+      expect(@dependinator).to receive(:register).with(
+        'build/a_test.pass',
+        files: ['build/a_test.out'],
+        meta:  { tools: [@tools_test_fixture] }
+      )
+
+      @executor.stage_execute( @state )
+    end
+
+    it "reruns the test fixture when only the :tools ↳ :test_fixture configuration changed, even though the executable is unchanged" do
+      @testable.executable_rebuilt = false
+      allow(@dependinator).to receive(:stale?).with('build/a_test.pass').and_return( true )
+      allow(@file_wrapper).to receive(:rm_f)
+
+      expect(@file_wrapper).to receive(:rm_f).with( Dir.glob( File.join( 'build/test/results', 'a_test.*' ) ) )
+      expect(@generator).to receive(:generate_test_results).with( hash_including( skipped: false ) )
+      expect(@dependinator).to receive(:mark_fresh).with('build/a_test.pass')
+
+      @executor.stage_execute( @state )
+    end
+
+    it "does not mark the fixture target fresh when the run was skipped" do
+      @testable.executable_rebuilt = false
+      allow(@generator).to receive(:generate_test_results)
+
+      expect(@dependinator).to_not receive(:mark_fresh)
+
       @executor.stage_execute( @state )
     end
   end

--- a/spec/units/test_build_executor_spec.rb
+++ b/spec/units/test_build_executor_spec.rb
@@ -32,16 +32,21 @@ describe TestBuildExecutor do
     @dependinator                                          = double( "Dependinator" )
     @test_source_file_directive_resolver                      = double( "TestSourceFileDirectiveResolver" )
 
-    @tools_test_compiler  = { name: 'fake compiler' }
-    @tools_test_assembler = { name: 'fake assembler' }
-    @tools_test_linker    = { name: 'fake linker' }
-    @tools_test_fixture   = { name: 'fake fixture' }
+    @tools_test_compiler                     = { name: 'fake compiler' }
+    @tools_test_assembler                    = { name: 'fake assembler' }
+    @tools_test_linker                       = { name: 'fake linker' }
+    @tools_test_fixture                      = { name: 'fake fixture' }
+    @tools_test_bare_includes_preprocessor   = { name: 'fake bare includes preprocessor' }
+    @tools_test_file_directives_only_preprocessor = { name: 'fake directives-only preprocessor' }
 
     allow(@configurator).to receive(:extension_assembly).and_return( FilenameExtension.new('.asm') )
     allow(@configurator).to receive(:tools_test_compiler).and_return( @tools_test_compiler )
     allow(@configurator).to receive(:tools_test_assembler).and_return( @tools_test_assembler )
     allow(@configurator).to receive(:tools_test_linker).and_return( @tools_test_linker )
     allow(@configurator).to receive(:tools_test_fixture).and_return( @tools_test_fixture )
+    allow(@configurator).to receive(:tools_test_bare_includes_preprocessor).and_return( @tools_test_bare_includes_preprocessor )
+    allow(@configurator).to receive(:tools_test_file_directives_only_preprocessor).and_return( @tools_test_file_directives_only_preprocessor )
+    allow(@configurator).to receive(:test_build_preprocess_force_fallback).and_return( false )
     allow(@configurator).to receive(:project_use_mocks).and_return( false )
     allow(@configurator).to receive(:project_use_exceptions).and_return( false )
     allow(@configurator).to receive(:collection_all_support).and_return( [] )
@@ -184,6 +189,26 @@ describe TestBuildExecutor do
         :context => :test, :test => :a_test, :source => 'src/foo.c', :object => 'build/foo.o', :state => @state
       )
     end
+
+    it "registers the configured compiler tool as meta for a C source, and the configured assembler tool for an assembly source" do
+      allow(@file_wrapper).to receive(:extname).with( 'src/foo.c' ).and_return( '.c' )
+      allow(@file_wrapper).to receive(:extname).with( 'src/foo.asm' ).and_return( '.asm' )
+      allow(@configurator).to receive(:test_build_use_assembly).and_return( true )
+      allow(@generator).to receive(:generate_object_file_c)
+      allow(@generator).to receive(:generate_object_file_asm)
+
+      expect(@dependinator).to receive(:register).with( 'build/foo.o', files: ['src/foo.c'], meta: hash_including( tools: [@tools_test_compiler] ) )
+      @executor.send(
+        :compile_test_component,
+        :context => :test, :test => :a_test, :source => 'src/foo.c', :object => 'build/foo.o', :state => @state
+      )
+
+      expect(@dependinator).to receive(:register).with( 'build/foo.o', files: ['src/foo.asm'], meta: hash_including( tools: [@tools_test_assembler] ) )
+      @executor.send(
+        :compile_test_component,
+        :context => :test, :test => :a_test, :source => 'src/foo.asm', :object => 'build/foo.o', :state => @state
+      )
+    end
   end
 
   context "#stage_build_objects" do
@@ -259,6 +284,18 @@ describe TestBuildExecutor do
       @executor.stage_build_executables( @state )
 
       expect( @testable.executable_rebuilt ).to be(false)
+    end
+
+    it "registers the configured test linker tool as meta, alongside link flags and library arguments" do
+      allow(@dependinator).to receive(:stale?).and_return( false )
+
+      expect(@dependinator).to receive(:register).with(
+        'build/a_test.out',
+        files: ['build/foo.o'],
+        meta:  { flags: [], lib_args: [], lib_paths: [], tools: [@tools_test_linker] }
+      )
+
+      @executor.stage_build_executables( @state )
     end
 
     it "logs a summary line stating how many executables were recalled from cache" do
@@ -497,6 +534,22 @@ describe TestBuildExecutor do
       allow(@reportinator).to receive(:generate_skip_summary).and_return( "Skipping mock preprocessing for 1 mock (nothing changed)..." )
 
       expect(@loginator).to receive(:log).with( "Skipping mock preprocessing for 1 mock (nothing changed)..." )
+      @executor.stage_preprocess_mocks( @state )
+    end
+
+    it "registers the bare-includes and directives-only preprocessor tools, and the fallback setting, as meta" do
+      allow(@preprocessinator).to receive(:preprocess_mockable_header_file)
+
+      expect(@dependinator).to receive(:register).with(
+        'build/preprocess/MockFoo.h',
+        files: ['src/Foo.h'],
+        meta:  {
+          flags: [], defines: [], search_paths: [], extras: false,
+          tools: [@tools_test_bare_includes_preprocessor, @tools_test_file_directives_only_preprocessor],
+          preprocess_force_fallback: false
+        }
+      )
+
       @executor.stage_preprocess_mocks( @state )
     end
   end

--- a/spec/units/test_build_executor_spec.rb
+++ b/spec/units/test_build_executor_spec.rb
@@ -395,6 +395,7 @@ describe TestBuildExecutor do
       # (the tool-config trigger) defaults to fresh here -- see the dedicated
       # "tool configuration changed" examples below for that case on its own.
       allow(@dependinator).to receive(:stale?).and_return( false )
+      allow(@file_wrapper).to receive(:touch)
 
       @testable = TestInvokerTypes::Testable.new(
         :name         => 'a_test',
@@ -404,6 +405,7 @@ describe TestBuildExecutor do
         :paths        => { :results => 'build/test/results' }
       )
       @state = TestInvokerTypes::PipelineState.new( :testables => { :a_test => @testable }, :lock => Mutex.new, :context => :test, :options => [] )
+      @fixture_target = 'build/test/results/a_test.fixture_run'
     end
 
     it "runs the test fixture when stage 16 rebuilt the executable, first clearing any stale prior result" do
@@ -495,12 +497,12 @@ describe TestBuildExecutor do
       @executor.stage_execute( @state )
     end
 
-    it "registers a target separate from the executable, with the executable as antecedent and the test fixture tool as meta" do
+    it "registers a dedicated marker target separate from the executable, with the executable as antecedent and the test fixture tool as meta" do
       @testable.executable_rebuilt = false
       allow(@generator).to receive(:generate_test_results)
 
       expect(@dependinator).to receive(:register).with(
-        'build/a_test.pass',
+        @fixture_target,
         files: ['build/a_test.out'],
         meta:  { tools: [@tools_test_fixture] }
       )
@@ -510,12 +512,27 @@ describe TestBuildExecutor do
 
     it "reruns the test fixture when only the :tools ↳ :test_fixture configuration changed, even though the executable is unchanged" do
       @testable.executable_rebuilt = false
-      allow(@dependinator).to receive(:stale?).with('build/a_test.pass').and_return( true )
+      allow(@dependinator).to receive(:stale?).with(@fixture_target).and_return( true )
       allow(@file_wrapper).to receive(:rm_f)
 
       expect(@file_wrapper).to receive(:rm_f).with( Dir.glob( File.join( 'build/test/results', 'a_test.*' ) ) )
       expect(@generator).to receive(:generate_test_results).with( hash_including( skipped: false ) )
-      expect(@dependinator).to receive(:mark_fresh).with('build/a_test.pass')
+      expect(@dependinator).to receive(:mark_fresh).with(@fixture_target)
+
+      @executor.stage_execute( @state )
+    end
+
+    # The whole reason this target is a dedicated marker file rather than the test's own
+    # outcome-dependent .pass/.fail result file: a failing test never writes the .pass
+    # path, and DependencyTracker#mark_fresh would otherwise crash trying to hash a target
+    # that doesn't exist -- exactly the CI failure this scenario guards against regressing.
+    it "marks the marker target fresh after a real run even when the test itself fails" do
+      @testable.executable_rebuilt = true
+      allow(@file_wrapper).to receive(:rm_f)
+      allow(@generator).to receive(:generate_test_results).and_return( { results: { counts: { failed: 1 } } } )
+
+      expect(@file_wrapper).to receive(:touch).with(@fixture_target)
+      expect(@dependinator).to receive(:mark_fresh).with(@fixture_target)
 
       @executor.stage_execute( @state )
     end

--- a/spec/units/test_build_setup_spec.rb
+++ b/spec/units/test_build_setup_spec.rb
@@ -39,6 +39,9 @@ describe TestBuildSetup do
     allow(@configurator).to receive(:project_build_vendor_ceedling_path).and_return( 'build/vendor/ceedling' )
     allow(@configurator).to receive(:cmock_mock_prefix).and_return( 'Mock' )
     allow(@configurator).to receive(:paths_test).and_return( [] )
+    allow(@configurator).to receive(:tools_test_bare_includes_preprocessor).and_return( { name: 'fake bare includes preprocessor' } )
+    allow(@configurator).to receive(:tools_test_file_directives_only_preprocessor).and_return( { name: 'fake directives-only preprocessor' } )
+    allow(@configurator).to receive(:test_build_preprocess_force_fallback).and_return( false )
     allow(@file_path_utils).to receive(:form_preprocessed_file_raw_directives_only_filepath).and_return( 'build/preprocess/raw/Foo.txt' )
     allow(@file_path_utils).to receive(:form_preprocessed_includes_list_filepath).and_return( 'build/preprocess/includes/Foo.c.yml' )
     allow(@file_path_utils).to receive(:form_test_build_directives_cache_filepath).and_return( 'build/preprocess/build_directives/a_test/Foo.c.yml' )
@@ -391,6 +394,27 @@ describe TestBuildSetup do
 
       @setup.stage_collect_preprocessor_context( @state )
     end
+
+    it "registers the test file as the sole antecedent, with preprocess flags/defines/search paths and the directives-only preprocessor tool as meta" do
+      testable = @testable
+      testable.preprocess_flags   = ['-Wall']
+      testable.preprocess_defines = ['TEST']
+      testable.search_paths       = ['src']
+      allow(@dependinator).to receive(:stale?).and_return( true )
+      allow(@preprocessinator).to receive(:generate_directives_only_output).and_return( 'build/preprocess/raw/Foo.txt' )
+
+      expect(@dependinator).to receive(:register).with(
+        'build/preprocess/raw/Foo.txt',
+        files: ['test/TestFoo.c'],
+        meta:  {
+          flags: ['-Wall'], defines: ['TEST'], search_paths: ['src'],
+          tools: [{ name: 'fake directives-only preprocessor' }],
+          preprocess_force_fallback: false
+        }
+      )
+
+      @setup.stage_collect_preprocessor_context( @state )
+    end
   end
 
   context "#stage_collect_preprocessor_context (bare-includes pass)" do
@@ -441,7 +465,7 @@ describe TestBuildSetup do
       @setup.stage_collect_preprocessor_context( @state )
     end
 
-    it "registers the test file as the sole antecedent, with preprocess flags/defines/search paths as meta" do
+    it "registers the test file as the sole antecedent, with preprocess flags/defines/search paths and the bare-includes preprocessor tool as meta" do
       testable = @testable
       testable.preprocess_flags   = ['-Wall']
       testable.preprocess_defines = ['TEST']
@@ -450,7 +474,11 @@ describe TestBuildSetup do
       expect(@dependinator).to receive(:register).with(
         'build/preprocess/includes/Foo.c.yml',
         files: ['test/TestFoo.c'],
-        meta:  { flags: ['-Wall'], defines: ['TEST'], search_paths: ['src'] }
+        meta:  {
+          flags: ['-Wall'], defines: ['TEST'], search_paths: ['src'],
+          tools: [{ name: 'fake bare includes preprocessor' }],
+          preprocess_force_fallback: false
+        }
       )
 
       @setup.stage_collect_preprocessor_context( @state )

--- a/spec/units/test_pipeline_helpers_spec.rb
+++ b/spec/units/test_pipeline_helpers_spec.rb
@@ -1,0 +1,81 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/test_invoker/test_pipeline_helpers'
+
+# A bare includer, exactly as any real pipeline stage class would mix this
+# module in -- `dependency_meta` reads `@configurator` from whatever host
+# object includes it, so this stand-in only needs that one ivar.
+class TestPipelineHelpersIncluder
+  include TestPipelineHelpers
+
+  attr_accessor :configurator
+
+  def initialize(configurator)
+    @configurator = configurator
+  end
+end
+
+describe TestPipelineHelpers do
+  before(:each) do
+    @configurator = double( "Configurator" )
+    allow(@configurator).to receive(:test_build_preprocess_force_fallback).and_return( false )
+
+    @host = TestPipelineHelpersIncluder.new( @configurator )
+  end
+
+  describe "#dependency_meta" do
+    it "returns flags, defines, and search paths given no other keyword" do
+      meta = @host.dependency_meta( flags: ['-Wall'], defines: ['TEST'], search_paths: ['src'] )
+
+      expect( meta[:flags] ).to eq( ['-Wall'] )
+      expect( meta[:defines] ).to eq( ['TEST'] )
+      expect( meta[:search_paths] ).to eq( ['src'] )
+    end
+
+    it "defaults tools to an empty list when not given" do
+      meta = @host.dependency_meta( flags: [], defines: [], search_paths: [] )
+
+      expect( meta[:tools] ).to eq( [] )
+    end
+
+    it "carries whatever tools list is given" do
+      tool = { name: 'fake compiler' }
+      meta = @host.dependency_meta( flags: [], defines: [], search_paths: [], tools: [tool] )
+
+      expect( meta[:tools] ).to eq( [tool] )
+    end
+
+    it "defaults preprocess_force_fallback to the configurator's current setting when not given" do
+      allow(@configurator).to receive(:test_build_preprocess_force_fallback).and_return( true )
+
+      meta = @host.dependency_meta( flags: [], defines: [], search_paths: [] )
+
+      expect( meta[:preprocess_force_fallback] ).to be(true)
+    end
+
+    it "carries an explicitly given preprocess_force_fallback instead of asking the configurator" do
+      meta = @host.dependency_meta( flags: [], defines: [], search_paths: [], preprocess_force_fallback: true )
+
+      expect( meta[:preprocess_force_fallback] ).to be(true)
+    end
+
+    it "omits :partials entirely when not given, rather than carrying a meaningless nil" do
+      meta = @host.dependency_meta( flags: [], defines: [], search_paths: [] )
+
+      expect( meta ).to_not have_key( :partials )
+    end
+
+    it "carries whatever :partials config is given" do
+      partials_config = { max_extraction_length: 5000 }
+      meta = @host.dependency_meta( flags: [], defines: [], search_paths: [], partials: partials_config )
+
+      expect( meta[:partials] ).to eq( partials_config )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

An audit of every `Dependinator#register(...)` call site in the test and release pipelines found four places where a build target's registered metadata didn't fully cover what actually governs its output:

1. No preprocess/compile/link step hashed the `:tools` config entry that actually runs it — a repointed executable, an added argument, or a changed name/optional/stderr_redirect setting went unnoticed.
2. `:test_build ↳ :preprocess_force_fallback` was read once, procedurally, and never reached any registered meta.
3. The `:partials` config block reached meta only at Partials' generation stage (and only `max_extraction_length`), not at the earlier preprocessing stage that feeds it.
4. Test execution (stage 17) was gated purely on whether the executable was relinked — a change to the tool that actually *runs* the fixture (`:tools ↳ :test_fixture`) went unnoticed when the executable itself was unchanged.

## Changes

- Widened the shared `dependency_meta` helper (`test_pipeline_helpers.rb`) to carry `tools:`, `preprocess_force_fallback:`, and an optional `partials:` key, and threaded it (or the equivalent inline literal, where a call site doesn't use the helper) through every preprocess/compile/link register call in both the test and release pipelines.
- Added `Configurator#get_partials_config`, mirroring the existing `get_cmock_config`/`get_runner_config`/`get_unity_config` pattern, so Partials register calls can hash the whole section.
- Gave stage 17 (test execution) its own dependency-tracker target, separate from stage 16's executable target, carrying the resolved `:test_fixture` tool as meta — a tool-only change now reruns the fixture without forcing an unnecessary relink.

## Testing

- Full `bundle exec rspec spec/units/`: 2833 examples, 0 failures.
- Four new targeted system-test scenarios in `spec/system/delta_builds_spec.rb`, one per gap, against real example projects (temp_sensor, wondrous_forest) — all green.
- Ran the rest of `delta_builds_spec.rb`: one pre-existing failure (an encoding/locale issue in `probe_header!`, unrelated to this branch — confirmed present identically on `next_version` before these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)