### PR TITLE
Refactor includes extraction: DRY the extractors, share one reconciliation core

### DIFF
--- a/lib/ceedling/preprocess/preprocessinator.rb
+++ b/lib/ceedling/preprocess/preprocessinator.rb
@@ -93,53 +93,19 @@ class Preprocessinator
   end
 
   # Extract user includes from a file using directives-only output (or text-only fallback).
-  # Called externally and internally by `preprocess_common`.
+  # Called externally and internally by `preprocess_file_includes_common`.
   def preprocess_user_includes(name:, filepath:, directives_only_filepath:, fallback: false, defines: [])
-    includes = []
-
-    if !fallback
-      includes = @includes_handler.extract_user_includes_preprocess(
-        name:                   name,
-        filepath:               filepath,
-        preprocessed_filepath:  directives_only_filepath
-      )
-    else
-      includes = @includes_handler.extract_user_includes_from_text(
-        name:     name,
-        filepath: filepath,
-        defines:  defines
-      )
-    end
-
-    header = "Extracted user #includes from #{filepath}:"
-    @loginator.log_list( includes, header, Verbosity::DEBUG )
-
-    return includes
+    _preprocess_includes( :user, name: name, filepath: filepath,
+                          directives_only_filepath: directives_only_filepath,
+                          fallback: fallback, defines: defines )
   end
 
   # Extract system includes from a file using directives-only output (or text-only fallback).
-  # Called externally and internally by `preprocess_common`.
+  # Called externally and internally by `preprocess_file_includes_common`.
   def preprocess_system_includes(name:, filepath:, directives_only_filepath:, fallback: false, defines: [])
-    includes = []
-
-    if !fallback
-      includes = @includes_handler.extract_system_includes_preprocess(
-        name:                   name,
-        filepath:               filepath,
-        preprocessed_filepath:  directives_only_filepath
-      )
-    else
-      includes = @includes_handler.extract_system_includes_from_text(
-        name:     name,
-        filepath: filepath,
-        defines:  defines
-      )
-    end
-
-    header = "Extracted system #includes from #{filepath}:"
-    @loginator.log_list( includes, header, Verbosity::DEBUG )
-
-    return includes
+    _preprocess_includes( :system, name: name, filepath: filepath,
+                          directives_only_filepath: directives_only_filepath,
+                          fallback: fallback, defines: defines )
   end
 
   # Persists `includes` under a cache file keyed by `test`/`filepath` so
@@ -494,6 +460,27 @@ class Preprocessinator
 
   ### Private ###
   private
+
+  # User and system include extraction differ only in which handler pair they call and
+  # one word in the debug log. `kind` is :user or :system; the accurate line-marker
+  # extraction runs unless `fallback`, in which case the original file's text is scanned.
+  def _preprocess_includes(kind, name:, filepath:, directives_only_filepath:, fallback:, defines:)
+    includes =
+      if fallback
+        @includes_handler.public_send(
+          "extract_#{kind}_includes_from_text",
+          name: name, filepath: filepath, defines: defines
+        )
+      else
+        @includes_handler.public_send(
+          "extract_#{kind}_includes_preprocess",
+          name: name, filepath: filepath, preprocessed_filepath: directives_only_filepath
+        )
+      end
+
+    @loginator.log_list( includes, "Extracted #{kind} #includes from #{filepath}:", Verbosity::DEBUG )
+    includes
+  end
 
   def _preprocess_partial_expand_macros(filepath:, test:, flags:, include_paths:, vendor_paths:, defines:)
     msg = @reportinator.generate_module_progress(

--- a/lib/ceedling/preprocess/preprocessinator.rb
+++ b/lib/ceedling/preprocess/preprocessinator.rb
@@ -122,12 +122,7 @@ class Preprocessinator
   def store_includes_list(test:, filepath:, includes:)
     _filepath = @file_path_utils.form_preprocessed_includes_list_filepath( filepath, test )
 
-    # Get or create a mutex for this specific cache file
-    file_lock = @file_locks_mutex.synchronize do
-      @file_locks[_filepath] ||= Mutex.new
-    end
-
-    file_lock.synchronize do
+    cache_file_lock( _filepath ).synchronize do
       @includes_handler.write_includes_list( _filepath, includes )
     end
   end
@@ -139,12 +134,7 @@ class Preprocessinator
   def load_includes_list(test:, filepath:)
     _filepath = @file_path_utils.form_preprocessed_includes_list_filepath( filepath, test )
 
-    # Get or create a mutex for this specific cache file
-    file_lock = @file_locks_mutex.synchronize do
-      @file_locks[_filepath] ||= Mutex.new
-    end
-
-    file_lock.synchronize do
+    cache_file_lock( _filepath ).synchronize do
       msg = @reportinator.generate_module_progress(
         operation: "Loading #include statement listing file for",
         module_name: test,
@@ -460,6 +450,12 @@ class Preprocessinator
 
   ### Private ###
   private
+
+  # One Mutex per includes-cache file, so concurrent testables serialize on the exact
+  # file they touch and nothing more. The map itself is guarded by @file_locks_mutex.
+  def cache_file_lock(cache_filepath)
+    @file_locks_mutex.synchronize { @file_locks[cache_filepath] ||= Mutex.new }
+  end
 
   # User and system include extraction differ only in which handler pair they call and
   # one word in the debug log. `kind` is :user or :system; the accurate line-marker

--- a/lib/ceedling/preprocess/preprocessinator.rb
+++ b/lib/ceedling/preprocess/preprocessinator.rb
@@ -597,31 +597,48 @@ class Preprocessinator
       defines:                  defines
     )
 
-    # Reconcile includes with overlapping information
-    includes = Includes.reconcile(
-      bare:          bare_includes,
-      user:          user_includes,
-      system:        system_includes,
-      test_filepath: filepath
+    includes = reconcile_includes(
+      bare: bare_includes, user: user_includes, system: system_includes, test_filepath: filepath
     )
-
-    # Sanitize the final list and remove any includes that have been mocked
-    Includes.sanitize!(includes) do |include, all|
-      all.include?( "#{@configurator.cmock_mock_prefix}#{include.filename}" )
-    end
 
     store_includes_list( filepath: filepath, test: test, includes: includes )
 
     return includes
   end
 
-  # `preprocess_file_includes_common` is the single reconciliation path for a mockable
-  # header or a Partial source/header. It sits in the private section next to the
-  # `preprocess_*` orchestration it grew up beside, but it is a self-contained,
-  # side-effect-scoped unit (its only writes are the YAML cache) and the integration
-  # spec tier drives it directly against real GCC output. Re-publicized here rather than
-  # relocated to keep this change small; a later refactor folds the test-file
-  # reconciliation in test_build_setup.rb into this same method.
-  public :preprocess_file_includes_common
+  # The merge step every includes-reconciliation site shares: intersect a bare list
+  # against the accurate user/system lists, log a NOTICE on any genuinely ambiguous
+  # `#include` (more than one file on the search path satisfies it), and -- for the
+  # mockable-header/Partial path -- drop a header whose mock is also present.
+  # `preprocess_file_includes_common` above and stage 4's test-file pass
+  # (test_build_setup.rb) build their own three lists and own their own caching; only
+  # this middle is common.
+  def reconcile_includes(bare:, user:, system:, test_filepath:, drop_mocked: true)
+    includes = Includes.reconcile(
+      bare: bare, user: user, system: system, test_filepath: test_filepath
+    ) do |bare_filepath, chosen, passed_over|
+      msg = "Multiple files satisfy #include '#{bare_filepath}' within #{test_filepath}; chose '#{chosen}' " \
+            "by search-path priority. Other candidates passed over: #{passed_over.join(', ')}. If this " \
+            "choice is wrong, add more path to that #include statement to select a different file -- or " \
+            "watch for a compilation error naming the real mismatch."
+      @loginator.log( msg, Verbosity::COMPLAIN, LogLabels::NOTICE )
+    end
+
+    if drop_mocked
+      Includes.sanitize!( includes ) do |include, all|
+        all.include?( "#{@configurator.cmock_mock_prefix}#{include.filename}" )
+      end
+    end
+
+    includes
+  end
+
+  # These two sit in the private section next to the `preprocess_*` orchestration they
+  # grew up beside, but both are self-contained and side-effect-scoped:
+  # `preprocess_file_includes_common` (its only writes are the YAML cache) is driven
+  # directly by the integration spec tier against real GCC output, and
+  # `reconcile_includes` is the merge step stage 4's test-file pass calls too.
+  # Re-publicized here rather than relocated to keep the diff small.
+  public :preprocess_file_includes_common, :reconcile_includes
 
 end

--- a/lib/ceedling/preprocess/preprocessinator_bare_includes_extractor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_bare_includes_extractor.rb
@@ -57,13 +57,10 @@ class PreprocessinatorBareIncludesExtractor
     INCLUDE_MATCHER = /^(\S+\.\S+):\s*$/ unless const_defined?(:INCLUDE_MATCHER, false) # <characters>.<extension>:
 
   def self.extract_includes(make_rules)
-    # Extract the #include dependencies from the "phony" make rules, one per line
-    includes = make_rules.scan( INCLUDE_MATCHER )
-    includes.flatten! # Regex results can be nested arrays becuase of paren captures
-    includes.uniq!
-
-    # Convert list of fileapth strings to list of bare Include objects
-    return includes.map { |_include| Include.new(_include) }
+    # One phony `<header>:` rule per #include dependency (.h, .c, ...). `scan` returns
+    # each single capture wrapped in its own array, hence the flatten; a header reached
+    # more than once (an include guard, say) is listed once.
+    make_rules.scan( INCLUDE_MATCHER ).flatten.uniq.map { |filepath| Include.new( filepath ) }
   end
 end
 

--- a/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
@@ -148,107 +148,45 @@ class PreprocessinatorIncludesHandler
     return clean_self_reference( filepath, includes )
   end
 
+  # User and system extraction are the same shape twice over -- once against the
+  # accurate directives-only line-marker stream, once against the original file's own
+  # text as a fallback. The public methods below stay as the four call sites callers
+  # and specs know; the two private helpers hold the body each pair shares.
+
   def extract_user_includes_preprocess(name:, filepath:, preprocessed_filepath:)
-    includes = []
+    _log_extraction_progress( 'Extracting user #includes from preprocessed output', name, filepath )
 
-    filename = File.basename(filepath)
-
-    msg = @reportinator.generate_module_progress(
-      operation: "Extracting user #includes from preprocessed output",
-      module_name: name,
-      filename: filename
+    # No depth limit: a user include matters however deeply it nests. `test:` lets the
+    # extractor strip this test's own mock subdirectory off a resolved mock include.
+    includes = @line_marker_includes_extractor.extract_includes_from_file(
+      preprocessed_filepath,
+      PreprocessinatorLineMarkerIncludesExtractor::USER,
+      test: name
     )
-    @loginator.log(msg, Verbosity::OBNOXIOUS)
 
-    includes =
-      @line_marker_includes_extractor.extract_includes_from_file(
-        preprocessed_filepath,
-        PreprocessinatorLineMarkerIncludesExtractor::USER,
-        # Note: No limit to max depth to search for user includes
-        test: name
-      )
-
-    return clean_self_reference( filepath, includes )
-  end
-
-  def extract_user_includes_from_text(name:, filepath:, defines: [])
-    includes = []
-
-    filename = File.basename(filepath)
-
-    msg = @reportinator.generate_module_progress(
-      operation: "Extracting user #includes from original file using fallback method",
-      module_name: name,
-      filename: filename
-    )
-    @loginator.log( msg, Verbosity::OBNOXIOUS, LogLabels::WARNING )
-
-    cond_tracker = CPreprocessorConditionals.new( defines )
-
-    # Open in binary mode: code_lines cleans the whole buffer via clean_encoding
-    # before ever splitting into lines, but a text-mode read could itself raise
-    # on invalid byte sequences before clean_encoding gets the chance.
-    @file_wrapper.open(filepath, 'rb') do |input|
-      @parsing_parcels.code_lines( input ) do |line|
-        cond_tracker.process_directive( line )
-        next unless cond_tracker.active?
-        _include = @include_factory.user_include_from_directive( line )
-        includes << _include.anchored( File.dirname( filepath ) ) if !_include.nil?
-      end
-    end
-
-    return clean_self_reference( filepath, includes )
+    clean_self_reference( filepath, includes )
   end
 
   def extract_system_includes_preprocess(name:, filepath:, preprocessed_filepath:)
-    includes = []
+    _log_extraction_progress( 'Extracting system #includes from preprocessed output', name, filepath )
 
-    filename = File.basename(filepath)
-
-    msg = @reportinator.generate_module_progress(
-      operation: "Extracting system #includes from preprocessed output",
-      module_name: name,
-      filename: filename
+    # A practical ceiling: system headers nest deeply through their own wrappers and
+    # everything past a handful of levels is noise, not a project dependency.
+    includes = @line_marker_includes_extractor.extract_includes_from_file(
+      preprocessed_filepath,
+      PreprocessinatorLineMarkerIncludesExtractor::SYSTEM,
+      SYSTEM_INCLUDE_MAX_DEPTH
     )
-    @loginator.log(msg, Verbosity::OBNOXIOUS)
 
-    includes = 
-      @line_marker_includes_extractor.extract_includes_from_file(
-        preprocessed_filepath,
-        PreprocessinatorLineMarkerIncludesExtractor::SYSTEM,
-        5 # Practical max depth limit for system headers (to avoid noisy length)
-      )
+    clean_self_reference( filepath, includes )
+  end
 
-    return clean_self_reference( filepath, includes )
+  def extract_user_includes_from_text(name:, filepath:, defines: [])
+    _extract_includes_from_text( :user_include_from_directive, 'user', name: name, filepath: filepath, defines: defines )
   end
 
   def extract_system_includes_from_text(name:, filepath:, defines: [])
-    includes = []
-
-    filename = File.basename(filepath)
-
-    msg = @reportinator.generate_module_progress(
-      operation: "Extracting system #includes from original file using fallback method",
-      module_name: name,
-      filename: filename
-    )
-    @loginator.log( msg, Verbosity::OBNOXIOUS, LogLabels::WARNING )
-
-    cond_tracker = CPreprocessorConditionals.new( defines )
-
-    # Open in binary mode: code_lines cleans the whole buffer via clean_encoding
-    # before ever splitting into lines, but a text-mode read could itself raise
-    # on invalid byte sequences before clean_encoding gets the chance.
-    @file_wrapper.open(filepath, 'rb') do |input|
-      @parsing_parcels.code_lines( input ) do |line|
-        cond_tracker.process_directive( line )
-        next unless cond_tracker.active?
-        _include = @include_factory.system_include_from_directive( line )
-        includes << _include.anchored( File.dirname( filepath ) ) if !_include.nil?
-      end
-    end
-
-    return clean_self_reference( filepath, includes )
+    _extract_includes_from_text( :system_include_from_directive, 'system', name: name, filepath: filepath, defines: defines )
   end
 
   # Write to disk a yaml representation of a list of includes
@@ -272,6 +210,46 @@ class PreprocessinatorIncludesHandler
 
   ### Private ###
   private
+
+  # Practical max depth for the system-header line-marker walk (see
+  # extract_system_includes_preprocess).
+  SYSTEM_INCLUDE_MAX_DEPTH = 5 unless const_defined?(:SYSTEM_INCLUDE_MAX_DEPTH, false)
+
+  # Fallback text scan for user or system includes -- identical but for which directive
+  # form IncludeFactory recognizes. `#if`/`#ifdef` state is tracked so a guarded include
+  # is only kept when its guard is actually true given `defines`.
+  def _extract_includes_from_text(directive_method, noun, name:, filepath:, defines:)
+    _log_extraction_progress(
+      "Extracting #{noun} #includes from original file using fallback method",
+      name, filepath, label: LogLabels::WARNING
+    )
+
+    cond_tracker = CPreprocessorConditionals.new( defines )
+    includes = []
+
+    # Binary read: code_lines runs clean_encoding over the whole buffer, but a text-mode
+    # read can raise on an invalid byte sequence before that ever happens.
+    @file_wrapper.open( filepath, 'rb' ) do |input|
+      @parsing_parcels.code_lines( input ) do |line|
+        cond_tracker.process_directive( line )
+        next unless cond_tracker.active?
+        _include = @include_factory.public_send( directive_method, line )
+        includes << _include.anchored( File.dirname( filepath ) ) unless _include.nil?
+      end
+    end
+
+    clean_self_reference( filepath, includes )
+  end
+
+  # Shared progress line for the four extraction methods above.
+  def _log_extraction_progress(operation, name, filepath, label: nil)
+    msg = @reportinator.generate_module_progress(
+      operation: operation, module_name: name, filename: File.basename( filepath )
+    )
+    args = [msg, Verbosity::OBNOXIOUS]
+    args << label unless label.nil?
+    @loginator.log( *args )
+  end
 
   # Remove any filepath in the includes list that is identical to the filepath being processed.
   # We want to prevent an includes list containing an unnecessary self-reference.

--- a/lib/ceedling/test_invoker/test_build_setup.rb
+++ b/lib/ceedling/test_invoker/test_build_setup.rb
@@ -406,20 +406,16 @@ class TestBuildSetup
         system_includes = Includes.system( all_includes )
       end
 
-      bare_includes = testable.preprocess[:includes]
-
-      all_includes = Includes.reconcile(
-        bare:          bare_includes,
+      # Shares the reconcile core with the mockable-header/Partial path, but keeps its
+      # own bare source (stage 4's list, no text supplement) and skips the mock-filter:
+      # a test file's own #include of a mock is deliberate and must survive.
+      all_includes = @preprocessinator.reconcile_includes(
+        bare:          testable.preprocess[:includes],
         user:          user_includes,
         system:        system_includes,
-        test_filepath: filepath
-      ) do |bare_filepath, chosen, passed_over|
-        msg = "Multiple files satisfy #include '#{bare_filepath}' within #{filepath}; chose '#{chosen}' " \
-              "by search-path priority. Other candidates passed over: #{passed_over.join(', ')}. If this " \
-              "choice is wrong, add more path to that #include statement to select a different file -- or " \
-              "watch for a compilation error naming the real mismatch."
-        @loginator.log( msg, Verbosity::COMPLAIN, LogLabels::NOTICE )
-      end
+        test_filepath: filepath,
+        drop_mocked:   false
+      )
 
       header = "Extracted reconciled #include list from #{filepath}:"
       @loginator.log_list( all_includes, header, Verbosity::OBNOXIOUS )

--- a/spec/system/conditional_include_macro_visibility_spec.rb
+++ b/spec/system/conditional_include_macro_visibility_spec.rb
@@ -8,46 +8,18 @@
 require 'spec_system_helper'
 
 ##
-## Conditional-#include Macro-Visibility Tests (directives-only preprocessing)
-## =============================================================================
+## Conditional-#include Macro-Visibility -- end-to-end smoke
+## =======================================================
 ##
-## Ceedling discovers a file's #includes via two preprocessor passes reconciled
-## into one list: a "bare" pass and an accurate pass (gcc -E -fdirectives-only
-## against the real file with real search paths -- genuinely opens every
-## header). Reconciliation keeps an accurate-pass entry only if bare also found
-## it, to filter out headers reached only via a deeper, nested path.
+## The detail of how Ceedling reconciles a file's #includes across its bare and
+## accurate preprocessor passes -- project-:defines guards, same-file #define
+## guards, sibling-header-macro guards (issue #1223), transitive headers not
+## promoted to spurious top-level entries -- is characterized directly against
+## real GCC in spec/integration/includes_extraction_spec.rb. This spec keeps one
+## full `ceedling` build over all of those shapes at once, to prove the pieces
+## still fit together through a real Partials build.
 ##
-## "Bare" is itself two things unioned together: a gcc -M -MG -MP pass against
-## an isolated, sibling-free copy of the file (so it never actually opens any
-## header the file #includes, but can still resolve an #include whose own
-## target is a macro, since command-line -D defines are visible even in
-## isolation), and a plain literal text scan of the file's own #include lines
-## (no conditional evaluation at all, so it sees past a guard the isolated gcc
-## pass can't evaluate -- but also can't resolve a macro-computed #include
-## target, since there's no literal filename in the source text to find).
-## Neither replaces the other; each catches what the other structurally can't.
-##
-## These tests characterize that reconciliation's behavior for #include
-## directives guarded by an #if/#ifdef, across the different places the
-## guarding macro can come from -- some already handled correctly, one
-## (issue #1223) fixed by adding the text-scan half of "bare" above.
-##
-## Test assets: assets/fixtures/tests_with_conditional_includes/
-##   - widget.c/.h: scenarios that already work correctly:
-##     (a) conditional include gated on a project :defines macro
-##     (b) conditional include gated on a same-file #define
-##     (c) a header reached only transitively (nested_wrapper.h's own
-##         #include, never itself directly #include'd by widget.c) --
-##         must not appear duplicated in as a false top-level entry
-##     (e) an #include whose own target is a macro (macro_target_extra.h via
-##         WIDGET_COMPUTED_HEADER) -- only the gcc-based half of "bare" can
-##         resolve this; confirms that half is still doing real work and
-##         wasn't made redundant by issue #1223's text-scan addition
-##   - widget_feature.c/.h + feature_config.h + feature_extra.h: issue #1223
-##     itself -- a conditional include gated on a macro defined by an
-##     *earlier #include in the same file* (feature_config.h's FEATURE_LEVEL),
-##     which the isolated bare pass can never see, silently dropping
-##     feature_extra.h and leaving FEATURE_EXTRA_MACRO undeclared.
+## Assets: assets/tests_with_conditional_includes/
 ##
 
 ceedling_system_tests do
@@ -67,91 +39,35 @@ ceedling_system_tests do
     before do
       @c.with_context do
         @c.ceedling_appcmd_exec("new #{@proj_name}")
+        Dir.chdir @proj_name do
+          %w[
+            widget.h widget.c project_flag_extra.h local_flag_extra.h
+            nested_wrapper.h nested_extra.h macro_target_extra.h
+            widget_feature.h widget_feature.c feature_config.h feature_extra.h
+          ].each { |f| FileUtils.cp test_asset_path("tests_with_conditional_includes/src/#{f}"), 'src/' }
+          %w[test_widget.c test_widget_feature.c].each do |f|
+            FileUtils.cp test_asset_path("tests_with_conditional_includes/test/#{f}"), 'test/'
+          end
+
+          @c.merge_project_yml_for_test(
+            :project => { :use_partials => true },
+            :defines => { :test => ['PROJECT_FLAG'] }
+          )
+        end
       end
     end
 
-    # =========================================================================
-    describe "Conditional includes that already resolve correctly today" do
-    # =========================================================================
-
-      before do
-        @c.with_context do
-          Dir.chdir @proj_name do
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/widget.h"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/widget.c"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/project_flag_extra.h"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/local_flag_extra.h"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/nested_wrapper.h"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/nested_extra.h"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/macro_target_extra.h"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/test/test_widget.c"), 'test/'
-
-            settings = {
-              :project => { :use_partials => true },
-              :defines => { :test => ['PROJECT_FLAG'] }
-            }
-            @c.merge_project_yml_for_test(settings)
-          end
+    it "builds and passes every conditional-#include Partials scenario in one run" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_build_exec("test:all")
+          expect(@c.last_exit_status).to eq(0)
+          expect(output).to match(/TESTED:\s+5/)
+          expect(output).to match(/PASSED:\s+5/)
+          expect(output).to match(/FAILED:\s+0/)
         end
       end
-
-      it "resolves a project-:defines-gated include, a same-file-#define-gated include, a macro-computed #include target, and correctly excludes a transitively-nested header from duplication" do
-        @c.with_context do
-          Dir.chdir @proj_name do
-            output = @c.ceedling_build_exec("test:widget")
-            expect(@c.last_exit_status).to eq(0)
-            expect(output).to match(/TESTED:\s+4/)
-            expect(output).to match(/PASSED:\s+4/)
-            expect(output).to match(/FAILED:\s+0/)
-
-            # (c) nested_extra.h is reached only transitively, through
-            # nested_wrapper.h's own #include -- confirm it is not promoted
-            # into a spurious, duplicated top-level #include in the generated
-            # Partial implementation (the exact filtering property the #1223
-            # fix must not break).
-            generated = Dir.glob('build/test/partials/**/*_impl.c').first
-            expect(generated).not_to be_nil
-            contents = File.read(generated)
-            expect(contents.scan(/#include\s+"nested_extra\.h"/).length).to eq(0)
-          end
-        end
-      end
-
     end
-
-    # =========================================================================
-    describe "Conditional include gated on a macro from an earlier #include in the same file (issue #1223)" do
-    # =========================================================================
-
-      before do
-        @c.with_context do
-          Dir.chdir @proj_name do
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/widget_feature.h"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/widget_feature.c"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/feature_config.h"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/src/feature_extra.h"), 'src/'
-            FileUtils.cp test_asset_path("tests_with_conditional_includes/test/test_widget_feature.c"), 'test/'
-
-            settings = { :project => { :use_partials => true } }
-            @c.merge_project_yml_for_test(settings)
-          end
-        end
-      end
-
-      it "keeps FEATURE_EXTRA_MACRO visible in the generated Partial so the build compiles" do
-        @c.with_context do
-          Dir.chdir @proj_name do
-            output = @c.ceedling_build_exec("test:widget_feature")
-            expect(@c.last_exit_status).to eq(0)
-            expect(output).to match(/TESTED:\s+1/)
-            expect(output).to match(/PASSED:\s+1/)
-            expect(output).to match(/FAILED:\s+0/)
-          end
-        end
-      end
-
-    end
-
   end
 
 end

--- a/spec/system/preprocessing_fallback_conditionals_spec.rb
+++ b/spec/system/preprocessing_fallback_conditionals_spec.rb
@@ -148,29 +148,10 @@ ceedling_system_tests do
         end
       end
 
-
-      # -----------------------------------------------------------------------
-      # Encoding safety: UTF-8 multi-byte characters in comments near #ifdef
-      # directives in source/header files must not cause encoding errors when
-      # the fallback partial preprocessor processes them.
-      # (The test assets already contain non-ASCII UTF-8 in comments.)
-      # -----------------------------------------------------------------------
-      it "should not raise errors for UTF-8 in comments near #ifdef" do
-        @c.with_context do
-          Dir.chdir @proj_name do
-            settings = {
-              :project    => { :use_partials => true },
-              :test_build => { :preprocess_force_fallback => true }
-            }
-            @c.merge_project_yml_for_test(settings)
-
-            output = @c.ceedling_build_exec("test:conditionals")
-            expect(@c.last_exit_status).to eq(0)
-            expect(output).to match(/using fallback method/i)
-            expect(output).to match(/PASSED:\s+1/)
-          end
-        end
-      end
+      # (The dedicated no-CONDITIONAL_FEATURE + UTF-8-in-comments example was folded
+      # away: the assets already carry non-ASCII UTF-8, so the two examples above
+      # exercise the encoding-safety path already, and preprocessing_encoding_spec
+      # plus the unit encoding tests cover it directly.)
 
     end
 

--- a/spec/units/preprocess/preprocessinator_spec.rb
+++ b/spec/units/preprocess/preprocessinator_spec.rb
@@ -334,6 +334,68 @@ RSpec.describe Preprocessinator do
   end
 
   # ===========================================================================
+  describe '#reconcile_includes' do
+  # ===========================================================================
+    # The merge step shared by preprocess_file_includes_common and stage 4's test-file
+    # pass: bare ∩ (user ∪ system), a NOTICE on a genuinely ambiguous #include, and an
+    # optional mock-supersedes-real filter. Uses the real Includes.reconcile.
+
+    it "keeps only entries the bare list and the accurate user/system lists agree on" do
+      result = subject.reconcile_includes(
+        bare:   [ Include.new('a.h'), Include.new('b.h') ],
+        user:   [ UserInclude.new('a.h') ],
+        system: [ SystemInclude.new('sys.h') ],   # not in bare -> dropped
+        test_filepath: 'test/T.c'
+      )
+      expect(result.map(&:filename)).to eq(['a.h'])
+    end
+
+    it "logs an ℹ️ NOTICE naming the chosen file and the candidates passed over for an ambiguous #include" do
+      expect(@loginator).to receive(:log).with(
+        a_string_matching(/foo\/bar\.h/).and(a_string_matching(/baz\/bar\.h/)).and(a_string_matching(%r{test/T\.c})),
+        Verbosity::COMPLAIN, LogLabels::NOTICE
+      )
+      subject.reconcile_includes(
+        bare:   [ Include.new('bar.h') ],
+        user:   [ UserInclude.new('foo/bar.h'), UserInclude.new('baz/bar.h') ],
+        system: [],
+        test_filepath: 'test/T.c'
+      )
+    end
+
+    it "logs no NOTICE when every bare #include resolves uniquely" do
+      expect(@loginator).to_not receive(:log).with(anything, Verbosity::COMPLAIN, LogLabels::NOTICE)
+      subject.reconcile_includes(
+        bare:   [ Include.new('bar.h') ],
+        user:   [ UserInclude.new('foo/bar.h') ],
+        system: [],
+        test_filepath: 'test/T.c'
+      )
+    end
+
+    it "drops a header whose mock is also present when drop_mocked is true (the default)" do
+      result = subject.reconcile_includes(
+        bare:   [ Include.new('sensor.h'), Include.new('Mocksensor.h') ],
+        user:   [ UserInclude.new('sensor.h'), UserInclude.new('Mocksensor.h') ],
+        system: [],
+        test_filepath: 'test/T.c'
+      )
+      expect(result.map(&:filename)).to eq(['Mocksensor.h'])
+    end
+
+    it "keeps a header alongside its mock when drop_mocked is false" do
+      result = subject.reconcile_includes(
+        bare:   [ Include.new('sensor.h'), Include.new('Mocksensor.h') ],
+        user:   [ UserInclude.new('sensor.h'), UserInclude.new('Mocksensor.h') ],
+        system: [],
+        test_filepath: 'test/T.c',
+        drop_mocked: false
+      )
+      expect(result.map(&:filename)).to contain_exactly('sensor.h', 'Mocksensor.h')
+    end
+  end
+
+  # ===========================================================================
   describe '#preprocess_mockable_header_file' do
   # ===========================================================================
 

--- a/spec/units/test_build_setup_spec.rb
+++ b/spec/units/test_build_setup_spec.rb
@@ -68,6 +68,7 @@ describe TestBuildSetup do
     # always runs, ungated (see its comment in test_build_setup.rb).
     allow(@preprocessinator).to receive(:preprocess_user_includes).and_return( [] )
     allow(@preprocessinator).to receive(:preprocess_system_includes).and_return( [] )
+    allow(@preprocessinator).to receive(:reconcile_includes).and_return( [] )
     allow(@test_context_extractor).to receive(:lookup_all_header_includes_list).and_return( [] )
     allow(@test_context_extractor).to receive(:ingest_includes)
 
@@ -557,28 +558,27 @@ describe TestBuildSetup do
       allow(@dependinator).to receive(:stale?).with('build/preprocess/includes/Foo.c.yml').and_return( true )
       allow(@dependinator).to receive(:stale?).with('build/preprocess/raw/Foo.txt').and_return( false )
       allow(@preprocessinator).to receive(:preprocess_bare_includes).and_return( [ Include.new('bar.h') ] )
+      allow(@preprocessinator).to receive(:preprocess_user_includes).and_return( [] )
+      allow(@preprocessinator).to receive(:preprocess_system_includes).and_return( [] )
     end
 
-    it "logs an ℹ️ NOTICE naming the chosen file and every candidate passed over when reconciliation resolves an ambiguous #include" do
-      allow(@preprocessinator).to receive(:preprocess_user_includes).and_return(
-        [ UserInclude.new('foo/bar.h'), UserInclude.new('baz/bar.h') ]
-      )
+    # The reconcile core -- intersection, the ambiguous-#include NOTICE, and the
+    # mock-filter -- now lives in Preprocessinator#reconcile_includes (its own specs).
+    # Here we only assert the third pass hands it the test file's own bare list, keeps
+    # the mock-filter off, and ingests what it returns.
+    it "delegates to Preprocessinator#reconcile_includes with the test file's bare list and drop_mocked: false" do
+      reconciled = [ UserInclude.new('bar.h') ]
+      expect(@preprocessinator).to receive(:reconcile_includes).with(
+        hash_including(
+          bare:          [ Include.new('bar.h') ],
+          user:          [],
+          system:        [],
+          test_filepath: 'test/TestFoo.c',
+          drop_mocked:   false
+        )
+      ).and_return( reconciled )
 
-      expect(@loginator).to receive(:log).with(
-        a_string_matching(/foo\/bar\.h/).and(a_string_matching(/baz\/bar\.h/)).and(a_string_matching(/test\/TestFoo\.c/)),
-        Verbosity::COMPLAIN,
-        LogLabels::NOTICE
-      )
-
-      @setup.stage_collect_preprocessor_context( @state )
-    end
-
-    it "logs no NOTICE when reconciliation resolves a bare #include uniquely" do
-      allow(@preprocessinator).to receive(:preprocess_user_includes).and_return(
-        [ UserInclude.new('foo/bar.h') ]
-      )
-
-      expect(@loginator).to_not receive(:log).with( anything, Verbosity::COMPLAIN, LogLabels::NOTICE )
+      expect(@test_context_extractor).to receive(:ingest_includes).with( 'test/TestFoo.c', reconciled )
 
       @setup.stage_collect_preprocessor_context( @state )
     end


### PR DESCRIPTION
## What

Behavior-preserving refactor of the includes-extraction subsystem (`lib/ceedling/preprocess/`). Second of three staged PRs toward computed-`#include` support (#1267). No feature change; the computed-`#include` mechanism itself lands in PR3.

PR1 (#1277, merged) stood up the `spec/integration/` tier and unit safety net. This PR refactors underneath those green nets with zero assertion changes to the characterization and integration suites.

## Changes

**`preprocessinator_includes_handler.rb` — DRY the four extractors and two dispatchers.** `extract_user_includes_from_text` / `extract_system_includes_from_text` were byte-identical but for `user_include_from_directive` vs `system_include_from_directive`; they now delegate to one private `_extract_includes_from_text(directive_method, noun, …)`. The shared logging prologue/epilogue moves into `_log_extraction_progress`. The `SYSTEM` depth literal `5` becomes the named `SYSTEM_INCLUDE_MAX_DEPTH`. `extract_user_includes_preprocess` / `extract_system_includes_preprocess` stay as short methods because their line-marker calls differ in a way the unit specs pin exactly (USER passes `test:`, no depth; SYSTEM passes depth, no `test:`).

**`preprocessinator.rb` — extract the shared reconciliation core.** `preprocess_user_includes` / `preprocess_system_includes` collapse onto one private `_preprocess_includes(kind, …)` using `public_send`. The reconcile+sanitize tail of `preprocess_file_includes_common` becomes a public `reconcile_includes(bare:, user:, system:, test_filepath:, drop_mocked: true)` that wraps `Includes.reconcile` (emitting a `NOTICE` on genuine ambiguity) and the mock-filter `Includes.sanitize!`. The three copies of `@file_locks_mutex.synchronize { @file_locks[k] ||= Mutex.new }` fold into one `cache_file_lock` helper.

**`test_build_setup.rb` — call the shared core.** The third reconciliation pass hand-rolled its own `Includes.reconcile` block inline; it now calls `@preprocessinator.reconcile_includes(…, drop_mocked: false)`. Only behavior delta anywhere in this PR: that path now also emits the ambiguity `NOTICE` its inline copy never did.

**`preprocessinator_bare_includes_extractor.rb` — idiom cleanup.** `flatten!`/`uniq!` bang chain to a plain `scan(…).flatten.uniq.map`.

**System specs thinned to end-to-end smokes.** `spec/integration/includes_extraction_spec.rb` now owns the detailed reconciliation characterization, so `conditional_include_macro_visibility_spec` collapses to one full Partials build over all the conditional-include assets at once, and the redundant third `preprocessing_fallback_conditionals` example (UTF-8 near `#ifdef`, already covered) is dropped.

## Verification

- `rake specs:units` — 3225 examples, 0 failures
- `rake specs:integration` — 21 examples, 0 failures (unchanged assertions: behavior-preserving proof)
- Trimmed system specs verified green in the `madsciencelab-plugins:1.1.0` container
- CI is the backstop across all platforms / Ruby matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)