### PR TITLE
Fix reconstructed header dropping macros whose name/value contains the include guard (#1266)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -120,6 +120,10 @@ Historically, Ceedling automatically compiles and links into a test executable a
 
 - [#1262](https://github.com/ThrowTheSwitch/Ceedling/issues/1262) Fixed a Partials-generated header occasionally concatenating two adjacent `#define` lines in one line causing a stray '#' compilation error. The triggering condition involved a `//` or `/* */` comment containing an apostrophe or quote (e.g. `// Don't ...`) that disrupted string literal handling.
 
+### Preprocessing
+
+- [#1266](https://github.com/ThrowTheSwitch/Ceedling/issues/1266) Fixed a reconstructed header silently dropping any macro whose name or value merely contained the header's own include guard as a substring (e.g. guard `RTC_H` matching inside `RTC_HOUR_SECONDS`), causing undeclared-identifier compile errors.
+
 ### Gcov plugin
 
 - Fixed `:gcov ↳ :gcovr ↳ :decisions` reporting an incorrect minimum-version requirement; the version check (and docs) now correctly require `gcovr` 5.1 or higher.

--- a/lib/ceedling/preprocess/preprocessinator_reconstructor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_reconstructor.rb
@@ -237,8 +237,15 @@ class PreprocessinatorReconstructor
   def extract_macro_defs(file_contents, include_guard)
     macro_definitions = extract_multiline_directives( file_contents, 'define' )
 
-    # Remove an include guard if provided
-    macro_definitions.reject! {|macro| macro.include?( include_guard ) } if !include_guard.nil?
+    # Remove an include guard if provided. A plain substring test here would also reject
+    # any ordinary macro whose name or value happens to contain the guard string -- e.g.
+    # guard RTC_H matching inside RTC_HOUR_SECONDS' own name, or inside RTC_DAY_SECONDS'
+    # value, which references RTC_HOUR_SECONDS (GH #1266). Anchoring to "#define <guard>"
+    # followed by whitespace or end-of-line only matches the guard definition itself.
+    if !include_guard.nil?
+      include_guard_regex = /^\s*#\s*define\s+#{Regexp.escape(include_guard)}(?:\s|$)/
+      macro_definitions.reject! {|macro| macro =~ include_guard_regex }
+    end
 
     return macro_definitions
   end

--- a/spec/units/preprocess/preprocessinator_reconstructor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_reconstructor_spec.rb
@@ -823,6 +823,45 @@ describe PreprocessinatorReconstructor do
       expect( @extractor.extract_macro_defs( file_text, '_INCLUDE_GUARD_' ) ).to eq expected
     end
 
+    # #1266: a plain substring test against the include guard rejected any macro whose
+    # name OR value merely contained the guard string, not only the guard macro itself.
+    # RTC_HOUR_SECONDS' own name contains the guard "RTC_H", and RTC_DAY_SECONDS'
+    # *value* references RTC_HOUR_SECONDS, so its captured text also contains "RTC_H" --
+    # both were silently dropped from the reconstructed header, breaking compilation.
+    it "does not reject an ordinary macro whose name or value merely contains the include guard as a substring (GH #1266)" do
+      file_text = <<~FILE_TEXT
+        #ifndef RTC_H
+        #define RTC_H
+
+        #define RTC_MINUTE_SECONDS 60u
+        #define RTC_HOUR_SECONDS (60u * RTC_MINUTE_SECONDS)
+        #define RTC_DAY_SECONDS (24u * RTC_HOUR_SECONDS)
+
+        #endif
+      FILE_TEXT
+
+      expected = [
+        "#define RTC_MINUTE_SECONDS 60u",
+        "#define RTC_HOUR_SECONDS (60u * RTC_MINUTE_SECONDS)",
+        "#define RTC_DAY_SECONDS (24u * RTC_HOUR_SECONDS)"
+      ]
+
+      expect( @extractor.extract_macro_defs( file_text, 'RTC_H' ) ).to eq expected
+    end
+
+    it "still rejects the include guard when it appears with trailing whitespace instead of a value" do
+      file_text = <<~FILE_TEXT
+        #ifndef RTC_H
+        #define RTC_H
+
+        #define RTC_MINUTE_SECONDS 60u
+      FILE_TEXT
+
+      expected = [ "#define RTC_MINUTE_SECONDS 60u" ]
+
+      expect( @extractor.extract_macro_defs( file_text, 'RTC_H' ) ).to eq expected
+    end
+
   end
 
   context "#compact_file_from_expansion" do


### PR DESCRIPTION
Fixes #1266.

## Root cause

`extract_macro_defs` filtered a header's own include guard out of the reconstructed macro list with a plain substring test (`macro.include?(include_guard)`). That also rejected any ordinary macro whose name or value merely happened to contain the guard string as a substring — e.g. with guard `RTC_H`:

```c
#define RTC_HOUR_SECONDS (60u * RTC_MINUTE_SECONDS)   // name contains "RTC_H"
#define RTC_DAY_SECONDS (24u * RTC_HOUR_SECONDS)       // value references RTC_HOUR_SECONDS, so it too contains "RTC_H"
```

Both were silently dropped from the reconstructed header (and from the corresponding preprocessed file), producing undeclared-identifier compile errors — exactly as reported.

## Fix

The match is now anchored to `#define <guard>` followed by whitespace or end-of-line, so only the guard's own definition line matches, regardless of what other macros elsewhere in the file happen to contain as substrings.

Same fix approach independently proposed by the issue reporter ([@BB-ROM](https://github.com/BB-ROM)'s [commit](https://github.com/BB-ROM/Ceedling/commit/6a9597aa0504555c4df5bdbd7c9dfbae551a341d)) — thank you for the clear repro and diagnosis.

## Diagnostic methodology

Checked for other `.include?`-style substring matching against `include_guard` elsewhere in `preprocessinator_reconstructor.rb`/`preprocessinator_file_assembler.rb`; this was the only site, so no related instances needed fixing.

## Tests

`spec/units/preprocess/preprocessinator_reconstructor_spec.rb`: new `#extract_macro_defs` cases using the reporter's own RTC example (a macro whose name contains the guard, and one whose value references such a macro) — verified failing against pre-fix code, passing after — plus a case confirming the guard itself (with only trailing whitespace, no value) is still correctly rejected.

Unit tests only, no system tests. Full `bundle exec rake specs:units` run clean (3217 examples, 0 failures) on host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)