### PR TITLE
🐛 Fix #104: literal [ ] in paths silently break the build

### DIFF
--- a/lib/ceedling/config/configurator_builder.rb
+++ b/lib/ceedling/config/configurator_builder.rb
@@ -359,8 +359,11 @@ class ConfiguratorBuilder
     in_hash[:collection_paths_test].each do |path|
       # A test file's basename carries the project's test-file prefix ahead of whichever
       # source extension is in play, so the prefix is folded into the glob fragment itself.
+      # #104 -- `path` is an already-resolved, concrete directory that may contain a
+      # literal `[`/`]` (e.g. a test file living directly under a bracket-named
+      # directory); FilePathUtils.glob escapes it before FileList#include re-globs it.
       in_hash[:extension_source].each do |ext|
-        all_tests.include( File.join(path, "#{in_hash[:project_test_file_prefix]}*#{ext}") )
+        all_tests.include( FilePathUtils.glob(path, "#{in_hash[:project_test_file_prefix]}*#{ext}") )
       end
     end
 
@@ -459,8 +462,11 @@ class ConfiguratorBuilder
     paths << in_hash[:project_build_vendor_cexception_path] if (in_hash[:project_use_exceptions])
 
     # Collect vendor framework code files
+    # #104 -- `path` is a vendor path rooted at the project directory, which may
+    # itself sit under a bracket-named directory (the original bug report's own
+    # scenario); FilePathUtils.glob escapes it before FileList#include re-globs it.
     paths.each do |path|
-      release_input.include( File.join(path, '*' + EXTENSION_CORE_SOURCE) )
+      release_input.include( FilePathUtils.glob(path, '*' + EXTENSION_CORE_SOURCE) )
     end
 
     # Collect source files
@@ -493,8 +499,11 @@ class ConfiguratorBuilder
     paths << in_hash[:project_build_vendor_cmock_path]      if (in_hash[:project_use_mocks])
 
     # Collect vendor framework code files
+    # #104 -- `path` is a vendor path rooted at the project directory, which may
+    # itself sit under a bracket-named directory (the original bug report's own
+    # scenario); FilePathUtils.glob escapes it before FileList#include re-globs it.
     paths.each do |path|
-      all_input.include( File.join(path, '*' + EXTENSION_CORE_SOURCE) )
+      all_input.include( FilePathUtils.glob(path, '*' + EXTENSION_CORE_SOURCE) )
     end
 
     paths =
@@ -574,8 +583,11 @@ class ConfiguratorBuilder
     paths = get_vendor_paths(in_hash)
 
     # Collect vendor framework code files
+    # #104 -- `path` is a vendor path rooted at the project directory, which may
+    # itself sit under a bracket-named directory (the original bug report's own
+    # scenario); FilePathUtils.glob escapes it before FileList#include re-globs it.
     paths.each do |path|
-      filelist.include( File.join(path, '*' + EXTENSION_CORE_SOURCE) )
+      filelist.include( FilePathUtils.glob(path, '*' + EXTENSION_CORE_SOURCE) )
     end
 
     # Force Rake::FileList to expand patterns to ensure it happens (FileList is a bit unreliable)

--- a/lib/ceedling/config/configurator_plugins.rb
+++ b/lib/ceedling/config/configurator_plugins.rb
@@ -6,6 +6,7 @@
 # =========================================================================
 
 require 'ceedling/constants'
+require 'ceedling/file_path_utils'
 
 class ConfiguratorPlugins
 
@@ -43,14 +44,21 @@ class ConfiguratorPlugins
       config[:plugins][:load_paths].each do |root|
         path = File.join(root, plugin)
 
+        # #104 -- `path` is real, unescaped, and used as-is below (add_load_path,
+        # plugin_paths[...]) -- only this glob-pattern-only variant needs a literal
+        # `[`/`]` in the user's own :load_paths: entry escaped, so it doesn't get
+        # misread as glob character-class syntax by Dir.glob (via directory_listing)
+        # and silently fail to match a real, existing plugin directory.
+        # FilePathUtils.glob handles the escaping itself.
+
         # Ceedling Ruby-based hash defaults plugin (or config for Ceedling programmatic plugin)
-        is_config_plugin       = ( not @file_wrapper.directory_listing( File.join( path, 'config', '*.rb' ) ).empty? )
+        is_config_plugin       = ( not @file_wrapper.directory_listing( FilePathUtils.glob( path, 'config', '*.rb' ) ).empty? )
 
         # Ceedling programmatic plugin
-        is_programmatic_plugin = ( not @file_wrapper.directory_listing( File.join( path, 'lib', '*.rb' ) ).empty? )
+        is_programmatic_plugin = ( not @file_wrapper.directory_listing( FilePathUtils.glob( path, 'lib', '*.rb' ) ).empty? )
 
         # Ceedling Rake plugin
-        is_rake_plugin         = ( not @file_wrapper.directory_listing( File.join( path, '*.rake' ) ).empty? )
+        is_rake_plugin         = ( not @file_wrapper.directory_listing( FilePathUtils.glob( path, '*.rake' ) ).empty? )
 
         if (is_config_plugin or is_programmatic_plugin or is_rake_plugin)
           plugin_paths[(plugin + '_path').to_sym] = path

--- a/lib/ceedling/config/configurator_validator.rb
+++ b/lib/ceedling/config/configurator_validator.rb
@@ -83,7 +83,10 @@ class ConfiguratorValidator
       # Expand paths using Ruby's Dir.glob()
       #  - A simple path will yield that path
       #  - A path glob will expand to one or more paths
-      _reformed = FilePathUtils::reform_subdirectory_glob( _path )
+      # #104 -- FilePathUtils.subdirectory_glob escapes a literal `[`/`]` in the
+      # user's own path before reforming the glob suffix, so it's matched literally
+      # rather than misread as glob character-class syntax.
+      _reformed = FilePathUtils.subdirectory_glob( _path )
       @file_wrapper.directory_listing( _reformed ).each do |entry|
         # For each result, add it to the working list *if* it's a directory
         dirs << entry if @file_wrapper.directory?(entry)
@@ -129,7 +132,9 @@ class ConfiguratorValidator
         next # Skip to next path
       end      
 
-      filelist = @file_wrapper.instantiate_file_list(_path)
+      # #104 -- escape a literal `[`/`]` in the user's own path so it's matched
+      # literally rather than misread as glob character-class syntax.
+      filelist = @file_wrapper.instantiate_file_list( FilePathUtils.escape_glob_brackets( _path ) )
 
       # If file list is empty, complain
       if (filelist.size == 0)

--- a/lib/ceedling/constants.rb
+++ b/lib/ceedling/constants.rb
@@ -86,7 +86,13 @@ CEEDLING_HEADER_FILEPATH = CEEDLING_HEADER_FILENAME # lib/ceedling/
 PARTIAL_FILENAME_PREFIX  = 'ceedling_partial_'
 
 class PATTERNS
-  GLOB = /[\*\?\{\}\[\]]/
+  # #104 -- `[`/`]` deliberately excluded: they're legal filename characters
+  # (common on Windows especially) but never a documented Ceedling glob feature
+  # (unlike `*`/`?`/`{`/`}`, Ceedling's own real wildcard syntax) -- including them
+  # here meant a literal bracket in a real directory name was silently treated as
+  # "where the glob starts," truncating path validation to the wrong ancestor
+  # directory. See FilePathUtils.no_decorators, this regex's one consumer.
+  GLOB = /[\*\?\{\}]/
 
   RUBY_STRING_REPLACEMENT = /#\{.+\}/
   TOOL_EXECUTOR_ARGUMENT_REPLACEMENT = /(\$\{(\d+)\})/

--- a/lib/ceedling/file_finder.rb
+++ b/lib/ceedling/file_finder.rb
@@ -10,6 +10,7 @@ require 'rake' # for adding ext() method to string
 require 'ceedling/exceptions'
 require 'ceedling/path_matcher'
 require 'ceedling/path_mirror'
+require 'ceedling/file_path_utils'
 
 class FileFinder
 
@@ -101,10 +102,14 @@ class FileFinder
     if (!release) and
        (source_file =~ /^#{Regexp.escape(@configurator.project_test_file_prefix)}.+#{Regexp.escape(@configurator.test_runner_file_suffix)}$/)
       _source_file = source_file + EXTENSION_CORE_SOURCE
+      # #104 -- runner_scope_dir mirrors the test's own subdirectory, which may itself
+      # contain a literal `[`/`]` (e.g. a test living directly under a bracket-named
+      # directory); FilePathUtils.glob escapes it before Dir.glob (via directory_listing)
+      # re-interprets it.
       found_file =
         @file_finder_helper.find_file_in_collection(
           _source_file,
-          @file_wrapper.directory_listing( File.join(runner_scope_dir(test_context), '*') ),
+          @file_wrapper.directory_listing( FilePathUtils.glob(runner_scope_dir(test_context), '*') ),
           complain)
 
     # Generated mocks -- scoped to this test's own mock subtree so another test's

--- a/lib/ceedling/file_path_collection_utils.rb
+++ b/lib/ceedling/file_path_collection_utils.rb
@@ -37,7 +37,12 @@ class FilePathCollectionUtils
       _path = FilePathUtils.no_aggregation_decorators( path )
 
       # If it's a glob, modify it for Ceedling's recursive subdirectory convention
-      _reformed = FilePathUtils::reform_subdirectory_glob( _path )
+      # #104 -- FilePathUtils.subdirectory_glob escapes a literal `[`/`]` in the
+      # user's own path before reforming the glob suffix, so it's matched literally
+      # rather than misread as glob character-class syntax. `_path` itself
+      # (unescaped) is still used below for suffix checks and decorator-stripping,
+      # neither of which is a glob operation.
+      _reformed = FilePathUtils.subdirectory_glob( _path )
 
       # Expand paths using Ruby's Dir.glob()
       #  - A simple path will yield that path
@@ -116,7 +121,9 @@ class FilePathCollectionUtils
 
       # Expand path by pattern as needed and add only filepaths to working list.
       # Sort for deterministic ordering — see collect_paths and Github Issue #860
-      @file_wrapper.directory_listing( path ).sort.each do |entry|
+      # #104 -- escape a literal `[`/`]` in the user's own path so it's matched
+      # literally rather than misread as glob character-class syntax.
+      @file_wrapper.directory_listing( FilePathUtils.escape_glob_brackets( path ) ).sort.each do |entry|
         filepaths << File.expand_path( entry ) if !@file_wrapper.directory?( entry )
       end
 
@@ -133,7 +140,13 @@ class FilePathCollectionUtils
     result_paths = (plus - minus).to_a
     result_paths.map! {|path| shortest_path_from_working(path) }
 
-    result = FileList.new( result_paths )
+    # #104 -- every entry here is already a concrete, real file (nothing left to glob-
+    # expand -- this method's whole job already resolved it from any actual glob), but
+    # plain FileList.new/#include re-interprets each entry as a glob pattern to
+    # re-resolve via Dir.glob regardless, silently dropping a literal `[`/`]` survivor
+    # all over again. FileWrapper#instantiate_file_list_literal (`<<`, not `.new`) adds
+    # every entry as-is, with no glob interpretation at all.
+    result = @file_wrapper.instantiate_file_list_literal( result_paths )
     result.resolve()  # Force expansion to prevent race conditions in threaded context
     return result
   end

--- a/lib/ceedling/file_path_utils.rb
+++ b/lib/ceedling/file_path_utils.rb
@@ -81,6 +81,40 @@ class FilePathUtils
     return path[0..(find_index-1)]
   end
 
+  # #104 -- `[`/`]` are legal filename characters (Windows especially) but Ruby's
+  # `Dir.glob`/`File.fnmatch` treat an unescaped `[...]` as character-class glob
+  # syntax, so a literal bracket in a real directory name silently fails to match
+  # its own glob pattern. Ceedling has no glob-escape helper of its own and Ruby
+  # provides none for this (unlike `Regexp.escape` for regexes), so this backslash-
+  # escapes just those two characters. Callers apply this only to the raw,
+  # user-supplied path *segment* of a pattern they're about to build -- never to a
+  # glob suffix Ceedling itself appends (e.g. `'*.rb'`/`'**/*.c'`), which must stay
+  # glob-active.
+  def self.escape_glob_brackets(path)
+    return path if path.nil?
+    return path.gsub(/([\[\]])/) { "\\#{$1}" }
+  end
+
+  # #104 -- the single, canonical way to turn a (possibly bracket-containing) base
+  # directory path into a glob pattern safe for anything that (re-)interprets it as
+  # a glob (`FileWrapper#directory_listing`, `Rake::FileList#include`,
+  # `FileWrapper#instantiate_file_list`). `escape_glob_brackets` alone only protects
+  # a call site that remembers to invoke it -- several didn't, because building the
+  # pattern via a bare `File.join(path, suffix)` gives no signal escaping was ever
+  # needed. Routing every base-path-plus-suffix glob pattern through this instead
+  # makes that omission structurally harder to repeat.
+  def self.glob(base_path, *suffix)
+    return File.join( escape_glob_brackets( base_path ), *suffix )
+  end
+
+  # Same escaping guarantee as `glob`, for the one caller shape that reforms
+  # Ceedling's own trailing `/**` recursive-directory convention instead of
+  # appending a suffix. `reform_subdirectory_glob` only inspects/appends based on
+  # a trailing `**`, so escaping first doesn't interfere with its own logic.
+  def self.subdirectory_glob(path)
+    return reform_subdirectory_glob( escape_glob_brackets( path ) )
+  end
+
   # Return whether the given path is to be aggregated (no aggregation modifier defaults to same as +:).
   # nil is treated as an additive (non-excluding) path.
   def self.add_path?(path)
@@ -433,15 +467,25 @@ class FilePathUtils
   # same-named object from the first. A file matching none of `roots` (a mock's own bare
   # basename, a vendor framework file, the test file itself under its own build path) is
   # left flat under `root`.
+  # #104 -- `files` (and, below, the `objects` this method itself computes) are already
+  # fully concrete filepaths -- nothing to glob-expand, no search to perform -- but
+  # `objects`' own entries in particular don't exist on disk yet at all (they're this
+  # very build's *about-to-be-compiled* output). FileWrapper#instantiate_file_list
+  # (Rake::FileList.new/#include) treats every entry as a glob pattern to resolve via
+  # Dir.glob regardless, which can only ever match files that already exist -- so a
+  # not-yet-existing object path is silently dropped outright, independent of whether
+  # it contains a literal `[`/`]`. FileWrapper#instantiate_file_list_literal (`<<`, not
+  # `.new`/`.include`) adds every entry as-is, with no glob interpretation at all -- the
+  # correct construction for a list that's already the real, final answer.
   def mirror_build_objects(files, root:, ext:, roots:)
     clean_roots = PathMirror.clean_roots( roots )
 
-    objects = @file_wrapper.instantiate_file_list(files).map do |file|
+    objects = @file_wrapper.instantiate_file_list_literal(files).map do |file|
       subdir   = PathMirror.relative_subdir_from_clean_roots( file, clean_roots )
       basename = File.basename(file).ext(ext)
       subdir.empty? ? File.join(root, basename) : File.join(root, subdir, basename)
     end
-    return @file_wrapper.instantiate_file_list(objects)
+    return @file_wrapper.instantiate_file_list_literal( objects )
   end
 
 end

--- a/lib/ceedling/file_wrapper.rb
+++ b/lib/ceedling/file_wrapper.rb
@@ -164,6 +164,23 @@ class FileWrapper
     return FileList.new(files)
   end
 
+  # #104 -- `FileList.new(files)` (and `FileList#include`) treats every string in `files`
+  # as a glob *pattern* to (re-)resolve against the real filesystem via Dir.glob, even
+  # when the caller already has a fully concrete, computed filepath in hand -- so a
+  # literal `[`/`]` surviving in one is silently dropped by that re-resolution, and a
+  # not-yet-existing path (e.g. an object file this same build is about to create) is
+  # dropped outright regardless of brackets, since Dir.glob only ever matches files that
+  # already exist. `<<` (unlike `.new`/`.include`) adds an entry to a FileList literally,
+  # with no glob interpretation at all -- the right tool whenever every entry is already
+  # exactly the real path wanted, existing or not. Only use this for that case; callers
+  # that actually want pattern matching (a directory to search, a real user-authored
+  # glob) still want `instantiate_file_list` + `.include`, same as always.
+  def instantiate_file_list_literal(files=[])
+    list = FileList.new
+    files.each { |file| list << file }
+    return list
+  end
+
   def mkdir(folder)
     check_path_length(folder, origin: 'FileWrapper#mkdir')
     return FileUtils.mkdir_p(folder)

--- a/lib/ceedling/filename_extension.rb
+++ b/lib/ceedling/filename_extension.rb
@@ -5,6 +5,8 @@
 #   SPDX-License-Identifier: MIT
 # =========================================================================
 
+require 'ceedling/file_path_utils'
+
 # A configured filename-extension setting for one file type (source, header,
 # assembly, and so on). A project may name a file type with a single
 # extension or with several -- an assembly file might be `.s` or `.S`, for
@@ -60,8 +62,16 @@ class FilenameExtension
   # Wildcard glob fragments for every configured extension, for building
   # a `path/*ext` search pattern per extension when collecting whole file
   # lists rather than resolving one specific candidate filename.
+  #
+  # #104 -- `path` here is an already-resolved, concrete directory (the output of
+  # FilePathCollectionUtils#collect_paths, not a user-typed glob), but every caller
+  # hands the result straight to Rake::FileList#include, which globs it again --
+  # so a literal `[`/`]` surviving from the real directory name (collect_paths'
+  # own fix escapes brackets only for *its own* glob, not this next one) still
+  # needs escaping here, or the file list silently comes up empty for that path.
+  # FilePathUtils.glob handles the escaping itself.
   def glob_patterns(path)
-    @extensions.map { |ext| File.join(path, "*#{ext}") }
+    @extensions.map { |ext| FilePathUtils.glob(path, "*#{ext}") }
   end
 
   # A human-readable rendering of the configured extensions for log and

--- a/lib/ceedling/plugins/report_tests_stdout_plugin.rb
+++ b/lib/ceedling/plugins/report_tests_stdout_plugin.rb
@@ -35,7 +35,12 @@ class ReportTestsStdoutPlugin < Plugin
     # Thread-safe manipulation since test fixtures can be run in child processes
     # spawned within multiple test execution threads.
     @mutex.synchronize do
-      if (result_file =~ /#{PROJECT_TEST_RESULTS_PATH}/) && !@result_list.include?(result_file)
+      # #104 -- `[`/`]` are legal filename characters, but also regex character-class
+      # syntax; interpolating PROJECT_TEST_RESULTS_PATH into this regex unescaped means
+      # a literal bracket anywhere in it (e.g. a bracket-containing :build_root:) silently
+      # breaks this match -- the test itself compiles, links, and passes, but never gets
+      # counted here, so the final summary wrongly reports no tests executed at all.
+      if (result_file =~ /#{Regexp.escape(PROJECT_TEST_RESULTS_PATH)}/) && !@result_list.include?(result_file)
         @result_list << arg_hash[:result_file]
       end
     end

--- a/plugins/bullseye/lib/bullseye.rb
+++ b/plugins/bullseye/lib/bullseye.rb
@@ -100,7 +100,11 @@ class Bullseye < Plugin
     result_file = arg_hash[:result_file]
 
     @mutex.synchronize do
-      if ((result_file =~ /#{BULLSEYE_RESULTS_PATH}/) and (not @result_list.include?(result_file)))
+      # #104 -- `[`/`]` are legal filename characters, but also regex character-class
+      # syntax; interpolating BULLSEYE_RESULTS_PATH into this regex unescaped means a
+      # literal bracket anywhere in it (e.g. a bracket-containing :build_root:) silently
+      # breaks this match, and the test never gets counted here.
+      if ((result_file =~ /#{Regexp.escape(BULLSEYE_RESULTS_PATH)}/) and (not @result_list.include?(result_file)))
         @result_list << result_file
       end
     end

--- a/plugins/gcov/lib/gcov.rb
+++ b/plugins/gcov/lib/gcov.rb
@@ -288,7 +288,11 @@ class Gcov < Plugin
     result_file = arg_hash[:result_file]
 
     @mutex.synchronize do
-      if (result_file =~ /#{GCOV_RESULTS_PATH}/) && !@result_list.include?(result_file)
+      # #104 -- `[`/`]` are legal filename characters, but also regex character-class
+      # syntax; interpolating GCOV_RESULTS_PATH into this regex unescaped means a
+      # literal bracket anywhere in it (e.g. a bracket-containing :build_root:) silently
+      # breaks this match, and the test never gets counted here.
+      if (result_file =~ /#{Regexp.escape(GCOV_RESULTS_PATH)}/) && !@result_list.include?(result_file)
         @result_list << arg_hash[:result_file]
       end
     end

--- a/plugins/valgrind/lib/valgrind.rb
+++ b/plugins/valgrind/lib/valgrind.rb
@@ -92,7 +92,11 @@ class Valgrind < Plugin
     result_file = arg_hash[:result_file]
 
     @mutex.synchronize do
-      if (result_file =~ /#{PROJECT_TEST_RESULTS_PATH}/) && !@result_list.include?(result_file)
+      # #104 -- `[`/`]` are legal filename characters, but also regex character-class
+      # syntax; interpolating PROJECT_TEST_RESULTS_PATH into this regex unescaped means
+      # a literal bracket anywhere in it (e.g. a bracket-containing :build_root:) silently
+      # breaks this match, and the test never gets counted here.
+      if (result_file =~ /#{Regexp.escape(PROJECT_TEST_RESULTS_PATH)}/) && !@result_list.include?(result_file)
         @result_list << arg_hash[:result_file]
       end
     end

--- a/spec/system/bracket_path_handling_spec.rb
+++ b/spec/system/bracket_path_handling_spec.rb
@@ -1,0 +1,216 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+
+##
+## A Source Path Segment Containing Literal [] Brackets Is Not Dropped (issue #104)
+## ==================================================================================
+##
+## `[`/`]` are legal filename characters (Windows especially -- the original report's
+## own scenario) but Ruby's Dir.glob treats an unescaped `[...]` as character-class
+## glob syntax, so a literal bracket in a real directory name silently failed to match
+## its own glob pattern. This broke not just plugin :load_paths: detection (the
+## original 2016 report) but the whole :paths: family: a source subdirectory named
+## e.g. `[legacy]` was silently dropped from the build entirely -- Dir.glob('src/**')
+## simply never matched it, no error, the file just never got compiled.
+##
+
+EXAMPLE_HEADER_BRACKET_PATH = <<~C
+  #ifndef EXAMPLE_FILE_BRACKET_H
+  #define EXAMPLE_FILE_BRACKET_H
+
+  int example_file_bracket_add(int a, int b);
+
+  #endif
+C
+
+EXAMPLE_SOURCE_BRACKET_PATH = <<~C
+  #include "example_file_bracket.h"
+
+  int example_file_bracket_add(int a, int b)
+  {
+    return a + b;
+  }
+C
+
+TEST_BRACKET_PATH_C = <<~C
+  #include "unity.h"
+  #include "example_file_bracket.h"
+
+  void setUp(void) {}
+  void tearDown(void) {}
+
+  void test_source_under_a_bracket_named_directory_is_compiled(void)
+  {
+    TEST_ASSERT_EQUAL_INT(3, example_file_bracket_add(1, 2));
+  }
+C
+
+# A trivial, dependency-free test -- these two additional scenarios exercise
+# collection/lookup paths (test-file collection, vendor framework collection, test
+# runner lookup) unrelated to source/header collection, so they don't need the
+# example_file_bracket fixtures above.
+TRIVIAL_TEST_C = <<~C
+  #include "unity.h"
+
+  void setUp(void) {}
+  void tearDown(void) {}
+
+  void test_trivial_truth(void)
+  {
+    TEST_ASSERT_EQUAL_INT(1, 1);
+  }
+C
+
+ceedling_system_tests do
+
+  before :all do
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  before { @proj_name = unique_proj_name("bracket_path") }
+
+  describe "Deployed as a gem" do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new #{@proj_name}")
+      end
+    end
+
+    before do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          # The default :paths: ↳ :source/:include is `src/**` -- already recursive,
+          # so a bracket-named subdirectory needs no extra :paths: config to exercise
+          # the bug; it's dropped (or, pre-fix validation, hard-errored) purely by
+          # virtue of Dir.glob never matching '[legacy]' as a literal directory name.
+          FileUtils.mkdir_p('src/[legacy]')
+          File.write('src/[legacy]/example_file_bracket.h', EXAMPLE_HEADER_BRACKET_PATH)
+          File.write('src/[legacy]/example_file_bracket.c', EXAMPLE_SOURCE_BRACKET_PATH)
+          File.write('test/test_bracket_path.c', TEST_BRACKET_PATH_C)
+        end
+      end
+    end
+
+    it "compiles and tests a source file living under a bracket-named directory" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_build_exec("test:all")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to_not match(/yielded no directories/)
+          expect(output).to match(/TESTED:\s+1/)
+          expect(output).to match(/PASSED:\s+1/)
+          expect(output).to match(/FAILED:\s+0/)
+        end
+      end
+    end
+  end
+
+  ##
+  ## A Test File Itself Living Under a Bracket-Named Directory Is Not Dropped
+  ## ==========================================================================
+  ##
+  ## The default :paths: ↳ :test convention (`+:test/**`) is just as recursive as
+  ## :source/:include, and test-file collection (ConfiguratorBuilder#collect_tests)
+  ## builds its own glob pattern independently of source/header collection -- a
+  ## separate call site that needed its own fix. This also exercises test runner
+  ## lookup (FileFinder#runner_scope_dir), since the runner generated for a test
+  ## under a bracket-named directory is itself mirrored into a bracket-named
+  ## subdirectory of the runners output path and must be found again there.
+  ##
+
+  describe "Deployed as a gem, test file under a bracket-named directory" do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new #{@proj_name}")
+      end
+    end
+
+    before do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          FileUtils.mkdir_p('test/[legacy]')
+          File.write('test/[legacy]/test_trivial.c', TRIVIAL_TEST_C)
+        end
+      end
+    end
+
+    it "compiles and tests a test file living under a bracket-named directory" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_build_exec("test:all")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to_not match(/yielded no directories/)
+          expect(output).to match(/TESTED:\s+1/)
+          expect(output).to match(/PASSED:\s+1/)
+          expect(output).to match(/FAILED:\s+0/)
+        end
+      end
+    end
+  end
+
+  ##
+  ## A Project Whose (Absolute) Build Root Falls Under a Bracket-Named Directory
+  ## Is Not Dropped
+  ## ==========================================================================
+  ##
+  ## The original 2016 report's own scenario (a bracket-containing staging/temp
+  ## directory, common on Windows). Every vendor framework path (Unity, and
+  ## CException/CMock when enabled) is rooted at :project ↳ :build_root -- `build`
+  ## by default, which is *relative* and so never embeds the project's own
+  ## directory ancestry in a glob pattern at all (Dir.glob resolves a relative
+  ## pattern against the process's cwd without re-parsing the cwd itself as glob
+  ## syntax). Only an *absolute* :build_root: -- a legitimate, supported setting --
+  ## actually embeds a bracket-containing ancestor into the glob pattern text these
+  ## vendor-collection call sites build, so that's what this scenario configures.
+  ##
+
+  describe "Deployed as a gem, absolute build root under a bracket-named directory" do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new #{@proj_name}")
+      end
+    end
+
+    before do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          File.write('test/test_trivial.c', TRIVIAL_TEST_C)
+
+          # Absolute :build_root: under a bracket-named directory -- forces every
+          # vendor framework path (derived from :build_root:) to carry the bracket
+          # literally in the glob pattern text, unlike the default relative 'build'.
+          bracket_build_root = File.expand_path( File.join('[build-staging]', 'build') )
+          @c.merge_project_yml_for_test({ :project => { :build_root => bracket_build_root } })
+        end
+      end
+    end
+
+    it "compiles and tests a project whose absolute build root falls under a bracket-named directory" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_build_exec("test:all")
+
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to_not match(/yielded no directories/)
+          expect(output).to match(/TESTED:\s+1/)
+          expect(output).to match(/PASSED:\s+1/)
+          expect(output).to match(/FAILED:\s+0/)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/units/file_path_collection_utils_spec.rb
+++ b/spec/units/file_path_collection_utils_spec.rb
@@ -18,6 +18,15 @@ describe FilePathCollectionUtils do
   # converts them back to the expected relative form without any filesystem access.
   before(:each) do
     @file_wrapper = double('file_wrapper')
+    # #104 -- real (not stubbed-away) behavior: builds a FileList via `<<`, never
+    # `.new`/`.include`, so a literal `[`/`]` survivor in an already-concrete path
+    # is never mistaken for glob syntax and silently dropped. revise_filelist's own
+    # final FileList construction goes through this.
+    allow(@file_wrapper).to receive(:instantiate_file_list_literal) do |files|
+      list = Rake::FileList.new
+      files.each { |file| list << file }
+      list
+    end
     @fpcu = described_class.new({ file_wrapper: @file_wrapper })
   end
 

--- a/spec/units/file_path_utils_spec.rb
+++ b/spec/units/file_path_utils_spec.rb
@@ -136,6 +136,78 @@ describe FilePathUtils do
       expect( FilePathUtils.no_decorators( nil ) ).to eq( '' )
     end
 
+    # #104 -- `[`/`]` are legal filename characters (Windows especially) but were
+    # swept into PATTERNS::GLOB alongside Ceedling's own genuinely-supported `*`/`?`/
+    # `{`/`}` wildcard syntax. Unlike those, `[`/`]` are never a documented Ceedling
+    # glob feature, so a literal bracket in a real directory name must not be treated
+    # as "where the glob starts" -- doing so silently validated the wrong, truncated
+    # ancestor directory instead of the real one.
+    it "returns a directory path containing literal brackets unchanged, not truncated ('foo/[bar]/baz')" do
+      expect( FilePathUtils.no_decorators( 'foo/[bar]/baz' ) ).to eq( 'foo/[bar]/baz' )
+    end
+
+    it "still extracts the directory portion ahead of a real glob when a literal bracket precedes it ('foo/[bar]/baz/*.c')" do
+      expect( FilePathUtils.no_decorators( 'foo/[bar]/baz/*.c' ) ).to eq( 'foo/[bar]/baz' )
+    end
+
+  end
+
+
+  describe '.escape_glob_brackets' do
+
+    it "backslash-escapes a literal '[' and ']'" do
+      expect( FilePathUtils.escape_glob_brackets( 'foo/[bar]/baz' ) ).to eq( 'foo/\\[bar\\]/baz' )
+    end
+
+    it "leaves a path with no brackets unchanged" do
+      expect( FilePathUtils.escape_glob_brackets( 'foo/bar/baz' ) ).to eq( 'foo/bar/baz' )
+    end
+
+    it "leaves Ceedling's own genuine glob syntax untouched" do
+      expect( FilePathUtils.escape_glob_brackets( 'foo/bar/**' ) ).to eq( 'foo/bar/**' )
+    end
+
+    it "returns nil for nil" do
+      expect( FilePathUtils.escape_glob_brackets( nil ) ).to be_nil
+    end
+
+  end
+
+
+  # #104 -- the canonical base-path-plus-suffix glob builder every call site should use
+  # instead of hand-rolling `File.join(path, suffix)`, so a literal `[`/`]` in `base_path`
+  # can't be forgotten by omission (several call sites did, before this existed).
+  describe '.glob' do
+
+    it "escapes brackets in the base path, leaving an appended suffix untouched" do
+      expect( FilePathUtils.glob( 'foo/[bar]', '*.c' ) ).to eq( 'foo/\\[bar\\]/*.c' )
+    end
+
+    it "joins multiple suffix parts, same as File.join" do
+      expect( FilePathUtils.glob( 'foo/[bar]', 'config', '*.rb' ) ).to eq( 'foo/\\[bar\\]/config/*.rb' )
+    end
+
+    it "behaves as a plain File.join when the base path has no brackets" do
+      expect( FilePathUtils.glob( 'foo/bar', '*.c' ) ).to eq( File.join( 'foo/bar', '*.c' ) )
+    end
+
+    it "returns just the escaped base path when no suffix is given" do
+      expect( FilePathUtils.glob( 'foo/[bar]' ) ).to eq( 'foo/\\[bar\\]' )
+    end
+
+  end
+
+
+  describe '.subdirectory_glob' do
+
+    it "escapes brackets in the path before reforming the trailing '/**' convention" do
+      expect( FilePathUtils.subdirectory_glob( 'foo/[bar]/**' ) ).to eq( 'foo/\\[bar\\]/**/**' )
+    end
+
+    it "escapes brackets in a path with no trailing glob" do
+      expect( FilePathUtils.subdirectory_glob( 'foo/[bar]' ) ).to eq( 'foo/\\[bar\\]' )
+    end
+
   end
 
 

--- a/spec/units/file_wrapper_spec.rb
+++ b/spec/units/file_wrapper_spec.rb
@@ -124,4 +124,30 @@ describe FileWrapper do
       end
     end
   end
+
+  # #104 -- plain FileList.new(files)/#include treats every entry as a glob pattern to
+  # (re-)resolve via Dir.glob, which drops a literal `[`/`]` survivor in an already-
+  # concrete filename, and can only ever match files that already exist on disk at all
+  # -- wrong for a caller that already has the real, final answer in hand (e.g. an
+  # object file this same build is about to create). `<<` bypasses glob interpretation
+  # entirely.
+  describe '#instantiate_file_list_literal' do
+    it 'returns a FileList instance' do
+      expect( @file_wrapper.instantiate_file_list_literal( [] ) ).to be_a( Rake::FileList )
+    end
+
+    it 'returns an empty FileList for an empty array' do
+      expect( @file_wrapper.instantiate_file_list_literal( [] ).to_a ).to eq( [] )
+    end
+
+    it 'preserves every entry exactly, including a not-yet-existing path with literal [] brackets' do
+      files = ['src/[legacy]/foo.c', 'build/test/out/a_test/[legacy]/foo.o']
+      expect( @file_wrapper.instantiate_file_list_literal( files ).to_a ).to eq( files )
+    end
+
+    it 'preserves entry order and duplicates as given, with no glob re-resolution' do
+      files = ['b.c', 'a.c', 'a.c']
+      expect( @file_wrapper.instantiate_file_list_literal( files ).to_a ).to eq( files )
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #104. `[`/`]` are legal filename characters (Windows especially — the original 2016 report's own scenario), but Ruby's `Dir.glob`/`File.fnmatch` treat an unescaped `[...]` as character-class glob syntax, and Ruby's `Regexp` treats it the same way. A literal bracket in a real path was silently mismatched by both — well beyond the plugin `:load_paths:` detection originally reported.

Investigation started at the original report's scope and expanded as each fix surfaced the next call site sharing the same root cause. A DRY-refactor pass (centralizing the escaping into shared helpers instead of leaving it scattered) surfaced several additional gaps the original scattered approach had missed — those are included here rather than left half-fixed.

## What was actually broken

- **Glob misinterpretation** (`Dir.glob`/`Rake::FileList`): plugin `:load_paths:` detection, the whole `:paths:`/`:files:` config family, source/header/test file collection, vendor framework file collection, and test-runner lookup — a bracket-named directory anywhere in these silently dropped files from the build, with no error.
- **A second, structurally different bug** found via the DRY pass: `[`/`]` are also regex character-class syntax. Four files (`report_tests_stdout_plugin.rb` plus the `gcov`/`bullseye`/`valgrind` plugins) interpolate a results-path constant straight into a `Regexp` literal to match a completed test's result file. Under a bracket-containing `:build_root:`, the test itself compiled, linked, and passed — but silently never got counted, so the final summary reported **no tests executed at all**.

## Fix

- `constants.rb`: `PATTERNS::GLOB` no longer includes `[`/`]` — they were never a real, documented Ceedling glob feature (only `*?{}` are).
- New `FilePathUtils.glob`/`.subdirectory_glob`/`.escape_glob_brackets`: canonical helpers for building a bracket-safe glob pattern from a directory path, used at every call site that turns a resolved path into a `Dir.glob`/`FileList` pattern.
- New `FileWrapper#instantiate_file_list_literal`: `Rake::FileList.new`/`#include` re-globs every entry via `Dir.glob` regardless of escaping, and `Dir.glob` can only ever match a file that already exists on disk — wrong for a caller that already has the final, concrete answer in hand (e.g. an object file this same build is about to create). Adds each entry via `<<` instead, with no glob re-interpretation at all.
- `Regexp.escape` at the four results-path-into-regex sites.

## Testing

- New system-test coverage (`bracket_path_handling_spec.rb`) for a source file, a test file, and a project with an absolute bracket-containing `:build_root:`, each living under a literal bracket-named directory. Each new fix was verified test-first (confirmed the relevant scenario fails without it, via `git stash`, then passes with it restored).
- New unit coverage for the new `FilePathUtils`/`FileWrapper` helpers.
- Full unit suite (2873 examples) and full system suite (446 examples) both green, on the host and inside the `madsciencelab-plugins` Docker image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)