### PR TITLE
Add .. (parent-directory) support to relative path resolution

### DIFF
--- a/assets/fixtures/parent_directory_references/alpha/extra.c
+++ b/assets/fixtures/parent_directory_references/alpha/extra.c
@@ -1,0 +1,4 @@
+int extra_value(void)
+{
+  return 222;
+}

--- a/assets/fixtures/parent_directory_references/common/helper.c
+++ b/assets/fixtures/parent_directory_references/common/helper.c
@@ -1,0 +1,6 @@
+#include "helper.h"
+
+int helper_value(void)
+{
+  return 111;
+}

--- a/assets/fixtures/parent_directory_references/common/helper.h
+++ b/assets/fixtures/parent_directory_references/common/helper.h
@@ -1,0 +1,6 @@
+#ifndef HELPER_H
+#define HELPER_H
+
+int helper_value(void);
+
+#endif // HELPER_H

--- a/assets/fixtures/parent_directory_references/unit/test_dotdot_include.c
+++ b/assets/fixtures/parent_directory_references/unit/test_dotdot_include.c
@@ -1,0 +1,10 @@
+#include "unity.h"
+#include "../common/helper.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_helper_value_via_parent_directory_include(void)
+{
+  TEST_ASSERT_EQUAL(111, helper_value());
+}

--- a/assets/fixtures/parent_directory_references/unit/test_dotdot_source.c
+++ b/assets/fixtures/parent_directory_references/unit/test_dotdot_source.c
@@ -1,0 +1,16 @@
+#include "unity.h"
+
+// extra.c has no corresponding header; this test file lives one directory
+// away from it, so resolving this directive exercises TEST_SOURCE_FILE()'s
+// own anchor-relative .. resolution rather than the #include machinery.
+TEST_SOURCE_FILE("../alpha/extra.c")
+
+extern int extra_value(void);
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_extra_value_via_parent_directory_test_source_file(void)
+{
+  TEST_ASSERT_EQUAL(222, extra_value());
+}

--- a/lib/ceedling/file_finder.rb
+++ b/lib/ceedling/file_finder.rb
@@ -65,7 +65,12 @@ class FileFinder
   # ambiguous, not have Ceedling silently guess which test they meant -- there's no
   # compilation step downstream to catch a wrong guess the way there is for a header
   # or source file resolved during a build.
+  #
+  # A task name has no file of its own to anchor a `..` against, unlike an #include or
+  # TEST_SOURCE_FILE() entry -- resolving with no anchor surfaces that as a specific,
+  # named error rather than falling through to a generic file-not-found further down.
   def find_test_file_from_name(name)
+    name = PathMatcher.resolve_relative(name)
     return find_first_candidate(name, @configurator.extension_source, @configurator.collection_all_tests, :error, strict: true)
   end
 

--- a/lib/ceedling/includes/includes.rb
+++ b/lib/ceedling/includes/includes.rb
@@ -7,6 +7,7 @@
 
 require 'set'
 require 'ceedling/exceptions'
+require 'ceedling/path_matcher'
 
 class Includes
   # Class method to convert mixed list of Include objects into an order-preserving list of hashes
@@ -209,9 +210,12 @@ class Includes
   # includes are never resolved against a real file under `-nostdinc`, so its bare text
   # is always exactly what was written.
   #
-  # `test_filepath` plays no part in matching -- it's carried only so a caller's own
-  # `on_ambiguous` block can name the one test file whose #include statement is worth a
-  # closer look, since nothing further up the call stack adds that context on its own.
+  # `test_filepath` is the anchor a bare entry's own `..` resolves against -- a bare
+  # scan sees a directory-relative #include exactly as written, `..` and all, so it's
+  # resolved here against the one file any such directive could possibly belong to:
+  # the test file itself. It's also carried so a caller's own `on_ambiguous` block can
+  # name the one test file whose #include statement is worth a closer look, since
+  # nothing further up the call stack adds that context on its own.
   def self.reconcile(bare:, user:, system:, test_filepath: nil, &on_ambiguous)
     # Validate input types
 
@@ -249,13 +253,20 @@ class Includes
     seen = Set.new
 
     bare.each do |bare_include|
+      # A directory-relative #include's own literal text is anchored to the one file
+      # a bare scan could have found it in -- the test file itself, never a header,
+      # since bare extraction never recurses into one. Resolving here, once, means
+      # every candidate below is compared against an ordinary, ..-free path exactly
+      # as if it had been written that way to begin with.
+      bare_filepath = PathMatcher.resolve_relative(bare_include.filepath, anchor: test_filepath && File.dirname(test_filepath))
+
       # Matching is deliberately bidirectional: a bare entry can carry either more path
       # than its candidate (literal, unresolved #include text against a bare-scanned
       # candidate from fallback preprocessing) or less (a pathless bare entry against a
       # candidate directives-only preprocessing resolved to a fuller real location) --
       # either side may be the more specific one, so whichever is shorter sets how many
       # of the longer one's trailing segments must match.
-      matched = user_filepaths.select { |filepath| paths_correspond?(bare_include.filepath, filepath) }
+      matched = user_filepaths.select { |filepath| paths_correspond?(bare_filepath, filepath) }
 
       next if matched.empty?
 
@@ -280,11 +291,10 @@ class Includes
   # Two filepaths correspond if the shorter one's path segments equal the longer one's
   # own trailing segments, exactly, in order -- checked without regard for which side is
   # shorter, since either a bare entry or its candidate may be the one carrying less path.
+  # Delegates to PathMatcher's own version of this same comparison rather than
+  # reimplementing segment-splitting a second time.
   def self.paths_correspond?(a, b)
-    segments_a = a.split(/[\\\/]/).reject(&:empty?)
-    segments_b = b.split(/[\\\/]/).reject(&:empty?)
-    shorter, longer = segments_a.length <= segments_b.length ? [segments_a, segments_b] : [segments_b, segments_a]
-    return longer.last(shorter.length) == shorter
+    PathMatcher.correspond?(a, b)
   end
   private_class_method :paths_correspond?
 
@@ -358,6 +368,18 @@ class Include
     @filename = File.basename(@filepath)
     @path = File.dirname(@filepath)
     @include_path = clean(include_path) if include_path
+  end
+
+  # Resolves any `..` in this include's own filepath against `anchor` (a directory
+  # path in the same representation `filepath` itself uses), returning a new instance
+  # of this same class if resolution actually changed anything, or this instance
+  # unchanged otherwise. A raw text scan -- unlike a real compiler, which resolves a
+  # directory-relative #include on its own while opening it -- has no way to know
+  # which real file its own literal directive text reaches until this runs.
+  def anchored(anchor)
+    resolved = PathMatcher.resolve_relative( @filepath, anchor: anchor )
+    return self if resolved == @filepath
+    return self.class.new( resolved, include_path: @include_path )
   end
 
   # Method specialized by subclasses

--- a/lib/ceedling/path_matcher.rb
+++ b/lib/ceedling/path_matcher.rb
@@ -60,6 +60,66 @@ class PathMatcher
     collection.select { |candidate| tail_matches?(query_segments, segments(candidate)) }
   end
 
+  # Collapses a `..` segment in `query` against `anchor`, a directory path in the
+  # same representation as every other path this class handles (e.g. a test file's
+  # own `File.dirname`) -- one anchor segment is popped per leading `..`, so the
+  # result is an ordinary, `..`-free query ready for `.match`/`.resolve`/`.candidates`
+  # exactly as if it had been written that way to begin with. A query with no `..` at
+  # all is returned completely untouched, so this is a no-op for the overwhelming
+  # majority of callers.
+  #
+  # `anchor: nil` means no file context exists to resolve against (e.g. a bare CLI
+  # task name, which names no file of its own) -- a `..` there can't mean anything,
+  # so it raises rather than silently mismatching or falling through to a confusing
+  # "not found" further down. `anchor: ''` is different: it means the query is
+  # already a complete, self-contained path that merely needs its own internal `..`
+  # collapsed, not prefixed onto anything else -- the shape GCC itself produces for a
+  # directory-relative quoted include, which is a full project-root-relative path
+  # left uncanonicalized.
+  #
+  # An absolute query (including a Windows drive letter) is returned unchanged --
+  # `candidates()`'s own `File.expand_path` comparison above already resolves `..`
+  # correctly for those, so reprocessing one here as anchor-relative would be wrong,
+  # not merely redundant.
+  def self.resolve_relative(query, anchor: nil)
+    return query if absolute?(query)
+
+    query_segments = segments(query)
+    return query unless query_segments.include?('..')
+
+    if anchor.nil?
+      raise CeedlingException.new(
+        "Relative path reference '..' in '#{query}' has no file context to resolve against here."
+      )
+    end
+
+    resolved = segments(anchor)
+
+    query_segments.each do |segment|
+      if segment == '..'
+        if resolved.empty?
+          raise CeedlingException.new("Relative path reference '..' in '#{query}' goes outside the project.")
+        end
+        resolved.pop
+      else
+        resolved << segment
+      end
+    end
+
+    resolved.join('/')
+  end
+
+  # Two filepaths correspond if the shorter one's path segments equal the longer
+  # one's own trailing segments, exactly, in order -- checked without regard for
+  # which side is shorter, since a query and a candidate can each be the more
+  # specific one depending on how each was discovered.
+  def self.correspond?(a, b)
+    segments_a = segments(a)
+    segments_b = segments(b)
+    shorter, longer = segments_a.length <= segments_b.length ? [segments_a, segments_b] : [segments_b, segments_a]
+    tail_matches?(shorter, longer)
+  end
+
   ### Private ###
 
   def self.absolute?(path)

--- a/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
@@ -6,6 +6,7 @@
 # =========================================================================
 
 require 'ceedling/includes/includes'
+require 'ceedling/path_matcher'
 require 'ceedling/preprocess/preprocessinator_bare_includes_extractor'
 require 'ceedling/preprocess/preprocessinator_line_marker_includes_extractor'
 require 'ceedling/preprocess/c_preprocessor_conditionals'
@@ -192,7 +193,7 @@ class PreprocessinatorIncludesHandler
         cond_tracker.process_directive( line )
         next unless cond_tracker.active?
         _include = @include_factory.user_include_from_directive( line )
-        includes << _include if !_include.nil?
+        includes << _include.anchored( File.dirname( filepath ) ) if !_include.nil?
       end
     end
 
@@ -243,7 +244,7 @@ class PreprocessinatorIncludesHandler
         cond_tracker.process_directive( line )
         next unless cond_tracker.active?
         _include = @include_factory.system_include_from_directive( line )
-        includes << _include if !_include.nil?
+        includes << _include.anchored( File.dirname( filepath ) ) if !_include.nil?
       end
     end
 

--- a/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
@@ -6,6 +6,7 @@
 # =========================================================================
 
 require 'ceedling/exceptions'
+require 'ceedling/path_matcher'
 require 'set'
 
 ##
@@ -163,6 +164,13 @@ class PreprocessinatorLineMarkerIncludesExtractor
 
         # Skip special markers like "<built-in>" and "<command-line>"
         next if filepath.start_with?('<')
+
+        # GCC forms a directory-relative quoted include's own line marker by
+        # concatenating the including file's directory onto the literal include
+        # text -- real and complete, but left uncanonicalized. Collapsing any ..
+        # here, once, means this path can correspond to the project's own real,
+        # ..-free file list the same way any other candidate already does.
+        filepath = PathMatcher.resolve_relative( filepath, anchor: '' )
 
         # Integer line number
         line_number = match[1].to_i

--- a/lib/ceedling/test_context_extractor.rb
+++ b/lib/ceedling/test_context_extractor.rb
@@ -100,8 +100,11 @@ class TestContextExtractor
       end
 
       if args.include?( Context::INCLUDES )
-        # Scan for contents of #include directives
-        includes += _extract_includes( line )
+        # Scan for contents of #include directives. Anchored to this test file's own
+        # directory: when preprocessing is off, nothing downstream ever reconciles or
+        # otherwise re-resolves this list, so a directory-relative reference has to be
+        # settled here, the only place that still knows which file it was written in.
+        includes += _extract_includes( line ).map { |include| include.anchored( File.dirname( filepath ) ) }
       end
     end
 

--- a/lib/ceedling/test_invoker/test_source_file_directive_resolver.rb
+++ b/lib/ceedling/test_invoker/test_source_file_directive_resolver.rb
@@ -8,6 +8,7 @@
 require 'ceedling/constants'
 require 'ceedling/exceptions'
 require 'ceedling/file_path_utils'
+require 'ceedling/path_matcher'
 require 'ceedling/test_invoker/test_build_validations'
 
 # Owns everything about the TEST_SOURCE_FILE() build directive's own path
@@ -33,9 +34,15 @@ class TestSourceFileDirectiveResolver
     raw = @test_context_extractor.lookup_build_directive_sources_list( test_filepath )
     additive, subtractive = raw.partition { |source| FilePathUtils.add_path?( source ) }
 
+    # A directive's own text is written directly in the test file, so its `..`, if
+    # any, is anchored to that same test file's own directory -- exactly as a
+    # directory-relative #include would be.
+    anchor = File.dirname( test_filepath )
+
     find = -> (source) {
+      stripped = FilePathUtils.no_aggregation_decorators( source )
       @file_finder.find_build_input_file(
-        filepath: FilePathUtils.no_aggregation_decorators( source ),
+        filepath: PathMatcher.resolve_relative( stripped, anchor: anchor ),
         complain: :ignore,
         context:  context
       )

--- a/spec/system/parent_directory_reference_spec.rb
+++ b/spec/system/parent_directory_reference_spec.rb
@@ -1,0 +1,155 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+
+##
+## Parent Directory (..) References
+## =================================
+##
+## Both #include directives and TEST_SOURCE_FILE() are resolved against a test
+## file's own directory, exactly as a real compiler resolves a directory-relative
+## quoted #include -- a query naming ".." to reach a sibling directory must
+## resolve the same way a real filesystem path would, under every preprocessing
+## mode a project can select.
+##
+## Test assets: assets/fixtures/parent_directory_references/
+##   - common/helper.h, common/helper.c: declares/defines helper_value() returning 111
+##   - unit/test_dotdot_include.c: #include "../common/helper.h", asserts 111
+##   - alpha/extra.c: extra_value() returning 222, no corresponding header
+##   - unit/test_dotdot_source.c: TEST_SOURCE_FILE("../alpha/extra.c"), asserts 222
+##
+
+ceedling_system_tests do
+
+  before :all do
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  before { @proj_name = unique_proj_name("dotdot") }
+
+  describe "Deployed as a gem" do
+    def copy_dotdot_include_assets(proj_name)
+      @c.with_context do
+        Dir.chdir proj_name do
+          FileUtils.mkdir_p 'test/common'
+          FileUtils.mkdir_p 'test/unit'
+          FileUtils.cp test_asset_path("parent_directory_references/common/helper.h"), 'test/common/'
+          FileUtils.cp test_asset_path("parent_directory_references/common/helper.c"), 'test/common/'
+          FileUtils.cp test_asset_path("parent_directory_references/unit/test_dotdot_include.c"), 'test/unit/'
+        end
+      end
+    end
+
+    def copy_dotdot_source_assets(proj_name)
+      @c.with_context do
+        Dir.chdir proj_name do
+          FileUtils.mkdir_p 'test/alpha'
+          FileUtils.mkdir_p 'test/unit'
+          FileUtils.cp test_asset_path("parent_directory_references/alpha/extra.c"), 'test/alpha/'
+          FileUtils.cp test_asset_path("parent_directory_references/unit/test_dotdot_source.c"), 'test/unit/'
+        end
+      end
+    end
+
+    # =========================================================================
+    describe "A test file that #includes a header in a sibling directory via .." do
+    # =========================================================================
+
+      before do
+        @c.with_context do
+          @c.ceedling_appcmd_exec("new #{@proj_name}")
+        end
+        copy_dotdot_include_assets(@proj_name)
+      end
+
+      it "compiles, links, and passes with preprocessing disabled -- the bare-scan fallback path" do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            settings = { :project => { :use_test_preprocessor => :none } }
+            @c.merge_project_yml_for_test(settings)
+
+            output = @c.ceedling_build_exec("test:all")
+            expect(@c.last_exit_status).to eq(0)
+            expect(output).to match(/TESTED:\s+1/)
+            expect(output).to match(/PASSED:\s+1/)
+          end
+        end
+      end
+
+      it "compiles, links, and passes with full test preprocessing enabled -- the GCC directives-only path" do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            settings = { :project => { :use_test_preprocessor => :all } }
+            @c.merge_project_yml_for_test(settings)
+
+            output = @c.ceedling_build_exec("test:all")
+            expect(@c.last_exit_status).to eq(0)
+            expect(output).to match(/TESTED:\s+1/)
+            expect(output).to match(/PASSED:\s+1/)
+          end
+        end
+      end
+
+    end
+
+    # =========================================================================
+    describe "A test file with a TEST_SOURCE_FILE() entry naming a sibling directory via .." do
+    # =========================================================================
+
+      before do
+        @c.with_context do
+          @c.ceedling_appcmd_exec("new #{@proj_name}")
+        end
+        copy_dotdot_source_assets(@proj_name)
+      end
+
+      it "compiles, links, and passes, resolving the directive against the test file's own directory" do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            output = @c.ceedling_build_exec("test:all")
+            expect(@c.last_exit_status).to eq(0)
+            expect(output).to match(/TESTED:\s+1/)
+            expect(output).to match(/PASSED:\s+1/)
+          end
+        end
+      end
+
+    end
+
+    # =========================================================================
+    describe "A `ceedling test:` task name containing .." do
+    # =========================================================================
+
+      before do
+        @c.with_context do
+          @c.ceedling_appcmd_exec("new #{@proj_name}")
+        end
+        copy_dotdot_include_assets(@proj_name)
+      end
+
+      it "fails clearly, naming .. as unsupported rather than a generic file-not-found" do
+        @c.with_context do
+          Dir.chdir @proj_name do
+            output = @c.ceedling_build_exec("test:../unit/test_dotdot_include")
+            expect(@c.last_exit_status).to_not eq(0)
+            expect(output).to match(/\.\./)
+            expect(output).to match(/context/i)
+          end
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/spec/units/file_finder_spec.rb
+++ b/spec/units/file_finder_spec.rb
@@ -225,6 +225,20 @@ describe FileFinder do
     it 'resolves when the name carries enough path to disambiguate' do
       expect(@file_finder.find_test_file_from_name('unit/test_foo')).to eq('unit/test_foo.c')
     end
+
+    it 'raises a clear CeedlingException naming .. as unsupported in a CLI task name, rather than a generic not-found' do
+      # A CLI task name has no file of its own to anchor a .. against -- unlike an
+      # #include or TEST_SOURCE_FILE() entry, which are always scoped to the test file
+      # that wrote them. Today's generic "Found no file" message happens to also
+      # contain the query text, so asserting on the query alone would pass for the
+      # wrong reason -- the message must specifically call out .. as the problem.
+      expect { @file_finder.find_test_file_from_name('../unit/test_foo') }.to raise_error(CeedlingException) do |error|
+        expect(error.message).to include('../unit/test_foo')
+        expect(error.message).not_to match(/Found no file/)
+        expect(error.message).to match(/\.\./)
+        expect(error.message).to match(/context/i)
+      end
+    end
   end
 
   describe '#find_file_from_list' do

--- a/spec/units/includes/includes_spec.rb
+++ b/spec/units/includes/includes_spec.rb
@@ -1330,5 +1330,29 @@ describe "Includes reconciliation" do
         "/usr/lib/gcc/x86_64-linux-gnu/14/include/stdint.h", "/usr/include/stdint.h"
       )
     end
+
+    it "resolves a .. in a bare entry's literal text against test_filepath's own directory to match a clean candidate" do
+      # A fallback text scan sees a directory-relative #include exactly as written --
+      # ".." and all -- while a candidate reported via directives-only preprocessing
+      # is already a clean, project-root-relative path with no .. of its own.
+      bare = [Include.new("../common/helper.h")]
+      user = [UserInclude.new("test/common/helper.h")]
+      system = []
+
+      result = Includes.reconcile(bare: bare, user: user, system: system, test_filepath: "test/unit/test_dotdot.c")
+
+      expect(result.length).to eq(1)
+      expect(result[0].filepath).to eq("test/common/helper.h")
+    end
+
+    it "raises a CeedlingException when a bare entry's .. has no test_filepath to anchor against" do
+      bare = [Include.new("../common/helper.h")]
+      user = [UserInclude.new("test/common/helper.h")]
+      system = []
+
+      expect {
+        Includes.reconcile(bare: bare, user: user, system: system)
+      }.to raise_error(CeedlingException, /\.\.\/common\/helper\.h/)
+    end
   end
 end

--- a/spec/units/path_matcher_spec.rb
+++ b/spec/units/path_matcher_spec.rb
@@ -120,4 +120,50 @@ describe PathMatcher do
     end
   end
 
+  describe '.resolve_relative' do
+    it 'returns a query with no .. segment completely unchanged, anchor or not' do
+      expect(described_class.resolve_relative('foo/bar.h')).to eq('foo/bar.h')
+      expect(described_class.resolve_relative('foo/bar.h', anchor: 'test/unit')).to eq('foo/bar.h')
+    end
+
+    it 'resolves a single leading .. against the anchor directory' do
+      expect(described_class.resolve_relative('../common/helper.h', anchor: 'test/unit')).to eq('test/common/helper.h')
+    end
+
+    it 'resolves multiple leading .. segments, one anchor segment popped per ..' do
+      expect(described_class.resolve_relative('../../common/helper.h', anchor: 'test/unit/adc')).to eq('test/common/helper.h')
+    end
+
+    it 'collapses an internal .. against an empty-string anchor, for an already self-contained path' do
+      # This is the shape GCC itself produces for a directory-relative quoted include --
+      # a complete, project-root-relative path that merely needs its own .. collapsed,
+      # not prefixed onto some other anchor.
+      expect(described_class.resolve_relative('test/unit/../common/helper.h', anchor: '')).to eq('test/common/helper.h')
+    end
+
+    it 'raises a CeedlingException naming the query when .. is present and no anchor is available' do
+      expect { described_class.resolve_relative('../common/helper.h') }.to raise_error(CeedlingException) do |error|
+        expect(error.message).to include('../common/helper.h')
+      end
+    end
+
+    it 'raises a CeedlingException naming the query when .. traverses past the anchor root' do
+      expect { described_class.resolve_relative('../../common/helper.h', anchor: 'test') }.to raise_error(CeedlingException) do |error|
+        expect(error.message).to include('../../common/helper.h')
+      end
+    end
+
+    it 'passes an absolute query through unchanged, even one containing .., deferring to expand_path-based matching elsewhere' do
+      expect(described_class.resolve_relative('/abs/unit/../common/helper.h')).to eq('/abs/unit/../common/helper.h')
+    end
+
+    it 'passes a Windows drive-letter query through unchanged, even one containing ..' do
+      expect(described_class.resolve_relative('C:\\unit\\..\\common\\helper.h')).to eq('C:\\unit\\..\\common\\helper.h')
+    end
+
+    it 'treats a backslash-separated .. query the same as a forward-slash one' do
+      expect(described_class.resolve_relative('..\\common\\helper.h', anchor: 'test/unit')).to eq('test/common/helper.h')
+    end
+  end
+
 end

--- a/spec/units/preprocess/preprocessinator_includes_handler_spec.rb
+++ b/spec/units/preprocess/preprocessinator_includes_handler_spec.rb
@@ -193,6 +193,13 @@ RSpec.describe PreprocessinatorIncludesHandler do
         expect(result.map(&:filename)).to contain_exactly('real.h')
       end
 
+      it 'anchors a .. in the directive text against the scanned file\'s own directory' do
+        nested_filepath = 'test/unit/module.c'
+        stub_file_open(nested_filepath, "#include \"../common/helper.h\"\n")
+        result = subject.extract_user_includes_from_text(name: 'test', filepath: nested_filepath)
+        expect(result.map(&:filepath)).to eq(['test/common/helper.h'])
+      end
+
     end
 
 
@@ -416,6 +423,13 @@ RSpec.describe PreprocessinatorIncludesHandler do
         stub_file_open(filepath, "#include \"user.h\"\n")
         result = subject.extract_system_includes_from_text(name: 'test', filepath: filepath)
         expect(result).to be_empty
+      end
+
+      it 'anchors a .. in the directive text against the scanned file\'s own directory, same as a user include' do
+        nested_filepath = 'test/unit/module.c'
+        stub_file_open(nested_filepath, "#include <../vendor/compat.h>\n")
+        result = subject.extract_system_includes_from_text(name: 'test', filepath: nested_filepath)
+        expect(result.map(&:filepath)).to eq(['test/vendor/compat.h'])
       end
 
     end

--- a/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
@@ -149,6 +149,21 @@ describe PreprocessinatorLineMarkerIncludesExtractor do
       expect( paths_of(includes) ).to eq( ['widget.h', 'nested.h'] )
     end
 
+    it 'collapses a .. segment GCC leaves uncanonicalized in a directory-relative quoted include line marker' do
+      # GCC forms a directory-relative quoted include's line marker as the including
+      # file's own directory concatenated with the literal include text -- it does not
+      # canonicalize away a .. this produces. Left uncanonicalized, this candidate could
+      # never correspond to the project's own, real, ..-free file list downstream.
+      content = <<~OUTPUT
+        # 1 "test/unit/test_dotdot.c"
+        # 1 "test/unit/../common/helper.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test/unit/test_dotdot.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['test/common/helper.h'] )
+    end
+
     it 'deduplicates a path reached more than once (e.g. via an include guard)' do
       content = <<~OUTPUT
         # 1 "test.c"

--- a/spec/units/test_source_file_directive_resolver_spec.rb
+++ b/spec/units/test_source_file_directive_resolver_spec.rb
@@ -87,6 +87,28 @@ describe TestSourceFileDirectiveResolver do
 
       expect(additive).to eq( ['src/foo.c'] )
     end
+
+    it "resolves a .. in an additive entry against the test file's own directory before looking it up" do
+      allow(@test_context_extractor).to receive(:lookup_build_directive_sources_list)
+        .with( 'test/unit/TestFoo.c' ).and_return( ['../common/extra.c'] )
+      allow(@file_finder).to receive(:find_build_input_file)
+        .with( filepath: 'test/common/extra.c', complain: :ignore, context: :test ).and_return( 'test/common/extra.c' )
+
+      additive, subtractive = @resolver.resolve( 'test/unit/TestFoo.c', :test )
+
+      expect(additive).to eq( ['test/common/extra.c'] )
+    end
+
+    it "resolves a .. in a subtractive entry the same way, against the test file's own directory" do
+      allow(@test_context_extractor).to receive(:lookup_build_directive_sources_list)
+        .with( 'test/unit/TestFoo.c' ).and_return( ['-:../common/extra.c'] )
+      allow(@file_finder).to receive(:find_build_input_file)
+        .with( filepath: 'test/common/extra.c', complain: :ignore, context: :test ).and_return( 'test/common/extra.c' )
+
+      additive, subtractive = @resolver.resolve( 'test/unit/TestFoo.c', :test )
+
+      expect(subtractive).to eq( { 'test/common/extra.c' => '-:../common/extra.c' } )
+    end
   end
 
   describe "#validate!" do


### PR DESCRIPTION
## Summary

`#include` directives, `TEST_SOURCE_FILE()`, and CLI `test:` task names got proper relative-path handling and duplicate-filename disambiguation in a recent refactor, but none of it accounted for `..` (parent-directory references). A `..`-containing query silently degraded to a plain not-found rather than naming `..` as the actual problem.

## What changed

- **`PathMatcher.resolve_relative(query, anchor:)`** (new) — collapses a query's own `..` against an anchor directory, or raises a clear, specific error when no anchor exists (e.g. a CLI task name) or when traversal would go outside the project.
- **Six wiring points**, not the three originally expected:
  1. `Includes.reconcile` — a bare `#include`'s own `..`, anchored to the test file's directory.
  2. `TestSourceFileDirectiveResolver#resolve` — same anchoring for `TEST_SOURCE_FILE()` entries.
  3. `FileFinder#find_test_file_from_name` — CLI `test:` task names raise a named "unsupported" error rather than a generic not-found (no file to anchor `..` against here).
  4. `PreprocessinatorLineMarkerIncludesExtractor` — GCC's own directives-only line-marker output leaves a directory-relative include's `..` uncanonicalized; collapsed at capture.
  5. `PreprocessinatorIncludesHandler`'s text-scan fallback (`:use_test_preprocessor` off or failed) — same literal-text problem via a different extraction pipeline.
  6. `TestContextExtractor#collect_context` — the only `#include` extraction that runs at all under `:use_test_preprocessor: :none`, since the reconciliation stage is skipped entirely (not just fallback-flagged) in that mode.
- Findings 4–6 were only found by running the fix end-to-end against real GCC output (`madsciencelab-plugins` Docker image) and watching it keep failing one level higher each time, rather than assuming preprocessor-derived paths were already clean.
- **DRY**: findings 5 and 6 needed identical "reconstruct with a resolved filepath" logic, consolidated into one `Include#anchored(anchor)` on the base class. `Includes.paths_correspond?` now delegates to a new `PathMatcher.correspond?` instead of independently reimplementing the same segment-tail-matching.

## Testing

- Full unit suite: 3129 examples, 0 failures (up from 3112 baseline).
- New `spec/system/parent_directory_reference_spec.rb`: 4/4 passing — `#include` under both preprocessing modes, `TEST_SOURCE_FILE()`, and the CLI error case.
- 38-example regression sweep across every existing path-disambiguation/includes/preprocessing system spec: 0 failures.

No Changelog entry — this is unreleased (1.2.0-only), already-documented functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)