### PR TITLE
Fix #1251, #1252, and ignored-test false crash reports

### DIFF
--- a/lib/ceedling/generators/generator_test_results_backtrace.rb
+++ b/lib/ceedling/generators/generator_test_results_backtrace.rb
@@ -66,13 +66,17 @@ class GeneratorTestResultsBacktrace
       # Attribute each group member its own real result line, if Unity printed one
       group.each do |test_case|
         case crash_result[:output]
-        # Success test case
-        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS\s*$)/
+        # Success test case -- tolerates a trailing duration suffix (e.g. `PASS (12 ms)`,
+        # UNITY_INCLUDE_EXEC_TIME), matching the real format generator_test_results.rb's
+        # own parser already recognizes for it.
+        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS(\s\(.*ms\))?\s*$)/
           group_results[:passed]  += 1
           group_results[:output] << $1
 
-        # Ignored test case
-        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE\s*$)/
+        # Ignored test case -- tolerates a trailing message (TEST_IGNORE_MESSAGE), same as
+        # FAIL below. Before this fix, a message-carrying ignore fell through to "unresolved"
+        # and was misreported as crash evidence -- IGNORE was only recognized bare.
+        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE(:.+)?\s*$)/
           group_results[:ignored] += 1
           group_results[:output] << $1
 
@@ -260,13 +264,17 @@ class GeneratorTestResultsBacktrace
       # Attribute each group member its own real result line, if Unity printed one
       group.each do |test_case|
         case crash_result[:output]
-        # Success test case
-        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS\s*$)/
+        # Success test case -- tolerates a trailing duration suffix (e.g. `PASS (12 ms)`,
+        # UNITY_INCLUDE_EXEC_TIME), matching the real format generator_test_results.rb's
+        # own parser already recognizes for it.
+        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS(\s\(.*ms\))?\s*$)/
           group_results[:passed]  += 1
           group_results[:output] << $1
 
-        # Ignored test case
-        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE\s*$)/
+        # Ignored test case -- tolerates a trailing message (TEST_IGNORE_MESSAGE), same as
+        # FAIL below. Before this fix, a message-carrying ignore fell through to "unresolved"
+        # and was misreported as crash evidence -- IGNORE was only recognized bare.
+        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE(:.+)?\s*$)/
           group_results[:ignored] += 1
           group_results[:output] << $1
 

--- a/lib/ceedling/plugins/report_tests_stdout_plugin.rb
+++ b/lib/ceedling/plugins/report_tests_stdout_plugin.rb
@@ -50,7 +50,10 @@ class ReportTestsStdoutPlugin < Plugin
 
     results = @plugin_reportinator.assemble_test_results( @result_list )
     hash = { :context => TEST_SYM, :results => results }
-    verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::NORMAL
+    # #1251 -- `:warnings` on the CLI maps to Verbosity::COMPLAIN (see VERBOSITY_OPTIONS
+    # in constants.rb), not NORMAL, so gating the all-clean case at NORMAL silently
+    # swallowed the Overall Test Summary at --verbosity=warnings even on a passing run.
+    verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::COMPLAIN
 
     # Print unit test suite results
     @plugin_reportinator.run_test_results_report( hash, verbosity )

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -40,11 +40,19 @@ class Gcov < Plugin
       )
     end
 
-    # Validate configuration and tools while building Reportinators
-    @reportinators = build_reportinators( 
-      @project_config[:gcov_utilities],
-      @reports_enabled
-    )
+    # #1252 -- Validate `:gcov ↳ :utilities` config (cheap, no external tool needed) and
+    # build the console summary Reportinator (needs no external tool of its own) here,
+    # eagerly, since `setup()` runs for every build this plugin is merely *enabled* for,
+    # not only real `gcov:` builds. Deliberately NOT building the gcovr/ReportGenerator
+    # Reportinators here -- doing so validates gcovr/ReportGenerator are installed
+    # (see their own constructors), which would make either a hard dependency of any
+    # build at all (e.g. plain `test:all`) rather than only a real `gcov:` build. See
+    # generate_coverage_reports, which builds (and so validates) them lazily, only once
+    # post_build already knows a gcov: task actually ran.
+    validate_utilities_config( @project_config[:gcov_utilities] )
+    @console_reportinator = summaries_enabled?( @project_config ) ?
+      ConsoleReportinator.new( @ceedling, @project_config ) : nil
+    @reportinators = nil
 
     # Convenient instance variable references
     @configurator = @ceedling[:configurator]
@@ -260,6 +268,15 @@ class Gcov < Plugin
   def generate_coverage_reports()
     return if not @reports_enabled
 
+    # #1252 -- Lazily build (and so validate the external tools of) the gcovr/
+    # ReportGenerator Reportinators only now: this method only runs from post_build
+    # (automatic reporting) or the standalone `gcov:report` task (manual reporting,
+    # mutually exclusive with automatic per :gcov_report_task) -- either way, only
+    # once a real gcov: task is confirmed to have already run. See setup()'s own
+    # comment for why this can't happen any earlier. `||=` just guards against ever
+    # rebuilding (and so re-validating) on a hypothetical repeat call.
+    @reportinators ||= build_reportinators( @project_config[:gcov_utilities] )
+
     @reportinators.each do |reportinator|
       # Create the artifacts output directory.
       @file_wrapper.mkdir( reportinator.artifacts_path ) if reportinator.artifacts_path
@@ -315,16 +332,10 @@ class Gcov < Plugin
     return sources - tested_sources
   end
 
-  def build_reportinators(config, enabled)
-    reportinators = []
-
-    # Instantiate console summary reportinator if summaries enabled
-    @console_reportinator = summaries_enabled?(@project_config) ?
-      ConsoleReportinator.new(@ceedling, @project_config) : nil
-
-    # Do not instantiate file reportinators (and tool validation) unless reports enabled
-    return reportinators if (!enabled)
-
+  # Fail fast at plugin setup if :utilities holds an unrecognized name (e.g. a typo) --
+  # cheap, config-shape-only validation, so this stays eager even though the actual
+  # Reportinators it names are built lazily (see build_reportinators, generate_coverage_reports).
+  def validate_utilities_config(config)
     config.each do |reportinator|
       if not GCOV_UTILITY_NAMES.map(&:upcase).include?( reportinator.upcase )
         options = GCOV_UTILITY_NAMES.map{ |utility| "'#{utility}'" }.join(', ')
@@ -332,6 +343,14 @@ class Gcov < Plugin
         raise CeedlingException.new(msg)
       end
     end
+  end
+
+  # #1252 -- Deliberately not called from setup(); see its own comment and
+  # generate_coverage_reports, the only caller. Constructing GcovrReportinator/
+  # ReportGeneratorReportinator validates gcovr/ReportGenerator are installed, so this
+  # can only run once a real gcov: task is confirmed to have run.
+  def build_reportinators(config)
+    reportinators = []
 
     # Run reports using gcovr
     if utility_enabled?( config, GCOV_UTILITY_NAME_GCOVR )

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -214,7 +214,10 @@ class Gcov < Plugin
         results: results
       }
 
-      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::NORMAL
+      # #1251 -- `:warnings` on the CLI maps to Verbosity::COMPLAIN (see VERBOSITY_OPTIONS
+      # in constants.rb), not NORMAL, so gating the all-clean case at NORMAL silently
+      # swallowed the Overall Test Summary at --verbosity=warnings even on a passing run.
+      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::COMPLAIN
 
       # Print unit test suite results
       @plugin_reportinator.run_test_results_report( hash, verbosity )

--- a/plugins/valgrind/lib/valgrind.rb
+++ b/plugins/valgrind/lib/valgrind.rb
@@ -101,7 +101,10 @@ class Valgrind < Plugin
         results: results
       }
 
-      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::NORMAL
+      # #1251 -- `:warnings` on the CLI maps to Verbosity::COMPLAIN (see VERBOSITY_OPTIONS
+      # in constants.rb), not NORMAL, so gating the all-clean case at NORMAL silently
+      # swallowed the Overall Test Summary at --verbosity=warnings even on a passing run.
+      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::COMPLAIN
 
       # Print unit test suite results
       @plugin_reportinator.run_test_results_report( hash, verbosity )

--- a/spec/system/deployment_as_gem_spec.rb
+++ b/spec/system/deployment_as_gem_spec.rb
@@ -87,6 +87,7 @@ ceedling_system_tests do
 
     describe "Verbosity and output" do
       test_case :test_project_with_named_verbosity
+      test_case :test_project_with_warnings_verbosity_prints_overall_summary
       test_case :test_project_with_numerical_verbosity
       test_case :report_tests_raw_output_log_plugin
     end

--- a/spec/system/deployment_as_vendor_spec.rb
+++ b/spec/system/deployment_as_vendor_spec.rb
@@ -90,6 +90,7 @@ ceedling_system_tests do
 
     describe "Verbosity and output" do
       test_case :test_project_with_named_verbosity
+      test_case :test_project_with_warnings_verbosity_prints_overall_summary
       test_case :test_project_with_numerical_verbosity
       test_case :report_tests_raw_output_log_plugin
     end

--- a/spec/system/gcov_deployment_spec.rb
+++ b/spec/system/gcov_deployment_spec.rb
@@ -33,6 +33,7 @@ ceedling_system_tests do
         end
       end
 
+      test_case :project_with_gcov_enabled_test_all_does_not_require_gcovr
       test_case :project_with_gcov_success
       test_case :project_with_gcov_fail
       test_case :gcov_console_report_with_system_header

--- a/spec/system/support/common_test_cases.rb
+++ b/spec/system/support/common_test_cases.rb
@@ -201,6 +201,29 @@ module CommonSystemTestCases
     end
   end
 
+  # #1251 -- the Overall Test Summary must still print at :warnings verbosity
+  # (`--verbosity=warnings`, Verbosity::COMPLAIN) on an all-passing run, not just
+  # when verbosity is :normal or higher, or when a test fails. Before this fix, the
+  # summary's own gate mistakenly required :normal, silently swallowing the summary
+  # on the (default) all-clean case at :warnings.
+  def test_project_with_warnings_verbosity_prints_overall_summary
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        output = @c.ceedling_build_exec("--verbosity=warnings")
+        expect(@c.last_exit_status).to eq(0)
+        expect(output).to match(/OVERALL TEST SUMMARY/)
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
   def test_project_with_numerical_verbosity
     @c.with_context do
       Dir.chdir @proj_name do

--- a/spec/system/support/gcov_common_test_cases.rb
+++ b/spec/system/support/gcov_common_test_cases.rb
@@ -10,6 +10,38 @@ require_relative 'gcov_helpers'
 module GcovCommonTestCases
   include GcovHelpers
 
+  # #1252 -- Enabling the gcov plugin must not make gcovr a hard dependency of every
+  # build. Deliberately does NOT call prep_project_yml_for_coverage (which conditionally
+  # strips :utilities ➡️ gcovr when the host lacks a real gcovr) -- the point here is
+  # gcovr enabled in config but genuinely unreachable, reproducing #1252 regardless of
+  # what's actually installed on the machine running this spec.
+  def project_with_gcov_enabled_test_all_does_not_require_gcovr
+    @c.with_context do
+      Dir.chdir @proj_name do
+        @c.uncomment_project_yml_option_for_test("- gcov")
+        # Default :gcov ↳ :utilities already includes gcovr and :reports already
+        # includes HtmlBasic -- exactly the enabled-but-unused shape #1252 reported.
+        @c.merge_project_yml_for_test(
+          { :tools => { :gcov_gcovr_report => { :executable => 'nonexistent_gcovr_binary_for_1252_test' } } }
+        )
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        # An ordinary test:all run must succeed -- it never needs gcovr at all.
+        output = @c.ceedling_build_exec("test:all")
+        expect(@c.last_exit_status).to eq(0)
+        expect(output).to_not match(/nonexistent_gcovr_binary_for_1252_test/)
+
+        # A real gcov: build still needs gcovr and must still fail loudly when it's missing --
+        # the fix defers gcovr's tool validation, it doesn't remove it.
+        output = @c.ceedling_build_exec("gcov:all")
+        expect(@c.last_exit_status).to_not eq(0)
+        expect(output).to match(/nonexistent_gcovr_binary_for_1252_test/)
+      end
+    end
+  end
+
   def project_with_gcov_success
     @c.with_context do
       Dir.chdir @proj_name do

--- a/spec/units/generators/generator_test_results_backtrace_spec.rb
+++ b/spec/units/generators/generator_test_results_backtrace_spec.rb
@@ -130,6 +130,7 @@ SIMPLE_ASSERT_CRASH_OUTPUT =
 SIMPLE_PASS_OUTPUT   = "test_lib.c:3:test_empty:PASS\n---------\n1 Tests 0 Failures 0 Ignored\nOK\n"
 SIMPLE_FAIL_OUTPUT   = "test_lib.c:8:test_bad:FAIL: Expected 1 Was 2\n---------\n1 Tests 1 Failures 0 Ignored\nFAIL\n"
 SIMPLE_IGNORE_OUTPUT = "test_lib.c:12:test_skip:IGNORE\n---------\n1 Tests 0 Failures 1 Ignored\nOK\n"
+SIMPLE_IGNORE_WITH_MESSAGE_OUTPUT = "test_lib.c:12:test_skip:IGNORE: Not yet implemented\n---------\n1 Tests 0 Failures 1 Ignored\nOK\n"
 
 
 describe GeneratorTestResultsBacktrace do
@@ -253,6 +254,31 @@ describe GeneratorTestResultsBacktrace do
       @backtrace.do_gdb( filename, executable, shell_result, [companion_case] + test_cases, context: :test )
 
       expect(expected_output_lines).to include('test_lib.c:9:test_asserting:FAIL: Expected 1 Was 2')
+    end
+
+    # Ignored-crash false positive: a TEST_IGNORE_MESSAGE(...) test case carries a
+    # trailing message, same as FAIL. Before this fix, only FAIL tolerated one --
+    # a message-carrying IGNORE fell through to "unresolved" and was misreported
+    # as crash evidence (a second @file_wrapper.write, for a companion_case that
+    # never actually crashed).
+    it 'handles an IGNORE test case with a trailing message and does not write a log' do
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: GDB_NO_SIGNAL_OUTPUT, time: 0.1, exit_code: 1, stderr: '', status: @ok_status },
+        { output: "test_lib.c:9:test_asserting:IGNORE: Not yet implemented\n---------\n1 Tests 0 Failures 1 Ignored\nOK\n",
+          time: 0.1, exit_code: 0, stderr: '', status: @ok_status }
+      )
+
+      expect(@file_wrapper).to receive(:write).once.with(%r{test_crashes_elsewhere}, anything, anything)
+
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
+
+      @backtrace.do_gdb( filename, executable, shell_result, [companion_case] + test_cases, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:9:test_asserting:IGNORE: Not yet implemented')
     end
 
     it "does not trust a matched PASS line when the retry's own real status contradicts it" do
@@ -469,6 +495,31 @@ describe GeneratorTestResultsBacktrace do
       @backtrace.do_simple( filename, executable, shell_result, test_cases_ignore, context: :test )
 
       expect(expected_output_lines).to include('test_lib.c:12:test_skip:IGNORE')
+    end
+
+    # Ignored-crash false positive: a TEST_IGNORE_MESSAGE(...) test case carries a
+    # trailing message, same as FAIL (handled just above). Before this fix, only FAIL
+    # tolerated one -- a message-carrying IGNORE fell through to the "no result line"
+    # branch and was misreported as a second crashed test case (test_skip, alongside
+    # the real crash attributed to test_crashes_elsewhere).
+    it 'handles an IGNORE test case with a trailing message' do
+      test_cases_ignore = [{ test: 'test_crashes_elsewhere', line_number: 20 }, { test: 'test_skip', line_number: 12 }]
+
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: SIMPLE_ASSERT_CRASH_OUTPUT, time: 0.1, exit_code: 134, stderr: '', status: @ok_status },
+        { output: SIMPLE_IGNORE_WITH_MESSAGE_OUTPUT, time: 0.02, exit_code: 0, stderr: '', status: @ok_status }
+      )
+
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
+
+      @backtrace.do_simple( filename, executable, shell_result, test_cases_ignore, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:12:test_skip:IGNORE: Not yet implemented')
+      expect(expected_output_lines).to_not include(a_string_matching(/test_skip:FAIL/))
     end
 
     it "does not trust a matched PASS line when the retry's own real status contradicts it" do


### PR DESCRIPTION
## Summary

Three independent, already-diagnosed bug fixes bundled together per plan (small, unrelated, low-risk):

1. **#1251** — `--verbosity=warnings` no longer printed the Overall Test Summary on an all-passing run. `:warnings` maps to `Verbosity::COMPLAIN`, but the passing-run branch in `report_tests_stdout_plugin.rb` / `gcov.rb` / `valgrind.rb` was gated at `Verbosity::NORMAL`, one level too high. Fixed in all three.
2. **#1252** — enabling the `gcov` plugin made `gcovr` a hard dependency of *any* build (including plain `test:all`), because `Plugin#setup()` eagerly built and validated the gcovr/ReportGenerator report backends regardless of which task actually ran. Tool validation for those backends is now deferred to `generate_coverage_reports()`, which only runs once a real `gcov:` task is confirmed.
3. **Ignored-test false crash** — a `TEST_IGNORE_MESSAGE(...)` test case (an ignore *with* a message) inside a test file that also genuinely crashed was misreported as crash evidence during backtrace diagnosis. The `do_gdb`/`do_simple` per-test-case regexes only tolerated a trailing message on `FAIL`, not `IGNORE`/`PASS`; widened to match, mirroring `FAIL`'s existing tolerance.

Each fix is test-first: a new/extended spec reproduces the bug against the pre-fix code, then passes after.

## Verification

- `rake specs:units` — 1977 examples, 0 failures.
- New/extended system specs (`deployment_as_gem_spec.rb`, `deployment_as_vendor_spec.rb`, `gcov_deployment_spec.rb`) run inside `madsciencelab-plugins`, plus the full existing gcov/valgrind/crash-handling/GDB-backtrace system suites — all green, no regressions.
- New/extended unit specs (`generator_test_results_backtrace_spec.rb`) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)