### PR TITLE
📝 Phase 4 docs: #1159 gcovr custom args & #104 bracket-path fix

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -53,6 +53,9 @@ Platform filepath limits (especially on Windows) can lead to mysterious build fa
 ### `ceedling.yml` as an alternate default project file
 [#1250](https://github.com/ThrowTheSwitch/Ceedling/issues/1250) `ceedling.yml` is now recognized as an alternate default project filename alongside `project.yml`. Either name is loaded the same way; neither is preferred over the other. If both exist in the same directory, Ceedling raises an error. `ceedling new` continues to generate `project.yml` by default; pass `--ceedling-yml` to generate `ceedling.yml` instead. See [Loading a Project Configuration](https://throwtheswitch.github.io/Ceedling/1.2.0/configuration/loading/).
 
+### Gcovr raw custom arguments
+[#1159](https://github.com/ThrowTheSwitch/Ceedling/issues/1159) Added [`:gcov` ↳ `:gcovr` ↳ `:custom_args:`](https://throwtheswitch.github.io/Ceedling/1.2.0/plugins/gcov/gcovr/), a list of raw command line arguments passed straight through to `gcovr`. This is an escape hatch for any `gcovr` flag Ceedling has no named option for (e.g. limiting gcovr's search root), mirroring the `:report_generator` ↳ `:custom_args:` option that already existed for the ReportGenerator side of the Gcov plugin. Unlike every other GCovr option, `:custom_args:` still applies even when `:config_file` is set.
+
 ## 💪 Fixed
 
 Note: 1.2.0 includes all bug fixes for 1.1.x.
@@ -61,6 +64,7 @@ Note: 1.2.0 includes all bug fixes for 1.1.x.
 - [#1251](https://github.com/ThrowTheSwitch/Ceedling/issues/1251) Fixed _Overall Test Summary_ not printing at logging verbosity of warning on an otherwise all-passing test run.
 - [#1252](https://github.com/ThrowTheSwitch/Ceedling/issues/1252) Fixed the Gcov plugin requiring `gcovr` to be installed for any build merely because the plugin was enabled, rather than only when a `gcov:` build actually runs.
 - Fixed a Unity `TEST_IGNORE_MESSAGE()` test case being misreported as crash evidence during crash-diagnosis retries when it shares a test file with a genuine crash.
+- [#104](https://github.com/ThrowTheSwitch/Ceedling/issues/104) Fixed a literal `[` or `]` in a path (legal on Windows especially) being silently misread as glob or regular expression syntax. This could drop files from a build with no error (a source, header, or test file living in a bracket-named directory; a project whose absolute `:build_root:` includes a bracket-named directory) or cause a passing test run to be reported as "no tests executed."
 
 ### Mixins
 

--- a/docs/mkdocs/plugins/gcov/gcovr.md
+++ b/docs/mkdocs/plugins/gcov/gcovr.md
@@ -21,21 +21,24 @@ GCovr can be configured in two ways:
 ### Gcovr configuration file
 
 !!! warning "Using a gcovr configuration file"
-    When `:config_file` is set, Ceedling passes only `--root` (`:report_root`) 
-    and `--config` (`:config_file`) to `gcovr` at the command line from your
-    plugin configuration. This prevents overriding config file settings with 
-    CLI arguments. You must provide any settings that would have been provided 
-    by the Gcov plugin.
+    When `:config_file` is set, Ceedling passes only `--root` (`:report_root`), 
+    `--config` (`:config_file`), and any `:custom_args:` to `gcovr` at the command 
+    line from your plugin configuration. This prevents overriding config file 
+    settings with other CLI arguments derived from plugin configuration. You must 
+    provide any settings that would have been provided by the Gcov plugin, either 
+    in the config file itself or via `:custom_args:`.
 
 To preserve filtering of test and build files from coverage results when
 using a Gcovr config file, you must provide explicit exclusion patterns matching 
 your project layout (example below).
 
 ```ini
-[gcovr]
 ; You will need to revise these example exclude patterns to match your
 ; project directories and file naming as they cannot be automatically 
 ; provided to Gcovr when a Gcovr configuration file is in use.
+;
+; Note: Gcovr's config file format is flat `key = value` lines with no
+;       `[section]` header — do not add one; gcovr rejects it as a syntax error.
 
 ; Test path(s) exclusions for 'test_' files with .c extensions. 
 exclude = .*test.*/test_.+\.c$
@@ -70,15 +73,17 @@ include all these options in your Gcov plugin configuration.
     #
     # When :config_file is set, Ceedling passes only --root and --config to
     # gcovr and defers all other configuration to the file. This prevents
-    # Ceedling from overriding config file values with its CLI arguments. Only
+    # Ceedling from overriding config file values with its CLI arguments.
     # :report_root is still applied because Ceedling may invoke gcovr from a
-    # different working directory than your project root.
+    # different working directory than your project root, and any :custom_args:
+    # (below) are still applied too — the one way to pass gcovr flags of your
+    # own alongside a config file.
     #
     # To preserve the plugin’s base filtering behavior, include the following
     # patterns in your config file (adjust paths to match your project’s
-    # :test_file_prefix, test paths, and :build_root settings):
+    # :test_file_prefix, test paths, and :build_root settings). Note gcovr's
+    # config file format has no [section] header:
     #
-    #   [gcovr]
     #   exclude = .*test.*/test_.+\.c$
     #   exclude = .*build/.+\.c$
     :config_file: <config_file>
@@ -181,6 +186,16 @@ include all these options in your Gcov plugin configuration.
 
     # Set the number of threads to use in parallel. (gcovr -j).
     :threads: <count>
+
+    # Optional list of one or more raw command line arguments to pass to gcovr.
+    # Useful as an escape hatch for any gcovr flag Ceedling has no named option for
+    # (e.g. limiting gcovr's search root).
+    # Note: Unlike every other option above, these arguments are still applied even
+    #       when :config_file is set — this is the one way to pass gcovr flags of
+    #       your own alongside a config file.
+    :custom_args:
+      - <argument>
+      - ...
 ```
 ## HTML reports
 

--- a/docs/mkdocs/snapshot/plugins/gcov/config/defaults.yml
+++ b/docs/mkdocs/snapshot/plugins/gcov/config/defaults.yml
@@ -20,6 +20,7 @@
   :gcovr:
     :report_root: "."             # Gcovr defaults to scanning for results starting in working directory
     :config_file: ~               # Specify the location of the GCOVR configuration file to use instead of settings config here
+    :custom_args: []              # Optional list of one or more command line arguments to pass to gcovr (e.g. search-path limiting). Explicitly defined as default empty array to simplify option validation code
 
                                   # For v6.0+ merge coverage results for same function tested multiple times
                                   # The default behavior is 'strict' which will cause a gcovr exception for many users


### PR DESCRIPTION
## Summary

Documentation for the two already-merged fixes from this round (#1256 / #1159, #1257 / #104). Phase 3 (#93) remains on hold, so its docs aren't included here.

- **Changelog**: new entries under 1.2.0 — an "Added" entry for gcovr `:custom_args:`, a "Fixed" bullet for the bracket-path fix.
- **`gcovr.md`**: documents the new `:gcov` ↳ `:gcovr` ↳ `:custom_args:` option, and corrects the existing `:config_file` warning — `:custom_args:` is the one setting that still applies alongside a config file, unlike every other gcovr option.
- **`gcovr.md` bug fix**: found as a byproduct of the #1159 work — gcovr's real config file format has no `[gcovr]` section header (confirmed against the real gcovr binary in the `madsciencelab-plugins` Docker image). The existing example showed one; following it as written would hand a user a config gcovr rejects with a syntax error. Fixed both occurrences.
- **Docs snapshot**: regenerated to pick up `defaults.yml`'s new `:custom_args:` default line.

Validated with `rake docs:build:prerelease` (`mkdocs build --strict`) — no broken links or build errors.

This is the documentation review/revision phase — please have a look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)