### PR TITLE
Fix reconstructed header dropping macros whose name/value contains the include guard (#1266)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -18,6 +18,10 @@ This changelog is complemented by three other documents:
 
 - [#1262](https://github.com/ThrowTheSwitch/Ceedling/issues/1262) Fixed a Partials-generated header occasionally concatenating two adjacent `#define` lines in one line causing a stray '#' compilation error. The triggering condition involved a `//` or `/* */` comment containing an apostrophe or quote (e.g. `// Don't ...`) that disrupted string literal handling.
 
+### Preprocessing
+
+- [#1266](https://github.com/ThrowTheSwitch/Ceedling/issues/1266) Fixed a reconstructed header silently dropping any macro whose name or value merely contained the header's own include guard as a substring (e.g. guard `RTC_H` matching inside `RTC_HOUR_SECONDS`), causing undeclared-identifier compile errors.
+
 ### Gcov plugin
 
 - Fixed `:gcov ↳ :gcovr ↳ :decisions` reporting an incorrect minimum-version requirement; the version check (and docs) now correctly require `gcovr` 5.1 or higher.

--- a/lib/ceedling/preprocess/preprocessinator_reconstructor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_reconstructor.rb
@@ -236,8 +236,15 @@ class PreprocessinatorReconstructor
   def extract_macro_defs(file_contents, include_guard)
     macro_definitions = extract_multiline_directives( file_contents, 'define' )
 
-    # Remove an include guard if provided
-    macro_definitions.reject! {|macro| macro.include?( include_guard ) } if !include_guard.nil?
+    # Remove an include guard if provided. A plain substring test here would also reject
+    # any ordinary macro whose name or value happens to contain the guard string -- e.g.
+    # guard RTC_H matching inside RTC_HOUR_SECONDS' own name, or inside RTC_DAY_SECONDS'
+    # value, which references RTC_HOUR_SECONDS (GH #1266). Anchoring to "#define <guard>"
+    # followed by whitespace or end-of-line only matches the guard definition itself.
+    if !include_guard.nil?
+      include_guard_regex = /^\s*#\s*define\s+#{Regexp.escape(include_guard)}(?:\s|$)/
+      macro_definitions.reject! {|macro| macro =~ include_guard_regex }
+    end
 
     return macro_definitions
   end

--- a/spec/units/preprocess/preprocessinator_reconstructor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_reconstructor_spec.rb
@@ -798,6 +798,45 @@ describe PreprocessinatorReconstructor do
       expect( @extractor.extract_macro_defs( file_text, '_INCLUDE_GUARD_' ) ).to eq expected
     end
 
+    # #1266: a plain substring test against the include guard rejected any macro whose
+    # name OR value merely contained the guard string, not only the guard macro itself.
+    # RTC_HOUR_SECONDS' own name contains the guard "RTC_H", and RTC_DAY_SECONDS'
+    # *value* references RTC_HOUR_SECONDS, so its captured text also contains "RTC_H" --
+    # both were silently dropped from the reconstructed header, breaking compilation.
+    it "does not reject an ordinary macro whose name or value merely contains the include guard as a substring (GH #1266)" do
+      file_text = <<~FILE_TEXT
+        #ifndef RTC_H
+        #define RTC_H
+
+        #define RTC_MINUTE_SECONDS 60u
+        #define RTC_HOUR_SECONDS (60u * RTC_MINUTE_SECONDS)
+        #define RTC_DAY_SECONDS (24u * RTC_HOUR_SECONDS)
+
+        #endif
+      FILE_TEXT
+
+      expected = [
+        "#define RTC_MINUTE_SECONDS 60u",
+        "#define RTC_HOUR_SECONDS (60u * RTC_MINUTE_SECONDS)",
+        "#define RTC_DAY_SECONDS (24u * RTC_HOUR_SECONDS)"
+      ]
+
+      expect( @extractor.extract_macro_defs( file_text, 'RTC_H' ) ).to eq expected
+    end
+
+    it "still rejects the include guard when it appears with trailing whitespace instead of a value" do
+      file_text = <<~FILE_TEXT
+        #ifndef RTC_H
+        #define RTC_H
+
+        #define RTC_MINUTE_SECONDS 60u
+      FILE_TEXT
+
+      expected = [ "#define RTC_MINUTE_SECONDS 60u" ]
+
+      expect( @extractor.extract_macro_defs( file_text, 'RTC_H' ) ).to eq expected
+    end
+
   end
 
   context "#compact_file_from_expansion" do


### PR DESCRIPTION
Fixes #1266. This is a port of #1271 (green on `next_version`) to `master`, for inclusion in 1.1.8.

## Root cause

`extract_macro_defs` filtered a header's own include guard out of the reconstructed macro list with a plain substring test (`macro.include?(include_guard)`). That also rejected any ordinary macro whose name or value merely happened to contain the guard string as a substring — e.g. with guard `RTC_H`:

```c
#define RTC_HOUR_SECONDS (60u * RTC_MINUTE_SECONDS)   // name contains "RTC_H"
#define RTC_DAY_SECONDS (24u * RTC_HOUR_SECONDS)       // value references RTC_HOUR_SECONDS, so it too contains "RTC_H"
```

Both were silently dropped from the reconstructed header, producing undeclared-identifier compile errors — exactly as reported.

## Fix

The match is now anchored to `#define <guard>` followed by whitespace or end-of-line, so only the guard's own definition line matches.

## Tests

Same coverage as #1271: new `#extract_macro_defs` cases in `preprocessinator_reconstructor_spec.rb` using the reporter's own RTC example, verified failing against pre-fix code, passing after. Unit tests only, no system tests. `bundle exec rake specs:units` clean (1991 examples, 0 failures, 1 pre-existing unrelated pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)