### PR TITLE
Fully integrate delta builds with Gcov, Valgrind, and Bullseye

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,11 @@ gem "rake", ">= 12", "< 14"
 gem "rr"
 gem "require_all"
 
+# Test-only: spec/system/support/gcov_partials_test_cases.rb parses coverage XML.
+# rexml has been removed from the default gems bundled with some Ruby installations
+# (same category as erb/benchmark below), so it must be declared explicitly here too.
+gem "rexml", ">= 3.2"
+
 # Dev-only: used by DependencyTracker's :full debug tier to render human-readable
 # content diffs. Soft dependency at runtime (lib/ceedling/dependencies/dependency_differ.rb
 # requires it defensively and degrades gracefully if absent) -- deliberately NOT declared in

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     parallel (1.28.0)
     rake (13.2.1)
     require_all (3.0.0)
+    rexml (3.4.4)
     rr (3.1.2)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -51,6 +52,7 @@ DEPENDENCIES
   parallel (~> 1.26)
   rake (>= 12, < 14)
   require_all
+  rexml (>= 3.2)
   rr
   rspec (~> 3.8)
   simplecov (~> 1.1)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -25,7 +25,7 @@ A delta build is simply a build run that only performs regeneration, compilation
 
 If a build requests a test to be built/run but no changes for it exist, its cached test results will be reported. The `--force-test-rerun` flag is available at the command line for any test-related tasks to force the delta build mechanism to rerun test executables and produce new test results.
 
-Delta builds are fully integrated with GCov, Valgrind, and Bullseye. Each runs its own build through the same test pipeline as an ordinary test build, under its own build context, so it gets the same content-hash-based staleness tracking — and its own isolated dependency cache, and correctly-tracked instrumented tool configuration.
+Delta builds are fully integrated with test build plugins (e.g. GCov, Valgrind). Each runs its own build through the same test pipeline as an ordinary test build, under its own build context, so it benefits from the same staleness tracking within its own isolated dependency cache
 
 ### `#include` relative paths & duplicate filename disambiguation
 Added support for properly distinguishing all C files by filepath (addressing [#1167](https://github.com/ThrowTheSwitch/Ceedling/issues) specifically but also the fundamental problem generally).

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -25,7 +25,7 @@ A delta build is simply a build run that only performs regeneration, compilation
 
 If a build requests a test to be built/run but no changes for it exist, its cached test results will be reported. The `--force-test-rerun` flag is available at the command line for any test-related tasks to force the delta build mechanism to rerun test executables and produce new test results.
 
-Note: Delta builds are not yet fully integrated with plugins such as GCov and Valgrind.
+Delta builds are fully integrated with GCov, Valgrind, and Bullseye. Each runs its own build through the same test pipeline as an ordinary test build, under its own build context, so it gets the same content-hash-based staleness tracking — and its own isolated dependency cache, and correctly-tracked instrumented tool configuration.
 
 ### `#include` relative paths & duplicate filename disambiguation
 Added support for properly distinguishing all C files by filepath (addressing [#1167](https://github.com/ThrowTheSwitch/Ceedling/issues) specifically but also the fundamental problem generally).

--- a/docs/mkdocs/development/plugins/index.md
+++ b/docs/mkdocs/development/plugins/index.md
@@ -46,6 +46,16 @@ reporting.
 See the [`:plugins` configuration reference][plugins-config] for details of operation
 and the [plugins overview][plugins-directory] for a directory of built-in plugins.
 
+## Plugins and Delta Builds
+
+Ceedling skips work when nothing has changed. This is called a delta build.
+See [Delta Builds](../../getting-started/builds.md).
+
+A plugin's own build runs through the same delta build tracking as an
+ordinary test build. A set of hook methods exist for this purpose. See
+[Delta build hooks](plugin-subclass.md#delta-build-hooks) in the `Plugin`
+subclass guide.
+
 ## Plugin Conventions & Architecture
 
 Plugins are enabled and configured from within a Ceedling project's YAML

--- a/docs/mkdocs/development/plugins/plugin-subclass.md
+++ b/docs/mkdocs/development/plugins/plugin-subclass.md
@@ -250,7 +250,7 @@ the matching `pre_*_execute` hook below, makes sure Ceedling's delta build
 check sees the real tool. Otherwise a change to that tool's own settings
 will not force a rebuild.
 
-## `Plugin` hook method `pre_compile_register(arg_hash)`
+## `Plugin` hook method `pre_test_compile_register(arg_hash)`
 
 Test builds only, not release builds. Runs once per C file in a test build.
 Runs before Ceedling registers the file as a delta build target.
@@ -308,7 +308,7 @@ arg_hash = {
 }
 ```
 
-## `Plugin` hook method `pre_link_register(arg_hash)`
+## `Plugin` hook method `pre_test_link_register(arg_hash)`
 
 Test builds only, not release builds. Runs once per test executable in a
 test build. Runs before Ceedling registers the executable as a delta build
@@ -316,7 +316,7 @@ target. See [Delta build hooks](#delta-build-hooks) above for why this hook
 exists and when it runs.
 
 A plugin swapping in its own linker tool for its own build context should
-do so here, for the same reason described under `pre_compile_register`
+do so here, for the same reason described under `pre_test_compile_register`
 above. Because this hook always runs, it also gives a plugin a reliable
 place to note that its own build context ran at all, apart from whether
 anything actually needed relinking.
@@ -376,7 +376,7 @@ for why this hook exists and when it runs.
 
 A plugin swapping in its own wrapper tool to run the test executable (as
 Valgrind does) should do so here, for the same reason described under
-`pre_compile_register` above. Otherwise a change to that wrapper tool's own
+`pre_test_compile_register` above. Otherwise a change to that wrapper tool's own
 settings will not force a rerun.
 
 The argument `arg_hash` follows the structure below:

--- a/docs/mkdocs/development/plugins/plugin-subclass.md
+++ b/docs/mkdocs/development/plugins/plugin-subclass.md
@@ -237,6 +237,36 @@ arg_hash = {
 }
 ```
 
+## `Plugin` hook method `pre_compile_register(arg_hash)`
+
+Test builds only (not release builds). Called once per C file in a test build,
+*before* Ceedling's own delta-build dependency tracking registers that file's
+build target and checks whether it needs recompiling — unlike
+`pre_compile_execute` below, this fires every time, whether or not the object
+actually ends up stale. A plugin swapping in its own compiler tool for its own
+build context (as GCov and Bullseye do for coverage instrumentation) should do
+so here, not only in `pre_compile_execute`, so that swap is what Ceedling's
+own staleness check is based on — otherwise editing that tool's own
+configuration won't invalidate the plugin's cached build targets.
+
+The argument `arg_hash` follows the structure below:
+
+```ruby
+arg_hash = {
+  :tool => {
+    # Hash holding compiler tool properties — see ':tools' in the Project Configuration Reference
+  },
+  # Symbol of the operation being considered, e.g. :compile or :assemble
+  :operation => :<operation>,
+  :context => :<context>,
+  :module_name => "<name>",
+  :source => "<filepath>",
+  :object => "<filepath>",
+  :flags => [<flags>],
+  :defines => [<defines>]
+}
+```
+
 ## `Plugin` hook methods `pre_compile_execute(arg_hash)` and `post_compile_execute(arg_hash)`
 
 These methods are called before and after source file compilation. These are
@@ -272,6 +302,31 @@ arg_hash = {
 }
 ```
 
+## `Plugin` hook method `pre_link_register(arg_hash)`
+
+Test builds only (not release builds). Called once per test executable,
+*before* Ceedling's own delta-build dependency tracking registers that
+executable's build target and checks whether it needs relinking — unlike
+`pre_link_execute` below, this fires every time, regardless of staleness. A
+plugin swapping in its own linker tool for its own build context should do so
+here, for the same reason described under `pre_compile_register` above.
+Firing unconditionally also makes this a reliable place for a plugin to note
+that its own build context ran at all, independent of whether anything
+actually needed relinking.
+
+The argument `arg_hash` follows the structure below:
+
+```ruby
+arg_hash = {
+  :tool => {
+    # Hash holding linker tool properties — see ':tools' in the Project Configuration Reference
+  },
+  :context => :<context>,
+  :flags => [<flags>],
+  :executable => "<filepath>"
+}
+```
+
 ## `Plugin` hook methods `pre_link_execute(arg_hash)` and `post_link_execute(arg_hash)`
 
 These methods are called before and after linking an executable. These are
@@ -303,6 +358,28 @@ arg_hash = {
   :libraries => [<names>],
   # List of libraries paths, e.g. the ones passed to the (GNU) linker with -L
   :libpaths => [<paths>]
+}
+```
+
+## `Plugin` hook method `pre_test_fixture_register(arg_hash)`
+
+Called once per test executable, *before* Ceedling's own delta-build
+dependency tracking registers that test's fixture-run target and checks
+whether the executable needs (re)running — unlike `pre_test_fixture_execute`
+below, this fires every time, regardless of staleness. A plugin swapping in
+its own wrapper tool to run the test executable (as Valgrind does) should do
+so here, for the same reason described under `pre_compile_register` above:
+otherwise editing that wrapper tool's own configuration won't force a rerun.
+
+The argument `arg_hash` follows the structure below:
+
+```ruby
+arg_hash = {
+  :tool => {
+    # Hash holding execution tool properties — see ':tools' in the Project Configuration Reference
+  },
+  :context => :<context>,
+  :test_name => "<name>"
 }
 ```
 

--- a/docs/mkdocs/development/plugins/plugin-subclass.md
+++ b/docs/mkdocs/development/plugins/plugin-subclass.md
@@ -237,17 +237,23 @@ arg_hash = {
 }
 ```
 
+## Delta build hooks
+
+Ceedling skips work when nothing has changed. This is called a delta build.
+See [Delta Builds](../../getting-started/builds.md) for the full picture.
+
+Three hook methods run before Ceedling checks delta build state for a
+target. Each one always runs, for every target, whether or not that target
+turns out to need rebuilding. A plugin uses one of these hooks to swap in
+its own tool for its own build context. Doing the swap here, not only in
+the matching `pre_*_execute` hook below, makes sure Ceedling's delta build
+check sees the real tool. Otherwise a change to that tool's own settings
+will not force a rebuild.
+
 ## `Plugin` hook method `pre_compile_register(arg_hash)`
 
-Test builds only (not release builds). Called once per C file in a test build,
-*before* Ceedling's own delta-build dependency tracking registers that file's
-build target and checks whether it needs recompiling — unlike
-`pre_compile_execute` below, this fires every time, whether or not the object
-actually ends up stale. A plugin swapping in its own compiler tool for its own
-build context (as GCov and Bullseye do for coverage instrumentation) should do
-so here, not only in `pre_compile_execute`, so that swap is what Ceedling's
-own staleness check is based on — otherwise editing that tool's own
-configuration won't invalidate the plugin's cached build targets.
+Test builds only, not release builds. Runs once per C file in a test build.
+Runs before Ceedling registers the file as a delta build target.
 
 The argument `arg_hash` follows the structure below:
 
@@ -304,15 +310,16 @@ arg_hash = {
 
 ## `Plugin` hook method `pre_link_register(arg_hash)`
 
-Test builds only (not release builds). Called once per test executable,
-*before* Ceedling's own delta-build dependency tracking registers that
-executable's build target and checks whether it needs relinking — unlike
-`pre_link_execute` below, this fires every time, regardless of staleness. A
-plugin swapping in its own linker tool for its own build context should do so
-here, for the same reason described under `pre_compile_register` above.
-Firing unconditionally also makes this a reliable place for a plugin to note
-that its own build context ran at all, independent of whether anything
-actually needed relinking.
+Test builds only, not release builds. Runs once per test executable in a
+test build. Runs before Ceedling registers the executable as a delta build
+target. See [Delta build hooks](#delta-build-hooks) above for why this hook
+exists and when it runs.
+
+A plugin swapping in its own linker tool for its own build context should
+do so here, for the same reason described under `pre_compile_register`
+above. Because this hook always runs, it also gives a plugin a reliable
+place to note that its own build context ran at all, apart from whether
+anything actually needed relinking.
 
 The argument `arg_hash` follows the structure below:
 
@@ -363,13 +370,14 @@ arg_hash = {
 
 ## `Plugin` hook method `pre_test_fixture_register(arg_hash)`
 
-Called once per test executable, *before* Ceedling's own delta-build
-dependency tracking registers that test's fixture-run target and checks
-whether the executable needs (re)running — unlike `pre_test_fixture_execute`
-below, this fires every time, regardless of staleness. A plugin swapping in
-its own wrapper tool to run the test executable (as Valgrind does) should do
-so here, for the same reason described under `pre_compile_register` above:
-otherwise editing that wrapper tool's own configuration won't force a rerun.
+Runs once per test executable. Runs before Ceedling registers the test run
+as a delta build target. See [Delta build hooks](#delta-build-hooks) above
+for why this hook exists and when it runs.
+
+A plugin swapping in its own wrapper tool to run the test executable (as
+Valgrind does) should do so here, for the same reason described under
+`pre_compile_register` above. Otherwise a change to that wrapper tool's own
+settings will not force a rerun.
 
 The argument `arg_hash` follows the structure below:
 
@@ -379,7 +387,10 @@ arg_hash = {
     # Hash holding execution tool properties — see ':tools' in the Project Configuration Reference
   },
   :context => :<context>,
-  :test_name => "<name>"
+  :test_name => "<name>",
+  # The delta build target for this test run. A plugin can register its own
+  # additional data against this same target — see Delta Builds.
+  :target => "<filepath>"
 }
 ```
 
@@ -430,6 +441,11 @@ termination points, including early exit due to a build error.
 The argument `context` is the build context symbol (e.g. `:test`, `:gcov`) that
 was passed to `TestInvoker#setup_and_invoke`. This lets a plugin respond
 differently depending on which kind of build triggered the pipeline.
+
+Each context also gets its own separate delta build cache. A plugin that
+runs its own build under a distinct context symbol keeps that build's
+tracked state apart from ordinary test builds and from any other plugin's
+builds. See [Delta Builds](../../getting-started/builds.md) for more.
 
 The argument `timestamp_s` is a floating-point stopwatch value in seconds
 (from `SystemWrapper.time_stopwatch_s`). Compare the `pre_test_build` and

--- a/docs/mkdocs/development/plugins/rake-tasks.md
+++ b/docs/mkdocs/development/plugins/rake-tasks.md
@@ -28,6 +28,14 @@ Resulting, example command line:
  > Hello World!
 ```
 
+## Running a test build from a Rake task
+
+A Rake task can trigger a full test build itself by calling
+`@ceedling[:test_invoker].setup_and_invoke`. Pass a context symbol unique to
+your plugin. Ceedling uses this context to distinguish build pipelines. It
+also keeps your build's delta build state separate from ordinary test builds.
+See [Delta Builds](../../getting-started/builds.md) for how this tracking works.
+
 ## Example Rake plugin layout
 
 Project configuration file:

--- a/docs/mkdocs/plugins/bullseye/overview.md
+++ b/docs/mkdocs/plugins/bullseye/overview.md
@@ -1,13 +1,19 @@
 # Plugin Overview
 
-!!! note
-    When enabled, this plugin creates a new set of `bullseye:` tasks that
-    mirror Ceedling's existing `test:` tasks. A `bullseye:` task compiles and
-    links test executables with Bullseye instrumentation, executes them, and
-    accumulates coverage data in a shared coverage data file.
+When enabled, this plugin creates a new set of `bullseye:` tasks that
+mirror Ceedling's existing `test:` tasks. A `bullseye:` task compiles and
+links test executables with Bullseye instrumentation, executes them, and
+accumulates coverage data in a shared coverage data file.
 
-    `bullseye:` tasks entirely duplicate `test:` tasks and test builds since
-    coverage instrumentation has to be applied at compile time.
+!!! note
+    `bullseye:` tasks entirely duplicate `test:` tasks and builds since
+    coverage instrumentation must be applied at compile time.
+
+    A `bullseye:` task is a [delta build](../../getting-started/builds.md).
+    It maintains its own dependency cache. A source file will be rebuilt the 
+    first time you run a `bullseye:` build. See
+    [Understanding plugin build duplication](../index.md#understanding-plugin-build-duplication)
+    for why `test:` and `bullseye:` builds remain separate.
 
 ## Coverage Metric
 

--- a/docs/mkdocs/plugins/gcov/overview.md
+++ b/docs/mkdocs/plugins/gcov/overview.md
@@ -1,12 +1,17 @@
 # Plugin Overview
 
-!!! note
-    When enabled, this plugin creates a new set of `gcov:` tasks that mirror
-    Ceedling’s existing `test:` tasks. A `gcov:` task executes one or more tests
-    with coverage enabled for the source files exercised by those tests.
+When enabled, this plugin creates a new set of `gcov:` tasks that mirror
+Ceedling’s existing `test:` tasks. A `gcov:` task executes one or more tests
+with coverage enabled for the source files exercised by those tests.
 
-    `gcov:` tasks entirely duplicate `test:` tasks and test builds because of 
-    the needs of coverage instrumentation at compile time.
+The Gcov plugin creates a duplicate test build with `gcov:` 
+command line plugin tasks because of the needs of coverage instrumentation 
+at compile time. [This is intentional and needed](index.md#understanding-plugin-build-duplication).
+
+!!! note
+    A `gcov:` task is a [delta build](../getting-started/builds.md).
+    This plugin maintains its own dependency cache. A test executable will be 
+    rebuilt the first time you run a `gcov:` build.
 
 This plugin also provides an extensive set of options for generating various
 coverage reports for your project. The simplest is text-based coverage 

--- a/docs/mkdocs/plugins/index.md
+++ b/docs/mkdocs/plugins/index.md
@@ -52,6 +52,17 @@ important issues:
    plugin task namespacing scheme naturally accomplished this along with the
    needs of (1) and (2).
 
+!!! note
+    A duplicated build task is a [delta build](../getting-started/builds.md).
+    Ceedling skips work in a `gcov:`, `bullseye:`, or `valgrind:` build in the same
+    way it does in a standard `test:` build.
+
+Each of these plugins maintains its own separate delta build cache, apart from
+plain test builds and from each other. A file with no role specific to a
+given plugin will still be rebuilt the first you run that plugin's build.
+This happens because each build tracks state in its own dependency cache, 
+not because of the file itself.
+
 ---
 
 ## Directory

--- a/docs/mkdocs/plugins/valgrind.md
+++ b/docs/mkdocs/plugins/valgrind.md
@@ -4,9 +4,13 @@ Adds Ceedling tasks to run test executables under [Valgrind] memory error
 detection to help find memory leaks, invalid memory accesses, and
 use-after-free bugs in your C code.
 
+The Valgrind plugin creates a duplicate test build with `valgrind:` 
+command line plugin tasks. [This is intentional and needed](index.md#understanding-plugin-build-duplication).
+
 !!! note
-    The Valgrind plugin creates a duplicate test build with `valgrind:` 
-    command line plugin tasks. [This is intentional and needed](index.md#understanding-plugin-build-duplication).
+    A `valgrind:` task is a [delta build](../getting-started/builds.md).
+    This plugin maintains its own dependency cache. A test executable will be 
+    rebuilt the first time you run a `valgrind:` build.
 
 ---
 

--- a/lib/ceedling/config/configurator_builder.rb
+++ b/lib/ceedling/config/configurator_builder.rb
@@ -93,9 +93,14 @@ class ConfiguratorBuilder
   # Processes recursively
   def populate_with_defaults(config, defaults)
     defaults.each do |key, value|
-      # If config is missing the same key, copy in the default entry
+      # If config is missing the same key, copy in the default entry -- cloned
+      # regardless of type (Hash, Array, String, ...), not just Hash, since a
+      # default sourced from a frozen literal constant (several plugins' own
+      # :tools entries) must never end up shared, live, with config -- downstream
+      # code (e.g. FilePathUtils::standardize_in_place) mutates path strings in
+      # place and expects every value it touches to be its own independent copy.
       if config[key].nil?
-        config[key] = value.is_a?(Hash) ? value.deep_clone : value
+        config[key] = value.deep_clone
 
       # Continue recursively for hash entries
       elsif config[key].is_a?(Hash) && value.is_a?(Hash)

--- a/lib/ceedling/plugins/plugin_manager.rb
+++ b/lib/ceedling/plugins/plugin_manager.rb
@@ -109,8 +109,8 @@ class PluginManager
   # plugin swapping in its own tool for a build context (Gcov, Valgrind, Bullseye)
   # implements these so that swap is what dependency-tracker meta reflects, not the
   # plain tool it's about to replace.
-  def pre_compile_register(arg_hash); execute_plugins(:pre_compile_register, arg_hash); end
-  def pre_link_register(arg_hash); execute_plugins(:pre_link_register, arg_hash); end
+  def pre_test_compile_register(arg_hash); execute_plugins(:pre_test_compile_register, arg_hash); end
+  def pre_test_link_register(arg_hash); execute_plugins(:pre_test_link_register, arg_hash); end
   def pre_test_fixture_register(arg_hash); execute_plugins(:pre_test_fixture_register, arg_hash); end
 
   def pre_compile_execute(arg_hash); execute_plugins(:pre_compile_execute, arg_hash); end

--- a/lib/ceedling/plugins/plugin_manager.rb
+++ b/lib/ceedling/plugins/plugin_manager.rb
@@ -102,6 +102,17 @@ class PluginManager
   def pre_runner_generate(arg_hash); execute_plugins(:pre_runner_generate, arg_hash); end
   def post_runner_generate(arg_hash); execute_plugins(:post_runner_generate, arg_hash); end
 
+  # Fire ahead of and separate from pre_compile_execute/pre_link_execute/
+  # pre_test_fixture_execute below -- once per object/executable/test, unconditionally,
+  # before TestBuildExecutor registers dependency-tracker meta or checks staleness,
+  # rather than only when a real (re)compile/link/fixture-run actually happens. A
+  # plugin swapping in its own tool for a build context (Gcov, Valgrind, Bullseye)
+  # implements these so that swap is what dependency-tracker meta reflects, not the
+  # plain tool it's about to replace.
+  def pre_compile_register(arg_hash); execute_plugins(:pre_compile_register, arg_hash); end
+  def pre_link_register(arg_hash); execute_plugins(:pre_link_register, arg_hash); end
+  def pre_test_fixture_register(arg_hash); execute_plugins(:pre_test_fixture_register, arg_hash); end
+
   def pre_compile_execute(arg_hash); execute_plugins(:pre_compile_execute, arg_hash); end
   def post_compile_execute(arg_hash); execute_plugins(:post_compile_execute, arg_hash); end
 

--- a/lib/ceedling/test_invoker/test_build_executor.rb
+++ b/lib/ceedling/test_invoker/test_build_executor.rb
@@ -738,7 +738,7 @@ class TestBuildExecutor
 
   # Lets a plugin swap in its own compiler tool (and adjust flags/defines) for a
   # particular build context -- e.g. Gcov/Bullseye's instrumented compilers -- via
-  # pre_compile_register, *before* dependency-tracker meta is computed below, so a
+  # pre_test_compile_register, *before* dependency-tracker meta is computed below, so a
   # plugin's own tool config is what actually drives that target's staleness rather
   # than the plain test compiler it's about to be swapped out for. The resolved
   # values are also what the real compile itself uses (see the two call sites
@@ -748,15 +748,15 @@ class TestBuildExecutor
       context: context, operation: operation, tool: tool, flags: flags, defines: defines,
       module_name: module_name, source: source, object: object
     }
-    @plugin_manager.pre_compile_register( arg_hash )
+    @plugin_manager.pre_test_compile_register( arg_hash )
     return arg_hash[:tool], arg_hash[:flags], arg_hash[:defines]
   end
 
-  # As resolve_compile_tool above, for the link step's own tool swap (pre_link_register),
+  # As resolve_compile_tool above, for the link step's own tool swap (pre_test_link_register),
   # e.g. Gcov/Bullseye's instrumented linkers.
   def resolve_link_tool(context:, tool:, flags:, executable:)
     arg_hash = { context: context, tool: tool, flags: flags, executable: executable }
-    @plugin_manager.pre_link_register( arg_hash )
+    @plugin_manager.pre_test_link_register( arg_hash )
     return arg_hash[:tool], arg_hash[:flags]
   end
 

--- a/lib/ceedling/test_invoker/test_build_executor.rb
+++ b/lib/ceedling/test_invoker/test_build_executor.rb
@@ -506,14 +506,14 @@ class TestBuildExecutor
 
     @batchinator.exec(workload: :test, things: state.testables) do |_, testable|
       begin
-        fixture_tool = resolve_fixture_tool( context: state.context, tool: @configurator.tools_test_fixture, test_name: testable.name )
-
         # `paths[:results]` is only per-test-unique for a test mirrored into its own
         # subdirectory -- a test with no mirrored subdir shares that directory with
         # every other such test, so the marker's own filename (not just its directory)
         # must be test-specific too, matching clean_test_results' own `test + '.*'`
         # naming below.
         fixture_target = File.join( testable.paths[:results], "#{File.basename( testable.name )}.fixture_run" )
+
+        fixture_tool = resolve_fixture_tool( context: state.context, tool: @configurator.tools_test_fixture, test_name: testable.name, target: fixture_target )
 
         @dependinator.register( fixture_target, files: [testable.executable], meta: { tools: [fixture_tool] } )
 
@@ -762,8 +762,12 @@ class TestBuildExecutor
 
   # As resolve_compile_tool/resolve_link_tool above, for the test-fixture step's own
   # tool swap (pre_test_fixture_register), e.g. Valgrind wrapping the executable.
-  def resolve_fixture_tool(context:, tool:, test_name:)
-    arg_hash = { context: context, tool: tool, test_name: test_name }
+  # `target` (the fixture-run marker target -- see stage_execute) is included so a
+  # plugin can register additional meta of its own against the same target, merging
+  # with what this stage registers immediately after -- Dependinator#register is
+  # additive across multiple calls for one target regardless of call order.
+  def resolve_fixture_tool(context:, tool:, test_name:, target:)
+    arg_hash = { context: context, tool: tool, test_name: test_name, target: target }
     @plugin_manager.pre_test_fixture_register( arg_hash )
     return arg_hash[:tool]
   end

--- a/lib/ceedling/test_invoker/test_build_executor.rb
+++ b/lib/ceedling/test_invoker/test_build_executor.rb
@@ -417,10 +417,13 @@ class TestBuildExecutor
     @batchinator.exec(workload: :compile, things: state.testables) do |_, testable|
       remove_partials_source_objects( testable.objects, testable.partials.configs )
 
+      link_flags = testable.link_flags
+      tool, link_flags = resolve_link_tool( context: state.context, tool: @configurator.tools_test_linker, flags: link_flags, executable: testable.executable )
+
       @dependinator.register(
         testable.executable,
         files: testable.objects,
-        meta:  { flags: testable.link_flags, lib_args: lib_args, lib_paths: lib_paths, tools: [@configurator.tools_test_linker] }
+        meta:  { flags: link_flags, lib_args: lib_args, lib_paths: lib_paths, tools: [tool] }
       )
       stale = @dependinator.stale?( testable.executable )
 
@@ -430,9 +433,10 @@ class TestBuildExecutor
           build_path: testable.paths[:build],
           executable: testable.executable,
           objects:    testable.objects,
-          flags:      testable.link_flags,
+          flags:      link_flags,
           lib_args:   lib_args,
-          lib_paths:  lib_paths
+          lib_paths:  lib_paths,
+          tool:       tool
         }
 
         generate_executable( **arg_hash )
@@ -488,7 +492,6 @@ class TestBuildExecutor
   def stage_execute(state)
     skipped = 0
     force_rerun = @configurator.force_test_rerun || @configurator.unity_shuffle_tests
-    fixture_tool = @configurator.tools_test_fixture
 
     overridden = state.testables.values.count { |t| !t.executable_rebuilt }
 
@@ -503,6 +506,8 @@ class TestBuildExecutor
 
     @batchinator.exec(workload: :test, things: state.testables) do |_, testable|
       begin
+        fixture_tool = resolve_fixture_tool( context: state.context, tool: @configurator.tools_test_fixture, test_name: testable.name )
+
         # `paths[:results]` is only per-test-unique for a test mirrored into its own
         # subdirectory -- a test with no mirrored subdir shares that directory with
         # every other such test, so the marker's own filename (not just its directory)
@@ -536,7 +541,8 @@ class TestBuildExecutor
           test_filepath: testable.filepath,
           executable:    testable.executable,
           result:        testable.results_pass,
-          skipped:       !run_now
+          skipped:       !run_now,
+          tool:          fixture_tool
         }
 
         run_fixture( **arg_hash )
@@ -558,10 +564,10 @@ class TestBuildExecutor
   # Helper methods
   # -----------------------------------------------------------------------
 
-  def generate_executable(context:, build_path:, executable:, objects:, flags:, lib_args:, lib_paths:)
+  def generate_executable(context:, build_path:, executable:, objects:, flags:, lib_args:, lib_paths:, tool:)
     begin
       @generator.generate_executable_file(
-        @configurator.tools_test_linker,
+        tool,
         context,
         objects.map { |v| "\"#{v}\"" },
         flags,
@@ -608,9 +614,9 @@ class TestBuildExecutor
     @file_wrapper.rm_f( Dir.glob( File.join( path, test + '.*' ) ) )
   end
 
-  def run_fixture(context:, test_name:, test_filepath:, executable:, result:, skipped: false)
+  def run_fixture(context:, test_name:, test_filepath:, executable:, result:, tool:, skipped: false)
     @generator.generate_test_results(
-      tool:          @configurator.tools_test_fixture,
+      tool:          tool,
       context:       context,
       test_name:     test_name,
       test_filepath: test_filepath,
@@ -649,7 +655,11 @@ class TestBuildExecutor
 
     if !@configurator.extension_assembly.match?( source )
       flags = testable.compile_flags
-      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: defines, search_paths: search_paths, tool: @configurator.tools_test_compiler )
+      tool, flags, defines = resolve_compile_tool(
+        context: context, operation: OPERATION_COMPILE_SYM, tool: @configurator.tools_test_compiler,
+        flags: flags, defines: defines, module_name: test, source: source, object: object
+      )
+      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: defines, search_paths: search_paths, tool: tool )
 
       return log_compile_skip( test: test, source: source ) unless stale
 
@@ -661,7 +671,7 @@ class TestBuildExecutor
       @file_wrapper.mkdir( File.dirname( dependencies ) )
 
       arg_hash = {
-        tool:         @configurator.tools_test_compiler,
+        tool:         tool,
         module_name:  test,
         context:      context,
         source:       source,
@@ -677,7 +687,11 @@ class TestBuildExecutor
 
     elsif @configurator.test_build_use_assembly
       flags = testable.assembler_flags
-      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: defines, search_paths: search_paths, tool: @configurator.tools_test_assembler )
+      tool, flags, defines = resolve_compile_tool(
+        context: context, operation: OPERATION_ASSEMBLE_SYM, tool: @configurator.tools_test_assembler,
+        flags: flags, defines: defines, module_name: test, source: source, object: object
+      )
+      stale = register_and_check_object_staleness( object: object, source: source, dependencies: dependencies, flags: flags, defines: defines, search_paths: search_paths, tool: tool )
 
       return log_compile_skip( test: test, source: source ) unless stale
 
@@ -685,7 +699,7 @@ class TestBuildExecutor
       @file_wrapper.mkdir( File.dirname( dependencies ) )
 
       arg_hash = {
-        tool:         @configurator.tools_test_assembler,
+        tool:         tool,
         module_name:  test,
         context:      context,
         source:       source,
@@ -720,6 +734,38 @@ class TestBuildExecutor
     )
     @loginator.log( msg, Verbosity::OBNOXIOUS )
     false
+  end
+
+  # Lets a plugin swap in its own compiler tool (and adjust flags/defines) for a
+  # particular build context -- e.g. Gcov/Bullseye's instrumented compilers -- via
+  # pre_compile_register, *before* dependency-tracker meta is computed below, so a
+  # plugin's own tool config is what actually drives that target's staleness rather
+  # than the plain test compiler it's about to be swapped out for. The resolved
+  # values are also what the real compile itself uses (see the two call sites
+  # above), so the two can never disagree about which tool actually ran.
+  def resolve_compile_tool(context:, operation:, tool:, flags:, defines:, module_name:, source:, object:)
+    arg_hash = {
+      context: context, operation: operation, tool: tool, flags: flags, defines: defines,
+      module_name: module_name, source: source, object: object
+    }
+    @plugin_manager.pre_compile_register( arg_hash )
+    return arg_hash[:tool], arg_hash[:flags], arg_hash[:defines]
+  end
+
+  # As resolve_compile_tool above, for the link step's own tool swap (pre_link_register),
+  # e.g. Gcov/Bullseye's instrumented linkers.
+  def resolve_link_tool(context:, tool:, flags:, executable:)
+    arg_hash = { context: context, tool: tool, flags: flags, executable: executable }
+    @plugin_manager.pre_link_register( arg_hash )
+    return arg_hash[:tool], arg_hash[:flags]
+  end
+
+  # As resolve_compile_tool/resolve_link_tool above, for the test-fixture step's own
+  # tool swap (pre_test_fixture_register), e.g. Valgrind wrapping the executable.
+  def resolve_fixture_tool(context:, tool:, test_name:)
+    arg_hash = { context: context, tool: tool, test_name: test_name }
+    @plugin_manager.pre_test_fixture_register( arg_hash )
+    return arg_hash[:tool]
   end
 
   # Registers `object`'s antecedents (its source file, plus whatever headers

--- a/lib/ceedling/test_invoker/test_invoker.rb
+++ b/lib/ceedling/test_invoker/test_invoker.rb
@@ -40,7 +40,12 @@ class TestInvoker
     timestamp_s = SystemWrapper.time_stopwatch_s()
     @plugin_manager.pre_test_build( context, timestamp_s )
 
-    @dependinator.open
+    # `identifier: context` isolates this run's own cache file (see Dependinator#open) --
+    # a plugin building its own variant of the test pipeline under a distinct context
+    # (:gcov, :valgrind, ...) gets its own cache automatically, never sharing one with
+    # ordinary :test runs (or another plugin's context) and never exposed to a full
+    # :test run's own pruning flush evicting its entries.
+    @dependinator.open( identifier: context )
 
     @state = PipelineState.new(
       tests:            tests,

--- a/plugins/bullseye/lib/bullseye.rb
+++ b/plugins/bullseye/lib/bullseye.rb
@@ -65,7 +65,7 @@ class Bullseye < Plugin
   # compiler this replaces. Instrument every non-assembly file uniformly; report-time
   # exclusions (covselect) filter framework/test noise rather than skipping
   # instrumentation at compile time.
-  def pre_compile_register(arg_hash)
+  def pre_test_compile_register(arg_hash)
     return if (arg_hash[:context] != BULLSEYE_SYM)
     return if EXTENSION_ASSEMBLY.match?(arg_hash[:source])
 
@@ -84,12 +84,12 @@ class Bullseye < Plugin
     )
   end
 
-  # As pre_compile_register above, for the covlink-wrapped linker. Fires every run
+  # As pre_test_compile_register above, for the covlink-wrapped linker. Fires every run
   # regardless of whether this executable actually needs relinking, which is also what
   # lets post_build's summary print correctly even on a fully-cached bullseye:all
   # re-run -- @cli_bullseye_task marks that a bullseye: task ran at all, not that a
   # link did.
-  def pre_link_register(arg_hash)
+  def pre_test_link_register(arg_hash)
     return if (arg_hash[:context] != BULLSEYE_SYM)
 
     @cli_bullseye_task = true

--- a/plugins/bullseye/lib/bullseye.rb
+++ b/plugins/bullseye/lib/bullseye.rb
@@ -200,23 +200,56 @@ class Bullseye < Plugin
         return
       end
 
+      dependinator = @ceedling[:dependinator]
+      skipped = 0
+
       untested_sources.each do |filepath|
-        filename = File.basename(filepath)
+        filename     = File.basename(filepath)
+        object       = @ceedling[:file_path_utils].form_test_object_filepath( filepath, context: BULLSEYE_SYM )
+        dependencies = @ceedling[:file_path_utils].form_test_dependencies_filepath( filepath, context: BULLSEYE_SYM )
+        search_paths = @configurator.collection_paths_include
+        flags        = @ceedling[:flaginator].flag_down( context: BULLSEYE_SYM, operation: OPERATION_COMPILE_SYM )
+        defines      = @ceedling[:defineinator].defines( subkey: BULLSEYE_SYM )
+
+        # Same register/stale?/mark_fresh idiom TestBuildExecutor's own object
+        # compilation uses -- this compile happens entirely outside that pipeline
+        # (untested sources have no test of their own to drive them through it), so
+        # nothing else registers it.
+        dependinator.register(
+          object, files: [filepath],
+          meta: { flags: flags, defines: defines, search_paths: search_paths, tools: [TOOLS_BULLSEYE_COMPILER] }
+        )
+        dependinator.register_gcc_deps_file( dependencies ) if @file_wrapper.exist?( dependencies )
+
+        unless dependinator.stale?( object )
+          msg = @reportinator.generate_module_progress(
+            operation:   'Skipping untested-source compilation for',
+            module_name: filename.ext(),
+            filename:    filename
+          )
+          @loginator.log( msg, Verbosity::OBNOXIOUS )
+          skipped += 1
+          next
+        end
+
         begin
           @ceedling[:generator].generate_object_file_c(
             tool:         TOOLS_BULLSEYE_COMPILER,
             module_name:  filename.ext(),
             context:      BULLSEYE_SYM,
             source:       filepath,
-            object:       @ceedling[:file_path_utils].form_test_object_filepath( filepath, context: BULLSEYE_SYM ),
-            search_paths: @configurator.collection_paths_include,
-            flags:        @ceedling[:flaginator].flag_down( context: BULLSEYE_SYM, operation: OPERATION_COMPILE_SYM ),
+            object:       object,
+            search_paths: search_paths,
+            flags:        flags,
             # 'CODE_COVERAGE' is not added here — pre_compile_execute appends it for every
             # BULLSEYE_SYM-context compile, including this one (generate_object_file_c fires
             # that hook itself); adding it here too would just duplicate the define.
-            defines:      @ceedling[:defineinator].defines( subkey: BULLSEYE_SYM ),
-            dependencies: @ceedling[:file_path_utils].form_test_dependencies_filepath( filepath, context: BULLSEYE_SYM )
+            defines:      defines,
+            dependencies: dependencies
           )
+
+          dependinator.register_gcc_deps_file( dependencies ) if @file_wrapper.exist?( dependencies )
+          dependinator.mark_fresh( object )
         rescue ShellException => ex
           if guidance
             notice = "Compiling untested '#{filename}' with coverage failed.\n" \
@@ -231,6 +264,16 @@ class Bullseye < Plugin
           raise ex
         end
       end
+
+      # TestInvoker's own flush (test_invoker.rb) already ran and persisted by the
+      # time this method runs (see bullseye.rake -- this is always called after
+      # setup_and_invoke returns) -- this flush persists the additional entries
+      # registered above on top of that, safely: flush doesn't clear in-memory
+      # state, so this just writes out the superset to the same already-open cache.
+      dependinator.flush( refresh_dependencies: false )
+
+      msg = @reportinator.generate_skip_summary( task: "compilation", count: skipped, noun: "untested sources" )
+      @loginator.log( msg ) unless msg.nil?
     end
   end
 

--- a/plugins/bullseye/lib/bullseye.rb
+++ b/plugins/bullseye/lib/bullseye.rb
@@ -59,25 +59,37 @@ class Bullseye < Plugin
     @ceedling[:tool_validator].validate( tool: TOOLS_BULLSEYE_LINKER, boom: true )
   end
 
-  def pre_compile_execute(arg_hash)
+  # Swaps in the covc-wrapped compiler (and the coverage define) ahead of
+  # TestBuildExecutor's own dependency-tracker meta capture, so a change to either is
+  # what actually invalidates a bullseye-context object's cache -- not the plain test
+  # compiler this replaces. Instrument every non-assembly file uniformly; report-time
+  # exclusions (covselect) filter framework/test noise rather than skipping
+  # instrumentation at compile time.
+  def pre_compile_register(arg_hash)
     return if (arg_hash[:context] != BULLSEYE_SYM)
-
-    source = arg_hash[:source]
-
-    # Instrument every non-assembly file uniformly; report-time exclusions (covselect)
-    # filter framework/test noise rather than skipping instrumentation at compile time
-    return if EXTENSION_ASSEMBLY.match?(source)
+    return if EXTENSION_ASSEMBLY.match?(arg_hash[:source])
 
     arg_hash[:tool] = TOOLS_BULLSEYE_COMPILER
     arg_hash[:defines] += ['CODE_COVERAGE']
+  end
+
+  def pre_compile_execute(arg_hash)
+    return if (arg_hash[:context] != BULLSEYE_SYM)
+    return if EXTENSION_ASSEMBLY.match?(arg_hash[:source])
+
     arg_hash[:msg] = @reportinator.generate_module_progress(
       operation: "Compiling with coverage",
       module_name: arg_hash[:module_name],
-      filename: File.basename(source)
+      filename: File.basename(arg_hash[:source])
     )
   end
 
-  def pre_link_execute(arg_hash)
+  # As pre_compile_register above, for the covlink-wrapped linker. Fires every run
+  # regardless of whether this executable actually needs relinking, which is also what
+  # lets post_build's summary print correctly even on a fully-cached bullseye:all
+  # re-run -- @cli_bullseye_task marks that a bullseye: task ran at all, not that a
+  # link did.
+  def pre_link_register(arg_hash)
     return if (arg_hash[:context] != BULLSEYE_SYM)
 
     @cli_bullseye_task = true

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -59,6 +59,16 @@ class Gcov < Plugin
     @file_wrapper = @ceedling[:file_wrapper]
     @tool_executor = @ceedling[:tool_executor]
     @plugin_manager = @ceedling[:plugin_manager]
+    @dependinator = @ceedling[:dependinator]
+
+    # Cloned from the original, unflattened project config (project_config_hash
+    # above has none of this -- flattening leaves no nested :gcov key) so the whole
+    # section can ride along as dependency-tracker meta alongside the specific
+    # :tools/:flags tracking elsewhere in this file, the same belt-and-suspenders
+    # reasoning :cmock's own whole-section meta capture already uses -- a future
+    # :gcov config key that affects a tracked target's real behavior is covered
+    # automatically, without needing its own dedicated wiring here first.
+    @gcov_config = @ceedling[:setupinator].config_hash[:gcov].clone
 
     @mutex = Mutex.new()
 
@@ -132,22 +142,61 @@ class Gcov < Plugin
         return
       end
 
+      skipped = 0
+
       untested_sources.each do |filepath|
-        filename = File.basename(filepath)
+        filename     = File.basename(filepath)
+        object       = @file_path_utils.form_test_object_filepath( filepath, context:GCOV_SYM )
+        dependencies = @file_path_utils.form_test_dependencies_filepath( filepath, context:GCOV_SYM )
+        search_paths = @configurator.collection_paths_include
+        defines      = @defineinator.defines( subkey:GCOV_SYM )
+
+        # Same MC/DC condition pre_compile_register applies for ordinary test-context
+        # compiles -- this path calls Generator directly, bypassing TestBuildExecutor
+        # (and therefore that hook) entirely, so it has to apply the flag itself.
+        flags = @flaginator.flag_down( context:GCOV_SYM, operation:OPERATION_COMPILE_SYM )
+        flags += ['-fcondition-coverage'] if @project_config[:gcov_mcdc]
+
+        # Same register/stale?/mark_fresh idiom TestBuildExecutor's own object
+        # compilation uses -- this compile happens entirely outside that pipeline
+        # (untested sources have no test of their own to drive them through it), so
+        # nothing else registers it. :gcov meta is the whole section, same
+        # belt-and-suspenders reasoning as pre_compile_register above.
+        @dependinator.register(
+          object, files: [filepath],
+          meta: { flags: flags, defines: defines, search_paths: search_paths, tools: [TOOLS_GCOV_COMPILER], gcov: @gcov_config }
+        )
+        @dependinator.register_gcc_deps_file( dependencies ) if @file_wrapper.exist?( dependencies )
+
+        unless @dependinator.stale?( object )
+          msg = @reportinator.generate_module_progress(
+            operation:   'Skipping untested-source compilation for',
+            module_name: filename.ext(),
+            filename:    filename
+          )
+          @loginator.log( msg, Verbosity::OBNOXIOUS )
+          skipped += 1
+          next
+        end
+
         begin
           @generator.generate_object_file_c(
             tool:         TOOLS_GCOV_COMPILER,
             module_name:  filename.ext(),
             context:      GCOV_SYM,
             source:       filepath,
-            object:       @file_path_utils.form_test_object_filepath( filepath, context:GCOV_SYM ),
-            search_paths: @configurator.collection_paths_include,
-            flags:        @flaginator.flag_down( context:GCOV_SYM, operation:OPERATION_COMPILE_SYM ),
-            defines:      @defineinator.defines( subkey:GCOV_SYM ),
-            dependencies: @file_path_utils.form_test_dependencies_filepath( filepath, context:GCOV_SYM )
+            object:       object,
+            search_paths: search_paths,
+            flags:        flags,
+            defines:      defines,
+            dependencies: dependencies
           )
+
+          @dependinator.register_gcc_deps_file( dependencies ) if @file_wrapper.exist?( dependencies )
+          @dependinator.mark_fresh( object )
         rescue ShellException => ex
-          # Log actionable guidance then re-raise immediately (omitted when `guidance` is false)
+          # Log actionable guidance then re-raise immediately (omitted when `guidance` is false) --
+          # left un-marked-fresh, so the next run retries this same source.
           if guidance
             notice = "Compiling untested '#{filename}' with coverage failed.\n" \
                      "NOTE: Compilation of an untested source for coverage (:gcov ↳ :untested_sources ➡️ :compile) " \
@@ -162,6 +211,16 @@ class Gcov < Plugin
           raise ex
         end
       end
+
+      # TestInvoker's own flush (test_invoker.rb) already ran and persisted by the
+      # time this method runs (see gcov.rake -- this is always called after
+      # setup_and_invoke returns) -- this flush persists the additional entries
+      # registered above on top of that, safely: flush doesn't clear in-memory
+      # state, so this just writes out the superset to the same already-open cache.
+      @dependinator.flush( refresh_dependencies: false )
+
+      msg = @reportinator.generate_skip_summary( task: "compilation", count: skipped, noun: "untested sources" )
+      @loginator.log( msg ) unless msg.nil?
     end
   end
 
@@ -176,6 +235,13 @@ class Gcov < Plugin
 
     arg_hash[:tool] = TOOLS_GCOV_COMPILER
     arg_hash[:flags] += ['-fcondition-coverage'] if @project_config[:gcov_mcdc]
+
+    # The whole :gcov config as meta, redundant alongside the :mcdc-derived flag
+    # above -- belt-and-suspenders against a future :gcov key affecting a compile
+    # this file doesn't yet know to thread through by hand, the same reasoning
+    # :cmock's own whole-section meta capture already uses. Additive: merges with
+    # TestBuildExecutor's own register call for this same target moments later.
+    @dependinator.register( arg_hash[:object], meta: { gcov: @gcov_config } )
   end
 
   def pre_compile_execute(arg_hash)
@@ -199,6 +265,10 @@ class Gcov < Plugin
     @cli_gcov_task = true
     arg_hash[:tool] = TOOLS_GCOV_LINKER
     arg_hash[:flags] += ['-fcondition-coverage'] if @project_config[:gcov_mcdc]
+
+    # See pre_compile_register above -- same belt-and-suspenders reasoning, same
+    # additive merge with TestBuildExecutor's own register call for this target.
+    @dependinator.register( arg_hash[:executable], meta: { gcov: @gcov_config } )
   end
 
   def pre_test_fixture_register(arg_hash)

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -151,7 +151,7 @@ class Gcov < Plugin
         search_paths = @configurator.collection_paths_include
         defines      = @defineinator.defines( subkey:GCOV_SYM )
 
-        # Same MC/DC condition pre_compile_register applies for ordinary test-context
+        # Same MC/DC condition pre_test_compile_register applies for ordinary test-context
         # compiles -- this path calls Generator directly, bypassing TestBuildExecutor
         # (and therefore that hook) entirely, so it has to apply the flag itself.
         flags = @flaginator.flag_down( context:GCOV_SYM, operation:OPERATION_COMPILE_SYM )
@@ -161,7 +161,7 @@ class Gcov < Plugin
         # compilation uses -- this compile happens entirely outside that pipeline
         # (untested sources have no test of their own to drive them through it), so
         # nothing else registers it. :gcov meta is the whole section, same
-        # belt-and-suspenders reasoning as pre_compile_register above.
+        # belt-and-suspenders reasoning as pre_test_compile_register above.
         @dependinator.register(
           object, files: [filepath],
           meta: { flags: flags, defines: defines, search_paths: search_paths, tools: [TOOLS_GCOV_COMPILER], gcov: @gcov_config }
@@ -229,7 +229,7 @@ class Gcov < Plugin
   # is what actually invalidates a gcov-context object's cache -- not the plain test
   # compiler this replaces. Compile all non-assembly files with coverage; gcovr
   # --exclude filters non-production files from reports.
-  def pre_compile_register(arg_hash)
+  def pre_test_compile_register(arg_hash)
     return unless arg_hash[:context] == GCOV_SYM
     return if EXTENSION_ASSEMBLY.match?(arg_hash[:source])
 
@@ -255,18 +255,18 @@ class Gcov < Plugin
     )
   end
 
-  # As pre_compile_register above, for the coverage-instrumented linker. Fires every
+  # As pre_test_compile_register above, for the coverage-instrumented linker. Fires every
   # run regardless of whether this executable actually needs relinking, which is also
   # what lets post_build's summary print correctly even on a fully-cached gcov:all
   # re-run -- @cli_gcov_task marks that a gcov: task ran at all, not that a link did.
-  def pre_link_register(arg_hash)
+  def pre_test_link_register(arg_hash)
     return unless arg_hash[:context] == GCOV_SYM
 
     @cli_gcov_task = true
     arg_hash[:tool] = TOOLS_GCOV_LINKER
     arg_hash[:flags] += ['-fcondition-coverage'] if @project_config[:gcov_mcdc]
 
-    # See pre_compile_register above -- same belt-and-suspenders reasoning, same
+    # See pre_test_compile_register above -- same belt-and-suspenders reasoning, same
     # additive merge with TestBuildExecutor's own register call for this target.
     @dependinator.register( arg_hash[:executable], meta: { gcov: @gcov_config } )
   end

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -165,35 +165,44 @@ class Gcov < Plugin
     end
   end
 
+  # Swaps in the coverage-instrumented compiler (and MC/DC flag, if configured) ahead
+  # of TestBuildExecutor's own dependency-tracker meta capture, so a change to either
+  # is what actually invalidates a gcov-context object's cache -- not the plain test
+  # compiler this replaces. Compile all non-assembly files with coverage; gcovr
+  # --exclude filters non-production files from reports.
+  def pre_compile_register(arg_hash)
+    return unless arg_hash[:context] == GCOV_SYM
+    return if EXTENSION_ASSEMBLY.match?(arg_hash[:source])
+
+    arg_hash[:tool] = TOOLS_GCOV_COMPILER
+    arg_hash[:flags] += ['-fcondition-coverage'] if @project_config[:gcov_mcdc]
+  end
+
   def pre_compile_execute(arg_hash)
-    if arg_hash[:context] == GCOV_SYM
-      source = arg_hash[:source]
+    return unless arg_hash[:context] == GCOV_SYM
+    return if EXTENSION_ASSEMBLY.match?(arg_hash[:source])
 
-      # Compile all non-assembly files with coverage; gcovr --exclude filters non-production files from reports
-      if !EXTENSION_ASSEMBLY.match?(source)
-        arg_hash[:tool] = TOOLS_GCOV_COMPILER
-        arg_hash[:msg] = @reportinator.generate_module_progress(
-          operation: "Compiling with coverage",
-          module_name: arg_hash[:module_name],
-          filename: File.basename(source)
-        )
-        arg_hash[:flags] += ['-fcondition-coverage'] if @project_config[:gcov_mcdc]
-      end
-    end
+    arg_hash[:msg] = @reportinator.generate_module_progress(
+      operation: "Compiling with coverage",
+      module_name: arg_hash[:module_name],
+      filename: File.basename(arg_hash[:source])
+    )
   end
 
-  def pre_link_execute(arg_hash)
-    if arg_hash[:context] == GCOV_SYM
-      @cli_gcov_task = true
-      arg_hash[:tool] = TOOLS_GCOV_LINKER
-      arg_hash[:flags] += ['-fcondition-coverage'] if @project_config[:gcov_mcdc]
-    end
+  # As pre_compile_register above, for the coverage-instrumented linker. Fires every
+  # run regardless of whether this executable actually needs relinking, which is also
+  # what lets post_build's summary print correctly even on a fully-cached gcov:all
+  # re-run -- @cli_gcov_task marks that a gcov: task ran at all, not that a link did.
+  def pre_link_register(arg_hash)
+    return unless arg_hash[:context] == GCOV_SYM
+
+    @cli_gcov_task = true
+    arg_hash[:tool] = TOOLS_GCOV_LINKER
+    arg_hash[:flags] += ['-fcondition-coverage'] if @project_config[:gcov_mcdc]
   end
 
-  def pre_test_fixture_execute(arg_hash)
-    if arg_hash[:context] == GCOV_SYM
-      arg_hash[:tool] = TOOLS_GCOV_FIXTURE
-    end
+  def pre_test_fixture_register(arg_hash)
+    arg_hash[:tool] = TOOLS_GCOV_FIXTURE if arg_hash[:context] == GCOV_SYM
   end
 
   # `Plugin` build step hook

--- a/plugins/valgrind/lib/valgrind.rb
+++ b/plugins/valgrind/lib/valgrind.rb
@@ -36,7 +36,11 @@ class Valgrind < Plugin
     @plugin_reportinator = @ceedling[:plugin_reportinator]
   end
 
-  def pre_test_fixture_execute(arg_hash)
+  # Swaps in the per-test Valgrind-wrapped fixture tool ahead of TestBuildExecutor's
+  # own dependency-tracker meta capture, so a change to :valgrind ↳ :arguments (or
+  # :tools ↳ :valgrind itself) is what actually forces a rerun -- not the plain test
+  # fixture tool this replaces.
+  def pre_test_fixture_register(arg_hash)
     return unless arg_hash[:context] == VALGRIND_SYM
 
     @mutex.synchronize do
@@ -57,6 +61,10 @@ class Valgrind < Plugin
       :optional   => TOOLS_VALGRIND[:optional],
       :arguments  => ["--log-file=\"#{log_path}\""] + valgrind_args + ["${1}"],
     }
+  end
+
+  def pre_test_fixture_execute(arg_hash)
+    return unless arg_hash[:context] == VALGRIND_SYM
 
     msg = "Running #{File.basename(arg_hash[:executable])} under Valgrind"
     arg_hash[:msg] = @reportinator.generate_progress( msg )

--- a/plugins/valgrind/lib/valgrind.rb
+++ b/plugins/valgrind/lib/valgrind.rb
@@ -34,6 +34,15 @@ class Valgrind < Plugin
     @rake_invocation_tracker   = @ceedling[:rake_invocation_tracker]
     @plugin_manager      = @ceedling[:plugin_manager]
     @plugin_reportinator = @ceedling[:plugin_reportinator]
+    @dependinator        = @ceedling[:dependinator]
+
+    # Cloned from the original, unflattened project config (project_config_hash
+    # has none of this -- flattening leaves no nested :valgrind key) so the whole
+    # section can ride along as dependency-tracker meta alongside the specific
+    # :arguments/:tools tracking already baked into the tool hash below -- the
+    # same belt-and-suspenders reasoning :cmock's own whole-section meta capture
+    # already uses.
+    @valgrind_config = @ceedling[:setupinator].config_hash[:valgrind].clone
   end
 
   # Swaps in the per-test Valgrind-wrapped fixture tool ahead of TestBuildExecutor's
@@ -61,6 +70,13 @@ class Valgrind < Plugin
       :optional   => TOOLS_VALGRIND[:optional],
       :arguments  => ["--log-file=\"#{log_path}\""] + valgrind_args + ["${1}"],
     }
+
+    # The whole :valgrind config as meta, redundant alongside :arguments already
+    # being part of the tool hash above -- belt-and-suspenders against a future
+    # :valgrind key affecting a run this file doesn't yet know to thread through by
+    # hand. Additive: merges with TestBuildExecutor's own register call for this
+    # same target moments later.
+    @dependinator.register( arg_hash[:target], meta: { valgrind: @valgrind_config } )
   end
 
   def pre_test_fixture_execute(arg_hash)

--- a/spec/system/plugin_delta_builds_spec.rb
+++ b/spec/system/plugin_delta_builds_spec.rb
@@ -75,34 +75,10 @@ ceedling_system_tests do
         Dir.chdir @proj_name do
           @c.ceedling_build_exec("gcov:all")
 
-          # :gcov_compiler exists only via the plugin's own defaults, never in a
-          # project's own project.yml -- merging just an inert key into it here
-          # (as the equivalent :tools ↳ :test_compiler scenario in
-          # delta_builds_spec.rb does) triggers an unrelated, pre-existing
-          # frozen-string crash when Ceedling merges a project-supplied partial
-          # override on top of a plugin-default-only tool entry's frozen
-          # :arguments (present identically on next_version before this branch,
-          # confirmed via a clean worktree at that commit). Supplying the whole
-          # tool -- matching plugins/gcov/config/defaults_gcov.rb's
-          # DEFAULT_GCOV_COMPILER_TOOL, plus the inert key -- sidesteps that
-          # unrelated bug rather than working around it here; the actual
-          # dependency-tracker-meta assertion this test cares about is unaffected
-          # either way.
-          @c.merge_project_yml_for_test({
-            :tools => {
-              :gcov_compiler => {
-                :executable => 'gcc',
-                :name       => 'default_gcov_compiler',
-                :optional   => false,
-                :arguments  => [
-                  '-g', '-fprofile-arcs', '-ftest-coverage',
-                  '-I"${5}"', '-D"${6}"', '-DGCOV_COMPILER', '-DCODE_COVERAGE',
-                  '-c "${1}"', '-o "${2}"', '-MMD', '-MF "${4}"'
-                ],
-                :ceedling_delta_probe => true
-              }
-            }
-          })
+          # An inert key Ceedling itself never reads -- isolates the assertion to
+          # the dependency tracker's own meta-hash comparison, not any real
+          # behavior change a different flag or executable might otherwise cause.
+          @c.merge_project_yml_for_test({ :tools => { :gcov_compiler => { :ceedling_delta_probe => true } } })
 
           rebuild = @c.ceedling_build_exec("gcov:all")
           expect(rebuild).to_not match(/EXCEPTION/)

--- a/spec/system/plugin_delta_builds_spec.rb
+++ b/spec/system/plugin_delta_builds_spec.rb
@@ -99,6 +99,28 @@ ceedling_system_tests do
         end
       end
     end
+
+    it "skips recompiling an untested source left unchanged, but recompiles it once its content changes" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          add_gcov_option("untested_sources", ":compile")
+          # Untested — no test references this source file.
+          FileUtils.cp test_asset_path("uncovered_example_file.c"), 'src/'
+
+          @c.ceedling_build_exec("gcov:all")
+
+          rebuild = @c.ceedling_build_exec("gcov:all")
+          expect(rebuild).to_not match(/EXCEPTION/)
+          expect(rebuild).to_not match(/Compiling.*uncovered_example_file/)
+
+          probe = File.read('src/uncovered_example_file.c')
+          File.write('src/uncovered_example_file.c', "#{probe}\n// probe\n")
+
+          recompile = @c.ceedling_build_exec("gcov:all")
+          expect(recompile).to match(/Compiling.*uncovered_example_file/)
+        end
+      end
+    end
   end
 
   describe "Valgrind context: cache isolation and tool-change staleness" do

--- a/spec/system/plugin_delta_builds_spec.rb
+++ b/spec/system/plugin_delta_builds_spec.rb
@@ -1,0 +1,176 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+require_relative 'support/gcov_helpers'
+require_relative 'support/valgrind_helpers'
+
+# Gcov/Valgrind/Bullseye all run their own build through the exact same core test
+# pipeline as ordinary `test:` builds, tagged with their own `context:` symbol --
+# see spec/system/delta_builds_spec.rb for the equivalent ordinary-:test coverage
+# this file extends to those plugin contexts specifically. Two gaps closed here:
+#
+# 1. Each pipeline context now gets its own isolated dependency cache file, so a
+#    `test:all` run's own pruning flush no longer evicts a plugin context's cache.
+# 2. A plugin's own swapped-in tool (Gcov's instrumented compiler, Valgrind's
+#    executable wrapper) is resolved before dependency-tracker meta is captured,
+#    so editing that plugin's own tool config actually invalidates its own cache.
+ceedling_system_tests do
+  include GcovHelpers
+
+  before :all do
+    determine_reports_to_test
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  before { @proj_name = unique_proj_name("plugin_delta") }
+
+  def deploy_gcov_project!
+    @c.ceedling_appcmd_exec("new --local #{@proj_name}")
+
+    Dir.chdir @proj_name do
+      prep_project_yml_for_coverage
+      FileUtils.cp test_asset_path("example_file.h"), 'src/'
+      FileUtils.cp test_asset_path("example_file.c"), 'src/'
+      FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+    end
+  end
+
+  describe "Gcov context: cache isolation and tool-change staleness" do
+    before do
+      @c.with_context { deploy_gcov_project! }
+    end
+
+    it "does not evict the gcov context's cache when an ordinary test:all run happens in between" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          baseline = @c.ceedling_build_exec("gcov:all")
+          expect(baseline).to_not match(/EXCEPTION/)
+
+          # An ordinary test:all run, sharing nothing on purpose with the gcov
+          # context's own build tree -- before Gap 1, its refresh_dependencies
+          # prune silently evicted gcov's cache entries anyway, since they lived
+          # in the same shared cache file.
+          @c.ceedling_build_exec("test:all")
+
+          rebuild = @c.ceedling_build_exec("gcov:all")
+          expect(rebuild).to_not match(/EXCEPTION/)
+          expect(rebuild).to_not match(/^Compiling /)
+          expect(rebuild).to_not match(/^Linking /)
+        end
+      end
+    end
+
+    it "recompiles and relinks the gcov context when :tools ↳ :gcov_compiler changes, with no source edits" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          @c.ceedling_build_exec("gcov:all")
+
+          # :gcov_compiler exists only via the plugin's own defaults, never in a
+          # project's own project.yml -- merging just an inert key into it here
+          # (as the equivalent :tools ↳ :test_compiler scenario in
+          # delta_builds_spec.rb does) triggers an unrelated, pre-existing
+          # frozen-string crash when Ceedling merges a project-supplied partial
+          # override on top of a plugin-default-only tool entry's frozen
+          # :arguments (present identically on next_version before this branch,
+          # confirmed via a clean worktree at that commit). Supplying the whole
+          # tool -- matching plugins/gcov/config/defaults_gcov.rb's
+          # DEFAULT_GCOV_COMPILER_TOOL, plus the inert key -- sidesteps that
+          # unrelated bug rather than working around it here; the actual
+          # dependency-tracker-meta assertion this test cares about is unaffected
+          # either way.
+          @c.merge_project_yml_for_test({
+            :tools => {
+              :gcov_compiler => {
+                :executable => 'gcc',
+                :name       => 'default_gcov_compiler',
+                :optional   => false,
+                :arguments  => [
+                  '-g', '-fprofile-arcs', '-ftest-coverage',
+                  '-I"${5}"', '-D"${6}"', '-DGCOV_COMPILER', '-DCODE_COVERAGE',
+                  '-c "${1}"', '-o "${2}"', '-MMD', '-MF "${4}"'
+                ],
+                :ceedling_delta_probe => true
+              }
+            }
+          })
+
+          rebuild = @c.ceedling_build_exec("gcov:all")
+          expect(rebuild).to_not match(/EXCEPTION/)
+          expect(rebuild).to match(/^Compiling /)
+        end
+      end
+    end
+
+    it "prints the coverage summary on a fully-cached gcov:all re-run" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          @c.ceedling_build_exec("gcov:all")
+
+          rebuild = @c.ceedling_build_exec("gcov:all")
+          expect(rebuild).to_not match(/^Compiling /)
+          expect(rebuild).to_not match(/^Linking /)
+          expect(rebuild).to match(/GCOV: CODE COVERAGE SUMMARY/i).or match(/Coverage Summary/i)
+        end
+      end
+    end
+  end
+
+  describe "Valgrind context: cache isolation and tool-change staleness" do
+    include_context "requires valgrind"
+
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new --local #{@proj_name}")
+
+        Dir.chdir @proj_name do
+          FileUtils.cp feature_asset_path("project.yml"), "project.yml"
+          @c.uncomment_project_yml_option_for_test("- valgrind")
+          FileUtils.cp test_asset_path("example_file.h"), 'src/'
+          FileUtils.cp test_asset_path("example_file.c"), 'src/'
+          FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+        end
+      end
+    end
+
+    it "does not evict the valgrind context's cache when an ordinary test:all run happens in between" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          @c.ceedling_build_exec("valgrind:all")
+          @c.ceedling_build_exec("test:all")
+
+          rebuild = @c.ceedling_build_exec("valgrind:all")
+          expect(rebuild).to_not match(/EXCEPTION/)
+          expect(rebuild).to_not match(/^Compiling /)
+          expect(rebuild).to_not match(/^Linking /)
+          expect(rebuild).to_not match(/^Running /)
+        end
+      end
+    end
+
+    it "reruns the valgrind context's fixture when :valgrind ↳ :arguments changes, with nothing else changed" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          @c.ceedling_build_exec("valgrind:all")
+
+          @c.merge_project_yml_for_test({ :valgrind => { :arguments => ["--leak-check=full", "--show-leak-kinds=all", "--track-origins=yes", "--errors-for-leak-kinds=all", "--num-callers=40"] } })
+
+          rebuild = @c.ceedling_build_exec("valgrind:all")
+          expect(rebuild).to_not match(/EXCEPTION/)
+          expect(rebuild).to_not match(/^Compiling /)
+          expect(rebuild).to_not match(/^Linking /)
+          expect(rebuild).to match(/^Running /)
+        end
+      end
+    end
+  end
+end

--- a/spec/units/configurator_builder_spec.rb
+++ b/spec/units/configurator_builder_spec.rb
@@ -11,8 +11,54 @@
 require 'spec_helper'
 require 'ceedling/config/configurator_builder'
 require 'ceedling/filename_extension'
+require 'ceedling/system_utils' # Object#deep_clone
 
 describe ConfiguratorBuilder do
+
+  describe '#populate_with_defaults' do
+    let(:builder) { ConfiguratorBuilder.new(file_path_collection_utils: nil, loginator: nil, file_wrapper: nil, system_wrapper: nil) }
+
+    it 'copies in a missing Hash default as an unfrozen, independent clone' do
+      default_tool = { :executable => 'gcc'.freeze, :arguments => ['-g'.freeze].freeze }.freeze
+      defaults = { :tools => { :some_tool => default_tool } }
+      config = { :tools => {} }
+
+      builder.populate_with_defaults(config, defaults)
+
+      expect(config[:tools][:some_tool][:executable]).to_not be_frozen
+      expect(config[:tools][:some_tool][:arguments].first).to_not be_frozen
+      expect(config[:tools][:some_tool][:executable]).to_not equal(default_tool[:executable])
+    end
+
+    # This is the actual gap: a project.yml that partially defines a tool already
+    # present as a Hash (e.g. one plugin-config key alongside a plugin-default-only
+    # tool) recurses into that existing sub-hash rather than copying it in wholesale
+    # -- any of its own still-missing String/Array leaf values were, before this fix,
+    # assigned by direct reference to the (often frozen, plugin-literal) default
+    # value, rather than cloned the same way a wholesale-missing tool already was.
+    it 'clones a String/Array leaf default even when only recursing into an already-present Hash' do
+      default_tool = { :executable => 'gcc'.freeze, :arguments => ['-g'.freeze].freeze }.freeze
+      defaults = { :tools => { :some_tool => default_tool } }
+      config = { :tools => { :some_tool => { :ceedling_delta_probe => true } } }
+
+      builder.populate_with_defaults(config, defaults)
+
+      expect(config[:tools][:some_tool][:executable]).to eq('gcc')
+      expect(config[:tools][:some_tool][:executable]).to_not be_frozen
+      expect(config[:tools][:some_tool][:arguments]).to eq(['-g'])
+      expect(config[:tools][:some_tool][:arguments].first).to_not be_frozen
+      expect(config[:tools][:some_tool][:ceedling_delta_probe]).to be(true)
+    end
+
+    it 'leaves an already-present value untouched rather than overwriting it with the default' do
+      defaults = { :tools => { :some_tool => { :executable => 'gcc' } } }
+      config = { :tools => { :some_tool => { :executable => 'clang' } } }
+
+      builder.populate_with_defaults(config, defaults)
+
+      expect(config[:tools][:some_tool][:executable]).to eq('clang')
+    end
+  end
 
   describe '#normalize_filename_extensions' do
     let(:builder) { ConfiguratorBuilder.new(file_path_collection_utils: nil, loginator: nil, file_wrapper: nil, system_wrapper: nil) }

--- a/spec/units/plugin_manager_spec.rb
+++ b/spec/units/plugin_manager_spec.rb
@@ -50,7 +50,7 @@ describe PluginManager do
   # TestBuildExecutor's resolve_compile_tool/resolve_link_tool/resolve_fixture_tool) --
   # distinct from and additional to the existing pre_compile_execute/pre_link_execute/
   # pre_test_fixture_execute hooks, which only fire for a target actually rebuilt.
-  describe 'pre_compile_register / pre_link_register / pre_test_fixture_register' do
+  describe 'pre_test_compile_register / pre_test_link_register / pre_test_fixture_register' do
     before(:each) do
       allow(@loginator).to receive(:lazy)
     end
@@ -63,20 +63,20 @@ describe PluginManager do
       plugin
     end
 
-    it 'dispatches pre_compile_register to a plugin implementing it, with the given arg_hash' do
-      plugin = stub_plugin_implementing(:pre_compile_register)
+    it 'dispatches pre_test_compile_register to a plugin implementing it, with the given arg_hash' do
+      plugin = stub_plugin_implementing(:pre_test_compile_register)
       arg_hash = { tool: 'fake tool' }
 
-      expect(plugin).to receive(:pre_compile_register).with(arg_hash)
-      @pm.pre_compile_register(arg_hash)
+      expect(plugin).to receive(:pre_test_compile_register).with(arg_hash)
+      @pm.pre_test_compile_register(arg_hash)
     end
 
-    it 'dispatches pre_link_register to a plugin implementing it, with the given arg_hash' do
-      plugin = stub_plugin_implementing(:pre_link_register)
+    it 'dispatches pre_test_link_register to a plugin implementing it, with the given arg_hash' do
+      plugin = stub_plugin_implementing(:pre_test_link_register)
       arg_hash = { tool: 'fake tool' }
 
-      expect(plugin).to receive(:pre_link_register).with(arg_hash)
-      @pm.pre_link_register(arg_hash)
+      expect(plugin).to receive(:pre_test_link_register).with(arg_hash)
+      @pm.pre_test_link_register(arg_hash)
     end
 
     it 'dispatches pre_test_fixture_register to a plugin implementing it, with the given arg_hash' do
@@ -88,8 +88,8 @@ describe PluginManager do
     end
 
     it 'is a harmless no-op for any of the three when no plugin implements it' do
-      expect { @pm.pre_compile_register({}) }.to_not raise_error
-      expect { @pm.pre_link_register({}) }.to_not raise_error
+      expect { @pm.pre_test_compile_register({}) }.to_not raise_error
+      expect { @pm.pre_test_link_register({}) }.to_not raise_error
       expect { @pm.pre_test_fixture_register({}) }.to_not raise_error
     end
   end

--- a/spec/units/plugin_manager_spec.rb
+++ b/spec/units/plugin_manager_spec.rb
@@ -45,4 +45,52 @@ describe PluginManager do
       expect(@pm.plugins_failed?).to be(false)
     end
   end
+
+  # These fire ahead of TestBuildExecutor's own dependency-tracker meta capture (see
+  # TestBuildExecutor's resolve_compile_tool/resolve_link_tool/resolve_fixture_tool) --
+  # distinct from and additional to the existing pre_compile_execute/pre_link_execute/
+  # pre_test_fixture_execute hooks, which only fire for a target actually rebuilt.
+  describe 'pre_compile_register / pre_link_register / pre_test_fixture_register' do
+    before(:each) do
+      allow(@loginator).to receive(:lazy)
+    end
+
+    def stub_plugin_implementing(method)
+      plugin = double('plugin', :name => 'fake')
+      allow(plugin).to receive(:respond_to?).and_return(false)
+      allow(plugin).to receive(:respond_to?).with(method).and_return(true)
+      @pm.instance_variable_set(:@plugin_objects, [plugin])
+      plugin
+    end
+
+    it 'dispatches pre_compile_register to a plugin implementing it, with the given arg_hash' do
+      plugin = stub_plugin_implementing(:pre_compile_register)
+      arg_hash = { tool: 'fake tool' }
+
+      expect(plugin).to receive(:pre_compile_register).with(arg_hash)
+      @pm.pre_compile_register(arg_hash)
+    end
+
+    it 'dispatches pre_link_register to a plugin implementing it, with the given arg_hash' do
+      plugin = stub_plugin_implementing(:pre_link_register)
+      arg_hash = { tool: 'fake tool' }
+
+      expect(plugin).to receive(:pre_link_register).with(arg_hash)
+      @pm.pre_link_register(arg_hash)
+    end
+
+    it 'dispatches pre_test_fixture_register to a plugin implementing it, with the given arg_hash' do
+      plugin = stub_plugin_implementing(:pre_test_fixture_register)
+      arg_hash = { tool: 'fake tool' }
+
+      expect(plugin).to receive(:pre_test_fixture_register).with(arg_hash)
+      @pm.pre_test_fixture_register(arg_hash)
+    end
+
+    it 'is a harmless no-op for any of the three when no plugin implements it' do
+      expect { @pm.pre_compile_register({}) }.to_not raise_error
+      expect { @pm.pre_link_register({}) }.to_not raise_error
+      expect { @pm.pre_test_fixture_register({}) }.to_not raise_error
+    end
+  end
 end

--- a/spec/units/test_build_executor_spec.rb
+++ b/spec/units/test_build_executor_spec.rb
@@ -561,6 +561,7 @@ describe TestBuildExecutor do
 
       swapped_tool = { name: 'fake valgrind wrapper' }
       allow(@plugin_manager).to receive(:pre_test_fixture_register) do |arg_hash|
+        expect( arg_hash[:target] ).to eq( @fixture_target )
         arg_hash[:tool] = swapped_tool
       end
 

--- a/spec/units/test_build_executor_spec.rb
+++ b/spec/units/test_build_executor_spec.rb
@@ -73,8 +73,8 @@ describe TestBuildExecutor do
     allow(@file_wrapper).to receive(:exist?).and_return( false )
     # Default: no plugin implements the new pre-*-register hooks -- each is a
     # no-op that leaves the arg_hash it's handed untouched.
-    allow(@plugin_manager).to receive(:pre_compile_register)
-    allow(@plugin_manager).to receive(:pre_link_register)
+    allow(@plugin_manager).to receive(:pre_test_compile_register)
+    allow(@plugin_manager).to receive(:pre_test_link_register)
     allow(@plugin_manager).to receive(:pre_test_fixture_register)
 
     allow(@dependinator).to receive(:register)
@@ -196,12 +196,12 @@ describe TestBuildExecutor do
       )
     end
 
-    it "resolves the compile tool/flags/defines through pre_compile_register before registering staleness meta, and uses the resolved values for the real compile" do
+    it "resolves the compile tool/flags/defines through pre_test_compile_register before registering staleness meta, and uses the resolved values for the real compile" do
       allow(@file_wrapper).to receive(:extname).with( 'src/foo.c' ).and_return( '.c' )
       allow(@configurator).to receive(:test_build_use_assembly).and_return( false )
 
       swapped_tool = { name: 'fake gcov compiler' }
-      allow(@plugin_manager).to receive(:pre_compile_register) do |arg_hash|
+      allow(@plugin_manager).to receive(:pre_test_compile_register) do |arg_hash|
         arg_hash[:tool]    = swapped_tool
         arg_hash[:flags]   += ['-fcondition-coverage']
         arg_hash[:defines] += ['CODE_COVERAGE']
@@ -324,11 +324,11 @@ describe TestBuildExecutor do
       expect( @testable.executable_rebuilt ).to be(false)
     end
 
-    it "resolves the link tool/flags through pre_link_register before registering staleness meta, and uses the resolved values for the real link" do
+    it "resolves the link tool/flags through pre_test_link_register before registering staleness meta, and uses the resolved values for the real link" do
       allow(@dependinator).to receive(:stale?).and_return( true )
 
       swapped_tool = { name: 'fake bullseye linker' }
-      allow(@plugin_manager).to receive(:pre_link_register) do |arg_hash|
+      allow(@plugin_manager).to receive(:pre_test_link_register) do |arg_hash|
         arg_hash[:tool] = swapped_tool
       end
 

--- a/spec/units/test_build_executor_spec.rb
+++ b/spec/units/test_build_executor_spec.rb
@@ -71,6 +71,12 @@ describe TestBuildExecutor do
     # stale -- i.e. every real build in this spec proceeds as an unconditional
     # fresh compile unless a test overrides `stale?` to exercise the skip path.
     allow(@file_wrapper).to receive(:exist?).and_return( false )
+    # Default: no plugin implements the new pre-*-register hooks -- each is a
+    # no-op that leaves the arg_hash it's handed untouched.
+    allow(@plugin_manager).to receive(:pre_compile_register)
+    allow(@plugin_manager).to receive(:pre_link_register)
+    allow(@plugin_manager).to receive(:pre_test_fixture_register)
+
     allow(@dependinator).to receive(:register)
     allow(@dependinator).to receive(:register_gcc_deps_file)
     allow(@dependinator).to receive(:stale?).and_return( true )
@@ -190,6 +196,38 @@ describe TestBuildExecutor do
       )
     end
 
+    it "resolves the compile tool/flags/defines through pre_compile_register before registering staleness meta, and uses the resolved values for the real compile" do
+      allow(@file_wrapper).to receive(:extname).with( 'src/foo.c' ).and_return( '.c' )
+      allow(@configurator).to receive(:test_build_use_assembly).and_return( false )
+
+      swapped_tool = { name: 'fake gcov compiler' }
+      allow(@plugin_manager).to receive(:pre_compile_register) do |arg_hash|
+        arg_hash[:tool]    = swapped_tool
+        arg_hash[:flags]   += ['-fcondition-coverage']
+        arg_hash[:defines] += ['CODE_COVERAGE']
+      end
+
+      expect(@dependinator).to receive(:register).with(
+        'build/foo.o',
+        files: ['src/foo.c'],
+        meta:  hash_including(
+          tools:   [swapped_tool],
+          flags:   array_including('-fcondition-coverage'),
+          defines: array_including('CODE_COVERAGE')
+        )
+      )
+      expect(@generator).to receive(:generate_object_file_c) do |**args|
+        expect( args[:tool] ).to eq( swapped_tool )
+        expect( args[:flags] ).to include('-fcondition-coverage')
+        expect( args[:defines] ).to include('CODE_COVERAGE')
+      end
+
+      @executor.send(
+        :compile_test_component,
+        :context => :test, :test => :a_test, :source => 'src/foo.c', :object => 'build/foo.o', :state => @state
+      )
+    end
+
     it "registers the configured compiler tool as meta for a C source, and the configured assembler tool for an assembly source" do
       allow(@file_wrapper).to receive(:extname).with( 'src/foo.c' ).and_return( '.c' )
       allow(@file_wrapper).to receive(:extname).with( 'src/foo.asm' ).and_return( '.asm' )
@@ -286,6 +324,26 @@ describe TestBuildExecutor do
       expect( @testable.executable_rebuilt ).to be(false)
     end
 
+    it "resolves the link tool/flags through pre_link_register before registering staleness meta, and uses the resolved values for the real link" do
+      allow(@dependinator).to receive(:stale?).and_return( true )
+
+      swapped_tool = { name: 'fake bullseye linker' }
+      allow(@plugin_manager).to receive(:pre_link_register) do |arg_hash|
+        arg_hash[:tool] = swapped_tool
+      end
+
+      expect(@dependinator).to receive(:register).with(
+        'build/a_test.out',
+        files: ['build/foo.o'],
+        meta:  hash_including( tools: [swapped_tool] )
+      )
+      expect(@generator).to receive(:generate_executable_file) do |tool, *_rest|
+        expect( tool ).to eq( swapped_tool )
+      end
+
+      @executor.stage_build_executables( @state )
+    end
+
     it "registers the configured test linker tool as meta, alongside link flags and library arguments" do
       allow(@dependinator).to receive(:stale?).and_return( false )
 
@@ -322,7 +380,8 @@ describe TestBuildExecutor do
         objects:    ['build/foo.o'],
         flags:      [],
         lib_args:   [],
-        lib_paths:  []
+        lib_paths:  [],
+        tool:       { name: 'fake linker' }
       }
     end
 
@@ -494,6 +553,26 @@ describe TestBuildExecutor do
       allow(@reportinator).to receive(:generate_skip_summary).and_return( "Skipping test execution for 1 test (reusing cached results)..." )
 
       expect(@loginator).to receive(:log).with( "Skipping test execution for 1 test (reusing cached results)..." )
+      @executor.stage_execute( @state )
+    end
+
+    it "resolves the fixture tool through pre_test_fixture_register before registering staleness meta, and uses the resolved value for the real run" do
+      @testable.executable_rebuilt = false
+
+      swapped_tool = { name: 'fake valgrind wrapper' }
+      allow(@plugin_manager).to receive(:pre_test_fixture_register) do |arg_hash|
+        arg_hash[:tool] = swapped_tool
+      end
+
+      expect(@dependinator).to receive(:register).with(
+        @fixture_target,
+        files: ['build/a_test.out'],
+        meta:  { tools: [swapped_tool] }
+      )
+      expect(@generator).to receive(:generate_test_results) do |**args|
+        expect( args[:tool] ).to eq( swapped_tool )
+      end
+
       @executor.stage_execute( @state )
     end
 

--- a/spec/units/test_invoker_spec.rb
+++ b/spec/units/test_invoker_spec.rb
@@ -67,6 +67,20 @@ describe TestInvoker do
       @invoker.setup_and_invoke( tests: [] )
     end
 
+    # Isolates each pipeline identifier's own cache file (see Dependinator#open) --
+    # sharing one cache file between, say, an ordinary test run and a plugin's own
+    # context (:gcov, :valgrind, ...) would let one's full-run pruning flush (see
+    # Dependinator#flush) silently evict the other's cache entries.
+    it "opens the dependency cache identified by the given context, isolating a plugin's own build context from ordinary test runs" do
+      expect(@dependinator).to receive(:open).with( identifier: :gcov )
+      @invoker.setup_and_invoke( tests: [], context: :gcov )
+    end
+
+    it "opens the dependency cache identified by TEST_SYM when context is not given" do
+      expect(@dependinator).to receive(:open).with( identifier: TEST_SYM )
+      @invoker.setup_and_invoke( tests: [] )
+    end
+
     it "flushes with refresh_dependencies true only when that option is present" do
       expect(@dependinator).to receive(:flush).with( refresh_dependencies: true )
       @invoker.setup_and_invoke( tests: [], options: [:refresh_dependencies] )


### PR DESCRIPTION
## Summary

Gcov, Valgrind, and Bullseye already run their own build through the exact same core test pipeline as ordinary `test:` builds (`TestInvoker#setup_and_invoke` tagged with their own `context:` symbol), and already benefit from `Dependinator`/`DependencyTracker` staleness gating — there's no second build engine. Two concrete gaps stood between that and *correct, complete* delta-build coverage for these plugins:

1. **Shared cache identifier.** `TestInvoker#setup_and_invoke` always opened the dependency cache with `identifier: :test`, regardless of `context:`. Since `test:all` prunes any cache entry not registered that run, running `test:all` after a `gcov:all` run silently evicted gcov's own cache entries from the shared file.
2. **Tool-swap-after-meta-capture.** `TestBuildExecutor` registered dependency-tracker meta using the plain `:tools ↳ :test_compiler`/`:test_linker`/`:test_fixture` *before* `Generator` ever fired the hooks a plugin uses to swap in its own instrumented tool — so editing `:tools ↳ :gcov_compiler`, toggling `:gcov ↳ :mcdc`, or changing `:valgrind ↳ :arguments` did **not** invalidate that plugin's own cached targets. A false-negative staleness check, not merely a missed optimization.

## Changes

- `TestInvoker#setup_and_invoke` now opens the dependency cache with `identifier: context`, giving every plugin following the context-tagged pattern its own isolated cache file automatically, with zero plugin code changes.
- Three new `PluginManager` hooks — `pre_compile_register`, `pre_link_register`, `pre_test_fixture_register` — fire unconditionally, once per object/executable/test, *before* `TestBuildExecutor` registers meta or checks staleness, distinct from and additional to the existing `pre_*_execute` hooks (which still fire only when a real (re)compile/link/run happens).
- `TestBuildExecutor` resolves the real tool/flags/defines through these new hooks before registering meta, then threads the resolved values through to the real compile/link/fixture-run call too, so the two can never disagree about what actually ran.
- Gcov, Valgrind, and Bullseye adopt the new hooks, splitting tool selection (register-time, meta-relevant) from progress-message text (execute-time only). As a side effect, this also fixes a latent bug where Gcov/Bullseye's coverage summary never printed on a fully-cached re-run, since their "did a task run" flag was only ever set inside the link hook, which didn't fire when nothing needed relinking.
- Developer docs and Changelog updated.

## Testing

- Full `bundle exec rspec spec/units/`: 2845 examples, 0 failures.
- New targeted system-test coverage (`spec/system/plugin_delta_builds_spec.rb`) for both gaps against real gcov/valgrind projects — gcov scenarios green; valgrind scenarios correctly skip locally (no valgrind installed) via the existing `"requires valgrind"` shared context.
- Full `spec/system/` suite run locally as a final backstop: 438 examples, 9 failures, 28 pending. All 9 failures confirmed pre-existing and unrelated to this branch (8 GDB codesigning failures already known from prior work; 1 cppcheck `--xml-version` mismatch against this machine's cppcheck binary, an unrelated plugin untouched here). Zero failures attributable to this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)