### PR TITLE
Fix indented #include inside a conditional block losing content in mockable headers (#1268)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -24,6 +24,7 @@ This changelog is complemented by three other documents:
 ### Preprocessing
 
 - [#1266](https://github.com/ThrowTheSwitch/Ceedling/issues/1266) Fixed a reconstructed header silently dropping any macro whose name or value merely contained the header's own include guard as a substring (e.g. guard `RTC_H` matching inside `RTC_HOUR_SECONDS`), causing undeclared-identifier compile errors.
+- [#1268](https://github.com/ThrowTheSwitch/Ceedling/issues/1268) Fixed a mockable header's `#include` losing the enums, structs, and function prototypes of a conditionally-included file (only its macros survived) when that `#include` was indented inside its `#ifdef` block, causing undeclared-identifier compile errors.
 
 ### Gcov plugin
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -24,7 +24,7 @@ This changelog is complemented by three other documents:
 ### Preprocessing
 
 - [#1266](https://github.com/ThrowTheSwitch/Ceedling/issues/1266) Fixed a reconstructed header silently dropping any macro whose name or value merely contained the header's own include guard as a substring (e.g. guard `RTC_H` matching inside `RTC_HOUR_SECONDS`), causing undeclared-identifier compile errors.
-- [#1268](https://github.com/ThrowTheSwitch/Ceedling/issues/1268) Fixed a mockable header's `#include` losing the enums, structs, and function prototypes of a conditionally-included file (only its macros survived) when that `#include` was indented inside its `#ifdef` block, causing undeclared-identifier compile errors.
+- [#1268](https://github.com/ThrowTheSwitch/Ceedling/issues/1268) Fixed a mockable header's `#include` losing the enums, structs, and function prototypes of a conditionally-included file when that `#include` was indented inside its `#ifdef` block, causing undeclared-identifier compile errors.
 
 ### Gcov plugin
 

--- a/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
@@ -82,7 +82,12 @@ require 'set'
 
 # Parse GCC preprocessor output (from -fdirectives-only) to extract system include directives
 class PreprocessinatorLineMarkerIncludesExtractor
-  LINE_MARKER_REGEX = /^#\s+(\d+)\s+"([^"]+)"(?:\s+(\d+(?:\s+\d+)*))?$/ unless const_defined?(:LINE_MARKER_REGEX)
+  # Leading whitespace is tolerated (`^\s*`, not just `^`): GCC's -fdirectives-only output
+  # replaces a top-level #include with a line marker that inherits that #include's own
+  # original indentation (GH #1268) -- an indented `#include "x.h"` produces an indented
+  # `    # 1 "x.h" 1`, not the flush-left marker every OTHER marker GCC generates uses.
+  # Without this, such an include is silently missing from the extracted list entirely.
+  LINE_MARKER_REGEX = /^\s*#\s+(\d+)\s+"([^"]+)"(?:\s+(\d+(?:\s+\d+)*))?$/ unless const_defined?(:LINE_MARKER_REGEX)
 
   SYSTEM = :system  unless const_defined?(:SYSTEM)
   USER   = :user    unless const_defined?(:USER)

--- a/lib/ceedling/preprocess/preprocessinator_reconstructor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_reconstructor.rb
@@ -278,10 +278,16 @@ class PreprocessinatorReconstructor
   def _scan_expansion_for_file(input, filepath, &block)
     # Expand filepath under inspection to ensure proper match
     extraction_filepath = File.expand_path( filepath )
-    # Preprocessor directive blocks generally take the form of '# <digits> <text> [optional digits]'
-    directive   = /^# \d+ \"/
+    # Preprocessor directive blocks generally take the form of '# <digits> <text> [optional digits]'.
+    # Leading whitespace is tolerated (`^\s*`, not just `^`): GCC's -fdirectives-only output
+    # replaces a top-level #include with a line marker that inherits that #include's own
+    # original indentation (GH #1268) -- an indented `#include "x.h"` produces an indented
+    # `    # 1 "x.h" 1`, not the flush-left marker every OTHER marker GCC generates uses.
+    # Failing to recognize such a marker here leaves `extract` stuck at whatever it already
+    # was instead of correctly toggling off, leaking the ignored file's content into output.
+    directive   = /^\s*# \d+ \"/
     # Line markers have the specific form of '# <digits> "path/filename.ext" [optional digits]' (see above)
-    line_marker = /^#\s(\d+)\s\"(.+)\"/
+    line_marker = /^\s*#\s(\d+)\s\"(.+)\"/
     # Boolean to ping pong between line-by-line extract/ignore
     extract = false
 

--- a/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
@@ -1,0 +1,64 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_helper'
+require 'ceedling/preprocess/preprocessinator_line_marker_includes_extractor'
+require 'ceedling/includes/includes'
+
+# Regression coverage for GH #1268 only -- this class otherwise has no unit spec on this
+# branch. Built on #extract_includes_from_string, a StringIO wrapper around the same
+# private #extract_includes every production call eventually reaches.
+describe PreprocessinatorLineMarkerIncludesExtractor do
+  before(:each) do
+    @include_factory = double('include_factory')
+
+    allow(@include_factory).to receive(:user_include_from_filepath) do |filepath|
+      UserInclude.new(filepath)
+    end
+    allow(@include_factory).to receive(:system_include_from_filepath) do |filepath|
+      SystemInclude.new(filepath)
+    end
+
+    @extractor = described_class.new(
+      :include_factory => @include_factory
+    )
+  end
+
+  def paths_of(includes)
+    includes.map(&:filepath)
+  end
+
+  describe '#extract_includes_from_string' do
+    # #1268: GCC's -fdirectives-only output preserves the ORIGINAL indentation of a
+    # top-level #include when it replaces that directive with a line marker entering
+    # the included file -- an indented `    #include "widget.h"` produces an indented
+    # `    # 1 "widget.h" 1`, not the flush-left marker every other marker GCC
+    # generates uses. LINE_MARKER_REGEX must recognize that marker too, or the include
+    # is silently missing from the extracted list entirely.
+    it 'recognizes a line marker that is itself indented (e.g. from an indented #include)' do
+      content = <<~OUTPUT
+        # 1 "test.c"
+            # 1 "widget.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['widget.h'] )
+    end
+
+    it 'still recognizes an ordinary, flush-left line marker' do
+      content = <<~OUTPUT
+        # 1 "test.c"
+        # 1 "widget.h" 1
+      OUTPUT
+
+      includes = @extractor.extract_includes_from_string( content, 'test.c', described_class::USER )
+
+      expect( paths_of(includes) ).to eq( ['widget.h'] )
+    end
+  end
+end

--- a/spec/units/preprocess/preprocessinator_reconstructor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_reconstructor_spec.rb
@@ -211,6 +211,41 @@ describe PreprocessinatorReconstructor do
       expect( @extractor.extract_file_as_array_from_expansion(input, filepath) ).to eq expected
     end
   
+    # #1268: GCC's -fdirectives-only output preserves the ORIGINAL indentation of a
+    # top-level #include when it replaces that directive with a line marker entering
+    # the included file -- e.g. a source line "    #include \"Module3.h\"" produces
+    # "    # 1 \"Module3.h\" 1", not the flush-left "# 1 ..." this method's marker
+    # regexes assumed every marker would be. An unrecognized entering-marker leaves
+    # `extract` stuck at whatever it already was instead of turning off, so the
+    # marker line itself (and everything up to the NEXT recognized marker, e.g. one
+    # from a nested system include triggered from inside the ignored file) leaks into
+    # the extracted output before the ping-pong finally self-corrects.
+    it "does not leak file content when the marker entering an included file is itself indented" do
+      filepath = "dir/our_file.c"
+
+      file_contents = [
+        '# 1 "dir/our_file.c"',
+        'void wanted_before(void);',
+        '    # 1 "dir/included.h" 1',        # indented entering-marker (leading whitespace from source)
+        'int leaked_from_included_h;',
+        '# 1 "/usr/include/nested.h" 1 3 4',  # a normal, flush-left marker from within included.h
+        'int also_should_not_leak;',
+        '# 2 "dir/included.h" 2',             # returning from nested.h back into included.h (still not our file)
+        'int still_should_not_leak;',
+        '# 3 "dir/our_file.c" 2',             # returning to our file
+        'void wanted_after(void);',
+      ]
+
+      expected = [
+        'void wanted_before(void);',
+        'void wanted_after(void);',
+      ]
+
+      input = StringIO.new( file_contents.join( "\n" ) )
+
+      expect( @extractor.extract_file_as_array_from_expansion( input, filepath ) ).to eq expected
+    end
+
     it "should extract text of original file from preprocessed expansion ignoring embedded expansions having similar names" do
       filepath = "dir1/dir2/our_file.c"
       


### PR DESCRIPTION
Fixes #1268. Port of #1275 (green on \`next_version\`) to \`master\`, for inclusion in 1.1.8.

## Root cause

GCC's \`-fdirectives-only\` preprocessing mode replaces a top-level \`#include\` with a line marker entering the included file. When that \`#include\` itself had leading whitespace in the source (e.g. indented inside an \`#ifdef\` block), GCC's marker for it inherits that same indentation — unlike every other marker GCC emits, which is always flush-left. Two separate line-marker regexes assumed every marker would be flush-left and silently failed to match the indented one:

1. \`PreprocessinatorReconstructor#_scan_expansion_for_file\`'s \`directive\`/\`line_marker\` regexes — failing to recognize the marker left \`extract\` stuck in whatever state it was already in instead of correctly turning off, leaking the ignored file's own content (its include guard, in the reported case) into the reconstructed header.
2. \`PreprocessinatorLineMarkerIncludesExtractor::LINE_MARKER_REGEX\` — the unmatched marker meant the conditionally-included file was never added to the extracted includes list at all, so its own literal \`#include\` line was never reinserted into the assembled mockable header either — losing every declaration from that file, matching the reported symptom exactly.

Both regexes now tolerate optional leading whitespace before the \`#\`.

## Note on this port

\`master\`'s \`preprocessinator_line_marker_includes_extractor.rb\` has no unit spec at all on this branch (the file that carries this coverage on \`next_version\` doesn't exist here — an existing, unrelated gap between the branches, not something this PR introduces). Rather than backport an entire spec file built around \`next_version\`'s slightly different constructor/API shape (it takes a \`file_wrapper\` and a \`test:\` keyword argument there; neither exists on \`master\`), this PR adds a small, self-contained spec file scoped to this fix, matching \`master\`'s actual current class shape.

## Verification

Same as #1275: new regression tests verified failing against pre-fix code, passing after; the reporter's own reproduction project re-run end-to-end via Docker (real GCC 14.2.0, real CMock 2.7.2) confirmed the fix resolves the actual reported failure. \`bundle exec rake specs:units\` clean (1997 examples, 0 failures, 1 pre-existing unrelated pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)