### PR TITLE
Fix #1251, #1252, ignored-test false crash reports, and :use_backtrace delta-build gap

### DIFF
--- a/lib/ceedling/generators/generator_test_results_backtrace.rb
+++ b/lib/ceedling/generators/generator_test_results_backtrace.rb
@@ -66,13 +66,17 @@ class GeneratorTestResultsBacktrace
       # Attribute each group member its own real result line, if Unity printed one
       group.each do |test_case|
         case crash_result[:output]
-        # Success test case
-        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS\s*$)/
+        # Success test case -- tolerates a trailing duration suffix (e.g. `PASS (12 ms)`,
+        # UNITY_INCLUDE_EXEC_TIME), matching the real format generator_test_results.rb's
+        # own parser already recognizes for it.
+        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS(\s\(.*ms\))?\s*$)/
           group_results[:passed]  += 1
           group_results[:output] << $1
 
-        # Ignored test case
-        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE\s*$)/
+        # Ignored test case -- tolerates a trailing message (TEST_IGNORE_MESSAGE), same as
+        # FAIL below. Before this fix, a message-carrying ignore fell through to "unresolved"
+        # and was misreported as crash evidence -- IGNORE was only recognized bare.
+        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE(:.+)?\s*$)/
           group_results[:ignored] += 1
           group_results[:output] << $1
 
@@ -260,13 +264,17 @@ class GeneratorTestResultsBacktrace
       # Attribute each group member its own real result line, if Unity printed one
       group.each do |test_case|
         case crash_result[:output]
-        # Success test case
-        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS\s*$)/
+        # Success test case -- tolerates a trailing duration suffix (e.g. `PASS (12 ms)`,
+        # UNITY_INCLUDE_EXEC_TIME), matching the real format generator_test_results.rb's
+        # own parser already recognizes for it.
+        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:PASS(\s\(.*ms\))?\s*$)/
           group_results[:passed]  += 1
           group_results[:output] << $1
 
-        # Ignored test case
-        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE\s*$)/
+        # Ignored test case -- tolerates a trailing message (TEST_IGNORE_MESSAGE), same as
+        # FAIL below. Before this fix, a message-carrying ignore fell through to "unresolved"
+        # and was misreported as crash evidence -- IGNORE was only recognized bare.
+        when /(^#{Regexp.escape(filename)}:\d+:#{Regexp.escape(test_case[:test])}:IGNORE(:.+)?\s*$)/
           group_results[:ignored] += 1
           group_results[:output] << $1
 

--- a/lib/ceedling/plugins/report_tests_stdout_plugin.rb
+++ b/lib/ceedling/plugins/report_tests_stdout_plugin.rb
@@ -50,7 +50,10 @@ class ReportTestsStdoutPlugin < Plugin
 
     results = @plugin_reportinator.assemble_test_results( @result_list )
     hash = { :context => TEST_SYM, :results => results }
-    verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::NORMAL
+    # #1251 -- `:warnings` on the CLI maps to Verbosity::COMPLAIN (see VERBOSITY_OPTIONS
+    # in constants.rb), not NORMAL, so gating the all-clean case at NORMAL silently
+    # swallowed the Overall Test Summary at --verbosity=warnings even on a passing run.
+    verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::COMPLAIN
 
     # Print unit test suite results
     @plugin_reportinator.run_test_results_report( hash, verbosity )

--- a/lib/ceedling/test_invoker/test_build_executor.rb
+++ b/lib/ceedling/test_invoker/test_build_executor.rb
@@ -515,7 +515,28 @@ class TestBuildExecutor
 
         fixture_tool = resolve_fixture_tool( context: state.context, tool: @configurator.tools_test_fixture, test_name: testable.name, target: fixture_target )
 
-        @dependinator.register( fixture_target, files: [testable.executable], meta: { tools: [fixture_tool] } )
+        # :use_backtrace doesn't swap the fixture tool itself (unlike Valgrind/Gcov's own
+        # pre_test_fixture_register hooks) -- it only selects what happens *after*
+        # run_fixture detects a crash (generator.rb's own case on :project_use_backtrace:
+        # :gdb runs tools_test_backtrace_gdb, :simple runs tools_test_fixture_simple_backtrace,
+        # :none does neither). Without capturing that selector (and the tool config(s) it
+        # actually drives) as meta here, toggling :use_backtrace -- or editing a backtrace
+        # tool's own executable/args -- would never invalidate this fixture_target, so a
+        # delta build would keep reusing a stale crash-diagnosis result on the next crash.
+        #
+        # tools_test_backtrace_gdb only exists at all when :use_backtrace is :gdb --
+        # Configurator only merges its defaults (DEFAULT_TOOLS_TEST_GDB_BACKTRACE) in that
+        # case (configurator.rb) -- so it's only read here when actually relevant.
+        # tools_test_fixture_simple_backtrace has no such gate (DEFAULT_TOOLS_TEST always
+        # includes it) and is always safe to read.
+        use_backtrace = @configurator.project_config_hash[:project_use_backtrace]
+        backtrace_tools = [@configurator.tools_test_fixture_simple_backtrace]
+        backtrace_tools << @configurator.tools_test_backtrace_gdb if use_backtrace == :gdb
+
+        @dependinator.register(
+          fixture_target, files: [testable.executable],
+          meta: { tools: [fixture_tool], use_backtrace: use_backtrace, backtrace_tools: backtrace_tools }
+        )
 
         run_now = testable.executable_rebuilt || force_rerun || @dependinator.stale?( fixture_target )
 

--- a/plugins/bullseye/lib/bullseye.rb
+++ b/plugins/bullseye/lib/bullseye.rb
@@ -117,7 +117,10 @@ class Bullseye < Plugin
         :results => results
       }
 
-      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::NORMAL
+      # #1251 -- `:warnings` on the CLI maps to Verbosity::COMPLAIN (see VERBOSITY_OPTIONS
+      # in constants.rb), not NORMAL, so gating the all-clean case at NORMAL silently
+      # swallowed the Overall Test Summary at --verbosity=warnings even on a passing run.
+      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::COMPLAIN
       @plugin_reportinator.run_test_results_report(hash, verbosity)
     end
 

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -299,7 +299,10 @@ class Gcov < Plugin
         results: results
       }
 
-      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::NORMAL
+      # #1251 -- `:warnings` on the CLI maps to Verbosity::COMPLAIN (see VERBOSITY_OPTIONS
+      # in constants.rb), not NORMAL, so gating the all-clean case at NORMAL silently
+      # swallowed the Overall Test Summary at --verbosity=warnings even on a passing run.
+      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::COMPLAIN
 
       # Print unit test suite results
       @plugin_reportinator.run_test_results_report( hash, verbosity )

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -40,11 +40,19 @@ class Gcov < Plugin
       )
     end
 
-    # Validate configuration and tools while building Reportinators
-    @reportinators = build_reportinators( 
-      @project_config[:gcov_utilities],
-      @reports_enabled
-    )
+    # #1252 -- Validate `:gcov ↳ :utilities` config (cheap, no external tool needed) and
+    # build the console summary Reportinator (needs no external tool of its own) here,
+    # eagerly, since `setup()` runs for every build this plugin is merely *enabled* for,
+    # not only real `gcov:` builds. Deliberately NOT building the gcovr/ReportGenerator
+    # Reportinators here -- doing so validates gcovr/ReportGenerator are installed
+    # (see their own constructors), which would make either a hard dependency of any
+    # build at all (e.g. plain `test:all`) rather than only a real `gcov:` build. See
+    # generate_coverage_reports, which builds (and so validates) them lazily, only once
+    # post_build already knows a gcov: task actually ran.
+    validate_utilities_config( @project_config[:gcov_utilities] )
+    @console_reportinator = summaries_enabled?( @project_config ) ?
+      ConsoleReportinator.new( @ceedling, @project_config ) : nil
+    @reportinators = nil
 
     # Convenient instance variable references
     @configurator = @ceedling[:configurator]
@@ -345,6 +353,15 @@ class Gcov < Plugin
   def generate_coverage_reports()
     return if not @reports_enabled
 
+    # #1252 -- Lazily build (and so validate the external tools of) the gcovr/
+    # ReportGenerator Reportinators only now: this method only runs from post_build
+    # (automatic reporting) or the standalone `gcov:report` task (manual reporting,
+    # mutually exclusive with automatic per :gcov_report_task) -- either way, only
+    # once a real gcov: task is confirmed to have already run. See setup()'s own
+    # comment for why this can't happen any earlier. `||=` just guards against ever
+    # rebuilding (and so re-validating) on a hypothetical repeat call.
+    @reportinators ||= build_reportinators( @project_config[:gcov_utilities] )
+
     @reportinators.each do |reportinator|
       # Create the artifacts output directory.
       @file_wrapper.mkdir( reportinator.artifacts_path ) if reportinator.artifacts_path
@@ -400,16 +417,10 @@ class Gcov < Plugin
     return sources - tested_sources
   end
 
-  def build_reportinators(config, enabled)
-    reportinators = []
-
-    # Instantiate console summary reportinator if summaries enabled
-    @console_reportinator = summaries_enabled?(@project_config) ?
-      ConsoleReportinator.new(@ceedling, @project_config) : nil
-
-    # Do not instantiate file reportinators (and tool validation) unless reports enabled
-    return reportinators if (!enabled)
-
+  # Fail fast at plugin setup if :utilities holds an unrecognized name (e.g. a typo) --
+  # cheap, config-shape-only validation, so this stays eager even though the actual
+  # Reportinators it names are built lazily (see build_reportinators, generate_coverage_reports).
+  def validate_utilities_config(config)
     config.each do |reportinator|
       if not GCOV_UTILITY_NAMES.map(&:upcase).include?( reportinator.upcase )
         options = GCOV_UTILITY_NAMES.map{ |utility| "'#{utility}'" }.join(', ')
@@ -417,6 +428,14 @@ class Gcov < Plugin
         raise CeedlingException.new(msg)
       end
     end
+  end
+
+  # #1252 -- Deliberately not called from setup(); see its own comment and
+  # generate_coverage_reports, the only caller. Constructing GcovrReportinator/
+  # ReportGeneratorReportinator validates gcovr/ReportGenerator are installed, so this
+  # can only run once a real gcov: task is confirmed to have run.
+  def build_reportinators(config)
+    reportinators = []
 
     # Run reports using gcovr
     if utility_enabled?( config, GCOV_UTILITY_NAME_GCOVR )

--- a/plugins/valgrind/lib/valgrind.rb
+++ b/plugins/valgrind/lib/valgrind.rb
@@ -125,7 +125,10 @@ class Valgrind < Plugin
         results: results
       }
 
-      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::NORMAL
+      # #1251 -- `:warnings` on the CLI maps to Verbosity::COMPLAIN (see VERBOSITY_OPTIONS
+      # in constants.rb), not NORMAL, so gating the all-clean case at NORMAL silently
+      # swallowed the Overall Test Summary at --verbosity=warnings even on a passing run.
+      verbosity = (results[:counts][:failed] > 0) ? Verbosity::ERRORS : Verbosity::COMPLAIN
 
       # Print unit test suite results
       @plugin_reportinator.run_test_results_report( hash, verbosity )

--- a/spec/system/deployment_as_gem_spec.rb
+++ b/spec/system/deployment_as_gem_spec.rb
@@ -87,6 +87,7 @@ ceedling_system_tests do
 
     describe "Verbosity and output" do
       test_case :test_project_with_named_verbosity
+      test_case :test_project_with_warnings_verbosity_prints_overall_summary
       test_case :test_project_with_numerical_verbosity
       test_case :report_tests_raw_output_log_plugin
     end

--- a/spec/system/deployment_as_vendor_spec.rb
+++ b/spec/system/deployment_as_vendor_spec.rb
@@ -90,6 +90,7 @@ ceedling_system_tests do
 
     describe "Verbosity and output" do
       test_case :test_project_with_named_verbosity
+      test_case :test_project_with_warnings_verbosity_prints_overall_summary
       test_case :test_project_with_numerical_verbosity
       test_case :report_tests_raw_output_log_plugin
     end

--- a/spec/system/gcov_deployment_spec.rb
+++ b/spec/system/gcov_deployment_spec.rb
@@ -33,6 +33,7 @@ ceedling_system_tests do
         end
       end
 
+      test_case :project_with_gcov_enabled_test_all_does_not_require_gcovr
       test_case :project_with_gcov_success
       test_case :project_with_gcov_fail
       test_case :gcov_console_report_with_system_header

--- a/spec/system/support/common_test_cases.rb
+++ b/spec/system/support/common_test_cases.rb
@@ -211,6 +211,29 @@ module CommonSystemTestCases
     end
   end
 
+  # #1251 -- the Overall Test Summary must still print at :warnings verbosity
+  # (`--verbosity=warnings`, Verbosity::COMPLAIN) on an all-passing run, not just
+  # when verbosity is :normal or higher, or when a test fails. Before this fix, the
+  # summary's own gate mistakenly required :normal, silently swallowing the summary
+  # on the (default) all-clean case at :warnings.
+  def test_project_with_warnings_verbosity_prints_overall_summary
+    @c.with_context do
+      Dir.chdir @proj_name do
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        output = @c.ceedling_build_exec("--verbosity=warnings")
+        expect(@c.last_exit_status).to eq(0)
+        expect(output).to match(/OVERALL TEST SUMMARY/)
+        expect(output).to match(/TESTED:\s+\d/)
+        expect(output).to match(/PASSED:\s+\d/)
+        expect(output).to match(/FAILED:\s+\d/)
+        expect(output).to match(/IGNORED:\s+\d/)
+      end
+    end
+  end
+
   def test_project_with_numerical_verbosity
     @c.with_context do
       Dir.chdir @proj_name do

--- a/spec/system/support/gcov_common_test_cases.rb
+++ b/spec/system/support/gcov_common_test_cases.rb
@@ -10,6 +10,38 @@ require_relative 'gcov_helpers'
 module GcovCommonTestCases
   include GcovHelpers
 
+  # #1252 -- Enabling the gcov plugin must not make gcovr a hard dependency of every
+  # build. Deliberately does NOT call prep_project_yml_for_coverage (which conditionally
+  # strips :utilities ➡️ gcovr when the host lacks a real gcovr) -- the point here is
+  # gcovr enabled in config but genuinely unreachable, reproducing #1252 regardless of
+  # what's actually installed on the machine running this spec.
+  def project_with_gcov_enabled_test_all_does_not_require_gcovr
+    @c.with_context do
+      Dir.chdir @proj_name do
+        @c.uncomment_project_yml_option_for_test("- gcov")
+        # Default :gcov ↳ :utilities already includes gcovr and :reports already
+        # includes HtmlBasic -- exactly the enabled-but-unused shape #1252 reported.
+        @c.merge_project_yml_for_test(
+          { :tools => { :gcov_gcovr_report => { :executable => 'nonexistent_gcovr_binary_for_1252_test' } } }
+        )
+        FileUtils.cp test_asset_path("example_file.h"), 'src/'
+        FileUtils.cp test_asset_path("example_file.c"), 'src/'
+        FileUtils.cp test_asset_path("test_example_file_success.c"), 'test/'
+
+        # An ordinary test:all run must succeed -- it never needs gcovr at all.
+        output = @c.ceedling_build_exec("test:all")
+        expect(@c.last_exit_status).to eq(0)
+        expect(output).to_not match(/nonexistent_gcovr_binary_for_1252_test/)
+
+        # A real gcov: build still needs gcovr and must still fail loudly when it's missing --
+        # the fix defers gcovr's tool validation, it doesn't remove it.
+        output = @c.ceedling_build_exec("gcov:all")
+        expect(@c.last_exit_status).to_not eq(0)
+        expect(output).to match(/nonexistent_gcovr_binary_for_1252_test/)
+      end
+    end
+  end
+
   def project_with_gcov_success
     @c.with_context do
       Dir.chdir @proj_name do

--- a/spec/units/generators/generator_test_results_backtrace_spec.rb
+++ b/spec/units/generators/generator_test_results_backtrace_spec.rb
@@ -130,6 +130,7 @@ SIMPLE_ASSERT_CRASH_OUTPUT =
 SIMPLE_PASS_OUTPUT   = "test_lib.c:3:test_empty:PASS\n---------\n1 Tests 0 Failures 0 Ignored\nOK\n"
 SIMPLE_FAIL_OUTPUT   = "test_lib.c:8:test_bad:FAIL: Expected 1 Was 2\n---------\n1 Tests 1 Failures 0 Ignored\nFAIL\n"
 SIMPLE_IGNORE_OUTPUT = "test_lib.c:12:test_skip:IGNORE\n---------\n1 Tests 0 Failures 1 Ignored\nOK\n"
+SIMPLE_IGNORE_WITH_MESSAGE_OUTPUT = "test_lib.c:12:test_skip:IGNORE: Not yet implemented\n---------\n1 Tests 0 Failures 1 Ignored\nOK\n"
 
 
 describe GeneratorTestResultsBacktrace do
@@ -253,6 +254,31 @@ describe GeneratorTestResultsBacktrace do
       @backtrace.do_gdb( filename, executable, shell_result, [companion_case] + test_cases, context: :test )
 
       expect(expected_output_lines).to include('test_lib.c:9:test_asserting:FAIL: Expected 1 Was 2')
+    end
+
+    # Ignored-crash false positive: a TEST_IGNORE_MESSAGE(...) test case carries a
+    # trailing message, same as FAIL. Before this fix, only FAIL tolerated one --
+    # a message-carrying IGNORE fell through to "unresolved" and was misreported
+    # as crash evidence (a second @file_wrapper.write, for a companion_case that
+    # never actually crashed).
+    it 'handles an IGNORE test case with a trailing message and does not write a log' do
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: GDB_NO_SIGNAL_OUTPUT, time: 0.1, exit_code: 1, stderr: '', status: @ok_status },
+        { output: "test_lib.c:9:test_asserting:IGNORE: Not yet implemented\n---------\n1 Tests 0 Failures 1 Ignored\nOK\n",
+          time: 0.1, exit_code: 0, stderr: '', status: @ok_status }
+      )
+
+      expect(@file_wrapper).to receive(:write).once.with(%r{test_crashes_elsewhere}, anything, anything)
+
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
+
+      @backtrace.do_gdb( filename, executable, shell_result, [companion_case] + test_cases, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:9:test_asserting:IGNORE: Not yet implemented')
     end
 
     it "does not trust a matched PASS line when the retry's own real status contradicts it" do
@@ -469,6 +495,31 @@ describe GeneratorTestResultsBacktrace do
       @backtrace.do_simple( filename, executable, shell_result, test_cases_ignore, context: :test )
 
       expect(expected_output_lines).to include('test_lib.c:12:test_skip:IGNORE')
+    end
+
+    # Ignored-crash false positive: a TEST_IGNORE_MESSAGE(...) test case carries a
+    # trailing message, same as FAIL (handled just above). Before this fix, only FAIL
+    # tolerated one -- a message-carrying IGNORE fell through to the "no result line"
+    # branch and was misreported as a second crashed test case (test_skip, alongside
+    # the real crash attributed to test_crashes_elsewhere).
+    it 'handles an IGNORE test case with a trailing message' do
+      test_cases_ignore = [{ test: 'test_crashes_elsewhere', line_number: 20 }, { test: 'test_skip', line_number: 12 }]
+
+      allow(@tool_executor).to receive(:exec).and_return(
+        { output: SIMPLE_ASSERT_CRASH_OUTPUT, time: 0.1, exit_code: 134, stderr: '', status: @ok_status },
+        { output: SIMPLE_IGNORE_WITH_MESSAGE_OUTPUT, time: 0.02, exit_code: 0, stderr: '', status: @ok_status }
+      )
+
+      expected_output_lines = []
+      allow(@generator_test_results).to receive(:regenerate_test_executable_stdout) do |**kwargs|
+        expected_output_lines = kwargs[:output]
+        'regenerated'
+      end
+
+      @backtrace.do_simple( filename, executable, shell_result, test_cases_ignore, context: :test )
+
+      expect(expected_output_lines).to include('test_lib.c:12:test_skip:IGNORE: Not yet implemented')
+      expect(expected_output_lines).to_not include(a_string_matching(/test_skip:FAIL/))
     end
 
     it "does not trust a matched PASS line when the retry's own real status contradicts it" do

--- a/spec/units/test_build_executor_spec.rb
+++ b/spec/units/test_build_executor_spec.rb
@@ -38,6 +38,8 @@ describe TestBuildExecutor do
     @tools_test_fixture                      = { name: 'fake fixture' }
     @tools_test_bare_includes_preprocessor   = { name: 'fake bare includes preprocessor' }
     @tools_test_file_directives_only_preprocessor = { name: 'fake directives-only preprocessor' }
+    @tools_test_backtrace_gdb                = { name: 'fake gdb backtrace' }
+    @tools_test_fixture_simple_backtrace     = { name: 'fake simple backtrace' }
 
     allow(@configurator).to receive(:extension_assembly).and_return( FilenameExtension.new('.asm') )
     allow(@configurator).to receive(:tools_test_compiler).and_return( @tools_test_compiler )
@@ -46,6 +48,13 @@ describe TestBuildExecutor do
     allow(@configurator).to receive(:tools_test_fixture).and_return( @tools_test_fixture )
     allow(@configurator).to receive(:tools_test_bare_includes_preprocessor).and_return( @tools_test_bare_includes_preprocessor )
     allow(@configurator).to receive(:tools_test_file_directives_only_preprocessor).and_return( @tools_test_file_directives_only_preprocessor )
+    # tools_test_backtrace_gdb is deliberately NOT stubbed here -- the real Configurator
+    # only defines it at all when :use_backtrace is :gdb (see test_build_executor.rb's
+    # own comment at its one call site), so leaving it unstubbed here means any example
+    # that calls it without :gdb mode explicitly set up fails loudly, the same way the
+    # real Configurator would raise NoMethodError.
+    allow(@configurator).to receive(:tools_test_fixture_simple_backtrace).and_return( @tools_test_fixture_simple_backtrace )
+    allow(@configurator).to receive(:project_config_hash).and_return( { project_use_backtrace: :simple } )
     allow(@configurator).to receive(:test_build_preprocess_force_fallback).and_return( false )
     allow(@configurator).to receive(:project_use_mocks).and_return( false )
     allow(@configurator).to receive(:project_use_exceptions).and_return( false )
@@ -568,7 +577,7 @@ describe TestBuildExecutor do
       expect(@dependinator).to receive(:register).with(
         @fixture_target,
         files: ['build/a_test.out'],
-        meta:  { tools: [swapped_tool] }
+        meta:  hash_including( tools: [swapped_tool] )
       )
       expect(@generator).to receive(:generate_test_results) do |**args|
         expect( args[:tool] ).to eq( swapped_tool )
@@ -584,7 +593,55 @@ describe TestBuildExecutor do
       expect(@dependinator).to receive(:register).with(
         @fixture_target,
         files: ['build/a_test.out'],
-        meta:  { tools: [@tools_test_fixture] }
+        meta:  hash_including( tools: [@tools_test_fixture] )
+      )
+
+      @executor.stage_execute( @state )
+    end
+
+    # :use_backtrace doesn't swap the fixture tool itself -- it only selects what
+    # generator.rb does *after* a crash is detected (see this call site's own comment
+    # in test_build_executor.rb). Without capturing it (and the tool config(s) it
+    # drives) as meta here, toggling it would never invalidate a cached-fresh
+    # fixture_target, so a delta build would keep reusing a stale crash-diagnosis result.
+    it "registers :use_backtrace and the gdb backtrace tool as meta when :use_backtrace is :gdb" do
+      @testable.executable_rebuilt = false
+      allow(@generator).to receive(:generate_test_results)
+      allow(@configurator).to receive(:project_config_hash).and_return( { project_use_backtrace: :gdb } )
+      allow(@configurator).to receive(:tools_test_backtrace_gdb).and_return( @tools_test_backtrace_gdb )
+
+      expect(@dependinator).to receive(:register).with(
+        @fixture_target,
+        files: ['build/a_test.out'],
+        meta:  {
+          tools: [@tools_test_fixture],
+          use_backtrace: :gdb,
+          backtrace_tools: [@tools_test_fixture_simple_backtrace, @tools_test_backtrace_gdb]
+        }
+      )
+
+      @executor.stage_execute( @state )
+    end
+
+    # Regression guard: tools_test_backtrace_gdb only exists on the real Configurator
+    # when :use_backtrace is :gdb (Configurator only merges its defaults in that case) --
+    # calling it unconditionally raised NoMethodError against a real project configured
+    # for :simple or :none. @configurator here is a plain double with no stub for
+    # tools_test_backtrace_gdb, so it fails the same way a real run would if this
+    # regressed.
+    it "registers only the simple backtrace tool as meta, and never reads the gdb tool's config, when :use_backtrace is :simple" do
+      @testable.executable_rebuilt = false
+      allow(@generator).to receive(:generate_test_results)
+      allow(@configurator).to receive(:project_config_hash).and_return( { project_use_backtrace: :simple } )
+
+      expect(@dependinator).to receive(:register).with(
+        @fixture_target,
+        files: ['build/a_test.out'],
+        meta:  {
+          tools: [@tools_test_fixture],
+          use_backtrace: :simple,
+          backtrace_tools: [@tools_test_fixture_simple_backtrace]
+        }
       )
 
       @executor.stage_execute( @state )


### PR DESCRIPTION
## Summary

`next_version` mirror of PR #1253's three bug fixes, plus one delta-build gap unique to this branch (no delta builds on master):

1. **#1251** — `--verbosity=warnings` no longer printed the Overall Test Summary on an all-passing run. Fixed in all four plugins sharing the ternary here (`report_tests_stdout_plugin.rb`, `gcov.rb`, `valgrind.rb`, and `bullseye.rb` — this fourth one only shares the bug's exact shape on this branch).
2. **#1252** — enabling the `gcov` plugin made `gcovr` a hard dependency of any build. Same fix as #1253: gcovr/ReportGenerator tool validation deferred to `generate_coverage_reports()`.
3. **Ignored-test false crash** — same `do_gdb`/`do_simple` regex widening as #1253.
4. **`:use_backtrace` delta-build gap** (new to this branch) — `TestBuildExecutor#stage_execute`'s fixture registration only captured the fixture tool as dependency-tracker meta, so toggling `:project ↳ :use_backtrace` (or editing either backtrace tool's own config) never invalidated a cached-fresh fixture target. Added `use_backtrace` and the backtrace tool config(s) it actually drives to that same registration.

Caught and fixed a real regression while verifying item 4: `tools_test_backtrace_gdb` only exists on `Configurator` when `:use_backtrace` is `:gdb` (its defaults are conditionally merged) — reading it unconditionally crashed every non-`:gdb` build with `NoMethodError`. The unit tests alone missed this (an over-stubbed double answered the method regardless); the real system-test suite caught it. Fixed by only reading that tool's config when `:use_backtrace` is actually `:gdb`, with a dedicated regression-guard unit spec.

## Verification

- `rake specs:units` — 2853 examples, 0 failures.
- Full crash-handling, GDB-backtrace, delta-build, gcov, valgrind, and bullseye system suites run inside `madsciencelab-plugins` — all green, no regressions.
- Each fix is test-first: a new/extended spec reproduces the bug against the pre-fix code, then passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)