### PR TITLE
Fix indented #include inside a conditional block losing content in mockable headers (#1268)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -126,6 +126,7 @@ Historically, Ceedling automatically compiles and links into a test executable a
 ### Preprocessing
 
 - [#1266](https://github.com/ThrowTheSwitch/Ceedling/issues/1266) Fixed a reconstructed header silently dropping any macro whose name or value merely contained the header's own include guard as a substring (e.g. guard `RTC_H` matching inside `RTC_HOUR_SECONDS`), causing undeclared-identifier compile errors.
+- [#1268](https://github.com/ThrowTheSwitch/Ceedling/issues/1268) Fixed a mockable header's `#include` losing the enums, structs, and function prototypes of a conditionally-included file (only its macros survived) when that `#include` was indented inside its `#ifdef` block, causing undeclared-identifier compile errors.
 
 ### Gcov plugin
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -126,7 +126,7 @@ Historically, Ceedling automatically compiles and links into a test executable a
 ### Preprocessing
 
 - [#1266](https://github.com/ThrowTheSwitch/Ceedling/issues/1266) Fixed a reconstructed header silently dropping any macro whose name or value merely contained the header's own include guard as a substring (e.g. guard `RTC_H` matching inside `RTC_HOUR_SECONDS`), causing undeclared-identifier compile errors.
-- [#1268](https://github.com/ThrowTheSwitch/Ceedling/issues/1268) Fixed a mockable header's `#include` losing the enums, structs, and function prototypes of a conditionally-included file (only its macros survived) when that `#include` was indented inside its `#ifdef` block, causing undeclared-identifier compile errors.
+- [#1268](https://github.com/ThrowTheSwitch/Ceedling/issues/1268) Fixed a mockable header's `#include` losing the enums, structs, and function prototypes of a conditionally-included file when that `#include` directive was indented inside its `#ifdef` block, causing undeclared-identifier compile errors.
 
 ### Gcov plugin
 

--- a/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
@@ -83,7 +83,12 @@ require 'set'
 
 # Parse GCC preprocessor output (from -fdirectives-only) to extract system include directives
 class PreprocessinatorLineMarkerIncludesExtractor
-  LINE_MARKER_REGEX = /^#\s+(\d+)\s+"([^"]+)"(?:\s+(\d+(?:\s+\d+)*))?$/ unless const_defined?(:LINE_MARKER_REGEX)
+  # Leading whitespace is tolerated (`^\s*`, not just `^`): GCC's -fdirectives-only output
+  # replaces a top-level #include with a line marker that inherits that #include's own
+  # original indentation (GH #1268) -- an indented `#include "x.h"` produces an indented
+  # `    # 1 "x.h" 1`, not the flush-left marker every OTHER marker GCC generates uses.
+  # Without this, such an include is silently missing from the extracted list entirely.
+  LINE_MARKER_REGEX = /^\s*#\s+(\d+)\s+"([^"]+)"(?:\s+(\d+(?:\s+\d+)*))?$/ unless const_defined?(:LINE_MARKER_REGEX)
 
   SYSTEM = :system  unless const_defined?(:SYSTEM)
   USER   = :user    unless const_defined?(:USER)

--- a/lib/ceedling/preprocess/preprocessinator_reconstructor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_reconstructor.rb
@@ -279,10 +279,16 @@ class PreprocessinatorReconstructor
   def _scan_expansion_for_file(input, filepath, &block)
     # Expand filepath under inspection to ensure proper match
     extraction_filepath = File.expand_path( filepath )
-    # Preprocessor directive blocks generally take the form of '# <digits> <text> [optional digits]'
-    directive   = /^# \d+ \"/
+    # Preprocessor directive blocks generally take the form of '# <digits> <text> [optional digits]'.
+    # Leading whitespace is tolerated (`^\s*`, not just `^`): GCC's -fdirectives-only output
+    # replaces a top-level #include with a line marker that inherits that #include's own
+    # original indentation (GH #1268) -- an indented `#include "x.h"` produces an indented
+    # `    # 1 "x.h" 1`, not the flush-left marker every OTHER marker GCC generates uses.
+    # Failing to recognize such a marker here leaves `extract` stuck at whatever it already
+    # was instead of correctly toggling off, leaking the ignored file's content into output.
+    directive   = /^\s*# \d+ \"/
     # Line markers have the specific form of '# <digits> "path/filename.ext" [optional digits]' (see above)
-    line_marker = /^#\s(\d+)\s\"(.+)\"/
+    line_marker = /^\s*#\s(\d+)\s\"(.+)\"/
     # Boolean to ping pong between line-by-line extract/ignore
     extract = false
 

--- a/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
@@ -68,6 +68,23 @@ describe PreprocessinatorLineMarkerIncludesExtractor do
       expect( paths_of(includes) ).to eq( ['widget.h'] )
     end
 
+    # #1268: GCC's -fdirectives-only output preserves the ORIGINAL indentation of a
+    # top-level #include when it replaces that directive with a line marker entering
+    # the included file -- an indented `    #include "widget.h"` produces an indented
+    # `    # 1 "widget.h" 1`, not the flush-left marker every other marker GCC
+    # generates uses. LINE_MARKER_REGEX must recognize that marker too, or the include
+    # is silently missing from the extracted list entirely.
+    it 'recognizes a line marker that is itself indented (e.g. from an indented #include)' do
+      content = <<~OUTPUT
+        # 1 "test.c"
+            # 1 "widget.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['widget.h'] )
+    end
+
     it 'extracts only non-system (flag 3 absent) includes for USER type' do
       content = <<~OUTPUT
         # 1 "test.c"

--- a/spec/units/preprocess/preprocessinator_reconstructor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_reconstructor_spec.rb
@@ -211,6 +211,41 @@ describe PreprocessinatorReconstructor do
       expect( @extractor.extract_file_as_array_from_expansion(input, filepath) ).to eq expected
     end
   
+    # #1268: GCC's -fdirectives-only output preserves the ORIGINAL indentation of a
+    # top-level #include when it replaces that directive with a line marker entering
+    # the included file -- e.g. a source line "    #include \"Module3.h\"" produces
+    # "    # 1 \"Module3.h\" 1", not the flush-left "# 1 ..." this method's marker
+    # regexes assumed every marker would be. An unrecognized entering-marker leaves
+    # `extract` stuck at whatever it already was instead of turning off, so the
+    # marker line itself (and everything up to the NEXT recognized marker, e.g. one
+    # from a nested system include triggered from inside the ignored file) leaks into
+    # the extracted output before the ping-pong finally self-corrects.
+    it "does not leak file content when the marker entering an included file is itself indented" do
+      filepath = "dir/our_file.c"
+
+      file_contents = [
+        '# 1 "dir/our_file.c"',
+        'void wanted_before(void);',
+        '    # 1 "dir/included.h" 1',        # indented entering-marker (leading whitespace from source)
+        'int leaked_from_included_h;',
+        '# 1 "/usr/include/nested.h" 1 3 4',  # a normal, flush-left marker from within included.h
+        'int also_should_not_leak;',
+        '# 2 "dir/included.h" 2',             # returning from nested.h back into included.h (still not our file)
+        'int still_should_not_leak;',
+        '# 3 "dir/our_file.c" 2',             # returning to our file
+        'void wanted_after(void);',
+      ]
+
+      expected = [
+        'void wanted_before(void);',
+        'void wanted_after(void);',
+      ]
+
+      input = StringIO.new( file_contents.join( "\n" ) )
+
+      expect( @extractor.extract_file_as_array_from_expansion( input, filepath ) ).to eq expected
+    end
+
     it "should extract text of original file from preprocessed expansion ignoring embedded expansions having similar names" do
       filepath = "dir1/dir2/our_file.c"
       


### PR DESCRIPTION
Fixes #1268.

## Root cause

GCC's `-fdirectives-only` preprocessing mode replaces a top-level `#include` with a line marker entering the included file. When that `#include` itself had leading whitespace in the source (e.g. indented inside an `#ifdef` block), GCC's marker for it inherits that same indentation:

```c
#ifdef ENABLE_MODULE3
    #include "Module3.h"
#endif
```
produces
```
    # 1 "Module3.h" 1
```
— unlike every other marker GCC emits, which is always flush-left. Two separate line-marker regexes assumed every marker would be flush-left and silently failed to match the indented one:

1. `PreprocessinatorReconstructor#_scan_expansion_for_file`'s `directive`/`line_marker` regexes — failing to recognize the marker left `extract` stuck in whatever state it was already in instead of correctly turning off, leaking the ignored file's own content (its include guard, in the reported case) into the reconstructed header before a later, flush-left marker (e.g. from a nested system include) finally corrected it.
2. `PreprocessinatorLineMarkerIncludesExtractor::LINE_MARKER_REGEX` — the unmatched marker meant the conditionally-included file was never added to the extracted includes list at all, so its own literal `#include` line was never reinserted into the assembled mockable header either — losing every declaration from that file (enums, structs, function prototypes), matching the reported symptom exactly.

Both regexes now tolerate optional leading whitespace before the `#`.

## Diagnostic methodology

The reporter's own hypothesis (a regex assuming `#include` lands at column 0) was checked first against every obvious `#include`-detection site in the codebase — all of those turned out to already be indentation-safe. The actual bug was in a less obvious place: GCC's own **line-marker** output for a directives-only pass, which (unlike every other marker) inherits indentation from the original `#include` line it replaces. This was confirmed empirically by running the reporter's own reproduction project end-to-end in a `madsciencelab-plugins` Docker container against this branch's checked-out code (real GCC 14.2.0, real CMock 2.7.2) and diffing the generated intermediate files at each pipeline stage between the working (flush-left) and broken (indented) cases, rather than continuing to reason from code alone.

## Verification

- Unit tests: new regression tests in both affected spec files, verified failing against pre-fix code, passing after.
- End-to-end: re-ran the reporter's own reproduction project after the fix — the previously-failing mock build now compiles and passes cleanly, and the generated header now matches the working (non-indented) case's output in substance (include guard, macros, and the literal `#include "Module3.h"` all present and correctly ordered).
- `bundle exec rake specs:units` clean (3222 examples, 0 failures) on host.

Unit tests only in the diff itself, per this session's established scoping — the Docker run was verification, not a checked-in system test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)