### PR TITLE
#1250: accept ceedling.yml as an alternate default project file

### DIFF
--- a/bin/cli.rb
+++ b/bin/cli.rb
@@ -224,6 +224,7 @@ module CeedlingTasks
     method_option :local, :type => :boolean, :default => false, :desc => DOC_LOCAL_FLAG
     method_option :docs, :type => :boolean, :default => false, :desc => DOC_DOCS_FLAG
     method_option :configs, :type => :boolean, :default => true, :desc => "Install starter project file in project root"
+    method_option :ceedling_yml, :type => :boolean, :default => false, :desc => "Name the starter project file ceedling.yml instead of project.yml"
     method_option :force, :type => :boolean, :default => false, :desc => "Ignore any existing project and recreate destination"
     method_option :debug, :type => :boolean, :default => false, :hide => true
     method_option :gitsupport, :type => :boolean, :default => false, :desc => "Create .gitignore / .gitkeep files for convenience"

--- a/bin/cli_handler.rb
+++ b/bin/cli_handler.rb
@@ -93,8 +93,10 @@ class CliHandler
     # If destination is nil, assume it's the working directory
     dest ||= '.'
 
-    # Check for existing project (unless --force)
-    if @helper.project_exists?( dest, :|, DEFAULT_PROJECT_FILENAME, 'src', 'test' )
+    # Check for existing project (unless --force) -- #1250: either default project
+    # filename counts, so `ceedling new` doesn't silently overwrite an existing
+    # ceedling.yml-based project just because it's looking for project.yml.
+    if @helper.project_exists?( dest, :|, DEFAULT_PROJECT_FILENAME, ALTERNATE_PROJECT_FILENAME, 'src', 'test' )
       msg = "It appears a project already exists at \"#{dest}/\"! Use --force to destroy it and create a new project."
       raise msg
     end unless options[:force]
@@ -117,7 +119,7 @@ class CliHandler
     @helper.vendor_tools( app_cfg[:ceedling_root_path], dest ) if options[:local]
 
     # Copy / set up project file
-    @helper.create_project_file( dest, options[:local], ceedling_tag ) if options[:configs]
+    @helper.create_project_file( dest, options[:local], ceedling_tag, ceedling_yml: options[:ceedling_yml] ) if options[:configs]
     
     # Copy in documentation
     @helper.copy_docs( app_cfg[:ceedling_root_path], File.join( dest, DOCS_SUBDIR ) ) if options[:docs]

--- a/bin/cli_helper.rb
+++ b/bin/cli_helper.rb
@@ -74,8 +74,13 @@ class CliHelper
   end
 
 
-  def create_project_file(dest, local, ceedling_tag)
-    project_filepath = File.join( dest, DEFAULT_PROJECT_FILENAME )
+  # #1250 -- `ceedling_yml:` names the generated file ALTERNATE_PROJECT_FILENAME
+  # (ceedling.yml) instead of the default DEFAULT_PROJECT_FILENAME (project.yml). Only
+  # the destination filename changes -- both are cloned from the same one template
+  # asset; no second template file exists or is needed.
+  def create_project_file(dest, local, ceedling_tag, ceedling_yml: false)
+    filename = ceedling_yml ? ALTERNATE_PROJECT_FILENAME : DEFAULT_PROJECT_FILENAME
+    project_filepath = File.join( dest, filename )
     source_filepath = File.join( 'assets', 'features', DEFAULT_PROJECT_FILENAME )
 
     # Clone the project file

--- a/bin/projectinator.rb
+++ b/bin/projectinator.rb
@@ -12,6 +12,9 @@ class Projectinator
 
   PROJECT_FILEPATH_ENV_VAR = 'CEEDLING_PROJECT_FILE'
   DEFAULT_PROJECT_FILEPATH = './' + DEFAULT_PROJECT_FILENAME
+  # #1250 -- self-documenting alternative default project filename, tried only
+  # alongside DEFAULT_PROJECT_FILEPATH during default discovery below.
+  ALTERNATE_PROJECT_FILEPATH = './' + ALTERNATE_PROJECT_FILENAME
   DEFAULT_YAML_FILE_EXTENSION = '.yml'
 
   constructor :file_wrapper, :path_validator, :yaml_wrapper, :loginator
@@ -20,7 +23,8 @@ class Projectinator
   # Precendence of attempts:
   #  1. Explcit flepath from argument
   #  2. Environment variable
-  #  3. Default filename in working directory
+  #  3. Default filename in working directory (project.yml or ceedling.yml --
+  #     #1250 -- an error if both exist, since neither is "preferred" over the other)
   # Returns:
   #  - Absolute path of project file found and used
   #  - Config hash loaded from project file
@@ -45,17 +49,37 @@ class Projectinator
       config[:history] = { config: [{type: :file, path: filepath, mechanism: :project}] }
       return _filepath, config
 
-    # Final option: default filepath
-    elsif @file_wrapper.exist?( DEFAULT_PROJECT_FILEPATH )
-      filepath = DEFAULT_PROJECT_FILEPATH
-      _filepath = File.expand_path( filepath )
-      config = load_and_log( _filepath, "from working directory", silent )
-      config[:history] = { config: [{type: :file, path: filepath, mechanism: :project}] }
-      return _filepath, config
-
-    # If no user-provided filepath and the default filepath does not exist, we have a big problem
+    # Final option: default filepath(s) in the working directory
     else
-      raise "No project filepath provided and default #{DEFAULT_PROJECT_FILEPATH} not found"
+      default_exists     = @file_wrapper.exist?( DEFAULT_PROJECT_FILEPATH )
+      alternate_exists    = @file_wrapper.exist?( ALTERNATE_PROJECT_FILEPATH )
+
+      # #1250 -- two default project files in one directory is almost certainly a
+      # mistake (which one would silently win?) -- error out rather than guess.
+      if default_exists && alternate_exists
+        raise CeedlingException.new( ambiguous_default_message() )
+      end
+
+      filepath =
+        if default_exists
+          DEFAULT_PROJECT_FILEPATH
+        elsif alternate_exists
+          ALTERNATE_PROJECT_FILEPATH
+        end
+
+      if filepath
+        _filepath = File.expand_path( filepath )
+        config = load_and_log( _filepath, "from working directory", silent )
+        config[:history] = { config: [{type: :file, path: filepath, mechanism: :project}] }
+        return _filepath, config
+
+      # If no user-provided filepath and neither default filepath exists, we have a big problem
+      else
+        raise CeedlingException.new(
+          "No project filepath provided and neither default " \
+          "#{DEFAULT_PROJECT_FILEPATH} nor #{ALTERNATE_PROJECT_FILEPATH} found"
+        )
+      end
     end
   end
 
@@ -89,6 +113,13 @@ class Projectinator
   ### Private ###
 
   private
+
+  # #1250 -- mirrors PathMatcher's own ambiguous-file message style (path_matcher.rb).
+  def ambiguous_default_message
+    "Ambiguous default project file: both #{DEFAULT_PROJECT_FILEPATH} and " \
+    "#{ALTERNATE_PROJECT_FILEPATH} exist in the working directory. " \
+    "Remove or rename one, or specify which to use with --project/-p."
+  end
 
   def load_and_log(filepath, method, silent)
     begin

--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -121,6 +121,11 @@ MIXIN_SIGIL_INLINE_YAML = '='
 MIXIN_SIGIL_FILEPATH    = '@'
 
 DEFAULT_PROJECT_FILENAME = 'project.yml'
+# #1250 -- self-documenting alternative to the generic DEFAULT_PROJECT_FILENAME, tried
+# during default discovery only (Projectinator#load) when no --project/-p or
+# CEEDLING_PROJECT_FILE was given. Neither name is "preferred" over the other -- either
+# alone is used as found; both present is an error (see Projectinator#load).
+ALTERNATE_PROJECT_FILENAME = 'ceedling.yml'
 DEFAULT_BUILD_LOGS_PATH = 'logs'
 
 DOCS_SITE_LOCAL_PATH = 'site-local'

--- a/spec/system/cli_surface_spec.rb
+++ b/spec/system/cli_surface_spec.rb
@@ -163,6 +163,22 @@ ceedling_system_tests do
         expect(File.exist?(File.join(@proj_name, 'marker.txt'))).to eq(false)
       end
     end
+
+    # #1250 -- `--ceedling-yml` names the generated starter file ceedling.yml
+    # instead of project.yml; the default (no flag, exercised by every other
+    # example in this block via the outer `before`) is unchanged.
+    it "generates ceedling.yml instead of project.yml under --ceedling-yml" do
+      @c.with_context do
+        alt_proj_name = "#{@proj_name}_ceedling_yml"
+        output = @c.ceedling_appcmd_exec("new #{alt_proj_name} --ceedling-yml")
+
+        expect(@c.last_exit_status).to eq(0)
+        Dir.chdir alt_proj_name do
+          expect(File.exist?("ceedling.yml")).to eq true
+          expect(File.exist?("project.yml")).to eq false
+        end
+      end
+    end
   end
 
   describe "No project required" do

--- a/spec/units/bin/projectinator_spec.rb
+++ b/spec/units/bin/projectinator_spec.rb
@@ -93,6 +93,45 @@ describe Projectinator do
       }.to raise_error( /No project filepath provided/ )
     end
 
+    # #1250 -- ceedling.yml as an alternative default project filename, self-documenting
+    # in a way the generic project.yml isn't. Default discovery only (no --project/-p,
+    # no CEEDLING_PROJECT_FILE) -- an explicit filepath or env var always wins outright,
+    # as already covered above.
+    it 'falls back to ceedling.yml in the working directory when project.yml is absent' do
+      allow(@file_wrapper).to receive(:exist?).with('./project.yml').and_return(false)
+      allow(@file_wrapper).to receive(:exist?).with('./ceedling.yml').and_return(true)
+      allow(@yaml_wrapper).to receive(:load).with(File.expand_path('./ceedling.yml')).and_return({:project => {}})
+
+      filepath, config = @projectinator.load
+
+      expect(filepath).to eq(File.expand_path('./ceedling.yml'))
+      expect(config[:history][:config].first[:mechanism]).to eq(:project)
+    end
+
+    it 'raises a CeedlingException naming both files when project.yml and ceedling.yml both exist, under default discovery' do
+      allow(@file_wrapper).to receive(:exist?).with('./project.yml').and_return(true)
+      allow(@file_wrapper).to receive(:exist?).with('./ceedling.yml').and_return(true)
+
+      expect {
+        @projectinator.load
+      }.to raise_error( CeedlingException, a_string_matching(/project\.yml/).and(a_string_matching(/ceedling\.yml/)) )
+    end
+
+    it 'does not raise the ambiguity error when only ceedling.yml exists' do
+      allow(@file_wrapper).to receive(:exist?).with('./project.yml').and_return(false)
+      allow(@file_wrapper).to receive(:exist?).with('./ceedling.yml').and_return(true)
+      allow(@yaml_wrapper).to receive(:load).and_return({:project => {}})
+
+      expect { @projectinator.load }.to_not raise_error
+    end
+
+    it 'ignores ceedling.yml (no ambiguity error) when an explicit filepath argument is given, even if both default files exist' do
+      allow(@file_wrapper).to receive(:exist?).and_return(true)
+      allow(@yaml_wrapper).to receive(:load).and_return({:project => {}})
+
+      expect { @projectinator.load( filepath: 'custom.yml' ) }.to_not raise_error
+    end
+
     it 'treats a blank YAML file as an empty config hash rather than nil' do
       allow(@yaml_wrapper).to receive(:load).and_return(nil)
 


### PR DESCRIPTION
## Summary

Implements #1250 per your three decisions on the issue:

**(a) Ambiguity when both exist.** `Projectinator#load`'s default-discovery branch (no `--project`/`-p`, no `CEEDLING_PROJECT_FILE`) now checks both `project.yml` and the new `ceedling.yml`. Either alone is used as found — neither is "preferred." Both present raises a `CeedlingException` naming both paths, mirroring `PathMatcher`'s own ambiguous-file message style.

**(b) `ceedling new` flag.** Keeps `project.yml` as the default (conservative choice). New opt-in boolean flag `--ceedling-yml` names the generated starter file `ceedling.yml` instead — both cloned from the same one template asset. `ceedling new`'s existing-project pre-flight check now also recognizes `ceedling.yml`, so it won't silently overwrite an existing `ceedling.yml`-based project without `--force`.

**(c) No dotfile support.** Confirmed nothing in the codebase references `.ceedling.yml` — nothing to implement or guard against.

Documentation updates (`docs/mkdocs/configuration/loading.md`, `docs/mkdocs/getting-started/command-line.md`) are deferred to the batch's final documentation phase, per your instruction to collect all doc changes together for review.

## Verification

- `rake specs:units` — 2853 examples, 0 failures.
- New unit specs (`projectinator_spec.rb`): falls back to `ceedling.yml` when `project.yml` absent, raises on both present, doesn't raise when only one exists, explicit `--project`/`-p` bypasses the check entirely.
- New system-test case (`cli_surface_spec.rb`): `new PROJ --ceedling-yml` produces `ceedling.yml`, not `project.yml` — reproduces the bug (unknown CLI switch) against the pre-fix code, passes after.
- Full `cli_surface_spec.rb`, plus project-creation/version-reporting system specs, run inside `madsciencelab-plugins` — all green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)