### PR TITLE
Resolve computed #includes (#1267) + rewrite preprocess/README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,14 @@ jobs:
       # Integration tests compose real lib/ceedling objects and shell out to real gcc,
       # but drive a single subsystem rather than a whole build. They need only gcc
       # (already on the runner), so they run here -- right after unit tests, before the
-      # slower external tool installs and the system suite.
+      # slower external tool installs and the system suite. Same Ruby-3.3-only coverage
+      # instrumentation as the unit and system steps; 'integration' routes it to its own
+      # raw resultset (see spec_helper.rb) so `coverage:report` builds a standalone
+      # integration report and still folds it into the combined one.
       - name: Run Integration Tests
         env:
           CI_RSPEC_PROGRESS_FORMAT: true
+          CEEDLING_TEST_COVERAGE: ${{ matrix.ruby == '3.3' && 'integration' || 'false' }}
         run: rake specs:integration
 
       # Install gdb for backtrace feature testing
@@ -249,9 +253,10 @@ jobs:
           coverage: ${{ matrix.ruby == '3.3' && 'system' || 'false' }}
 
       # Merges the resultset all prior coverage-instrumented steps accumulated (see
-      # Run Unit Tests, Run System Tests, and Run Plugin Tests above) into one HTML
-      # report and uploads it, downloadable from this run's own Actions summary page.
-      # Ruby-3.3-only, same leg those steps instrumented.
+      # Run Unit Tests, Run Integration Tests, Run System Tests, and Run Plugin Tests
+      # above) into per-suite HTML reports plus one combined report, and uploads them,
+      # downloadable from this run's own Actions summary page. Ruby-3.3-only, same leg
+      # those steps instrumented.
       - name: Generate Combined Coverage Report
         if: matrix.ruby == '3.3'
         run: rake coverage:report

--- a/Rakefile
+++ b/Rakefile
@@ -52,52 +52,59 @@ task 'specs:system:debug' do
   Rake::Task['specs:system'].invoke
 end
 
-# Formats three HTML reports -- units alone, system alone, and both combined --
-# from the raw coverage data that CEEDLING_TEST_COVERAGE test runs accumulate
-# (see .simplecov and spec/support/system/simplecov_boot.rb). Run after both
-# `specs:units` and `specs:system`/`specs:system:debug` have completed with that
-# env var set -- this task only reads back what they already wrote, it doesn't
-# run any specs itself. Sources, one per report:
-#   units    -- coverage/.resultset.json, written directly by the one unit-test
-#               process (spec_helper.rb)
-#   system   -- coverage/raw/system-<pid>-<timestamp>/.resultset.json, one small
-#               file per system-test child process (simplecov_boot.rb). Each
-#               process gets its own file rather than all sharing one growing
-#               coverage/.resultset.json -- sharing one file means every single
-#               process's exit re-reads, re-merges, and rewrites the *entire*
-#               accumulated file so far, a cost that grows with every process
-#               that ran before it and compounds across a full system-test run.
-#               merge_results below reads each small file once, the same
-#               approach SimpleCov itself recommends for "big CI setups" with
-#               many result files.
-#   combined -- the units file plus every system file
+# Formats four HTML reports -- units alone, integration alone, system alone, and all
+# combined -- from the raw coverage data that CEEDLING_TEST_COVERAGE test runs
+# accumulate (see .simplecov and spec/support/system/simplecov_boot.rb). Run after
+# `specs:units`, `specs:integration`, and `specs:system`/`specs:system:debug` have
+# completed with that env var set -- this task only reads back what they already
+# wrote, it doesn't run any specs itself. Sources, one per report:
+#   units       -- coverage/.resultset.json, written directly by the one unit-test
+#                  process (spec_helper.rb)
+#   integration -- coverage/raw/integration/.resultset.json, written directly by the
+#                  one integration-test process (spec_helper.rb, its own coverage_dir)
+#   system      -- coverage/raw/system-<pid>-<timestamp>/.resultset.json, one small
+#                  file per system-test child process (simplecov_boot.rb). Each
+#                  process gets its own file rather than all sharing one growing
+#                  coverage/.resultset.json -- sharing one file means every single
+#                  process's exit re-reads, re-merges, and rewrites the *entire*
+#                  accumulated file so far, a cost that grows with every process
+#                  that ran before it and compounds across a full system-test run.
+#                  merge_results below reads each small file once, the same
+#                  approach SimpleCov itself recommends for "big CI setups" with
+#                  many result files.
+#   combined    -- the units file plus the integration file plus every system file
 #
 # `require 'simplecov'` here briefly starts SimpleCov for this task's own process
 # too (via .simplecov's own autoload) -- overriding at_exit to a no-op keeps that
 # process's own trivial self-coverage from being written anywhere at all, since
 # this task reformats coverage_dir multiple times over its own run and has
 # nothing of its own worth preserving.
-desc "Merge and format units-only, system-only, and combined SimpleCov coverage reports"
+desc "Merge and format units-only, integration-only, system-only, and combined SimpleCov coverage reports"
 task 'coverage:report' do
   require 'simplecov'
   SimpleCov.at_exit { }
 
-  units_file  = File.join('coverage', '.resultset.json')
-  system_files = Dir[File.join('coverage', 'raw', 'system-*', '.resultset.json')]
+  units_file        = File.join('coverage', '.resultset.json')
+  integration_files = Dir[File.join('coverage', 'raw', 'integration', '.resultset.json')]
+  system_files      = Dir[File.join('coverage', 'raw', 'system-*', '.resultset.json')]
 
   raise "No coverage data found under coverage/ -- " \
-        "run specs:units and specs:system with CEEDLING_TEST_COVERAGE set first" \
-        if !File.exist?(units_file) && system_files.empty?
+        "run specs:units, specs:integration, and specs:system with CEEDLING_TEST_COVERAGE set first" \
+        if !File.exist?(units_file) && integration_files.empty? && system_files.empty?
+
+  units_files = File.exist?(units_file) ? [units_file] : []
 
   reports = {
-    'units'    => File.exist?(units_file) ? [units_file] : [],
-    'system'   => system_files,
-    'combined' => (File.exist?(units_file) ? [units_file] : []) + system_files
+    'units'       => units_files,
+    'integration' => integration_files,
+    'system'      => system_files,
+    'combined'    => units_files + integration_files + system_files
   }
 
   reports.each do |label, files|
     if files.empty?
-      puts "Skipping #{label} report -- no matching coverage data (run with CEEDLING_TEST_COVERAGE=#{label == 'combined' ? 'units/system' : label} first)"
+      want = label == 'combined' ? 'units/integration/system' : label
+      puts "Skipping #{label} report -- no matching coverage data (run with CEEDLING_TEST_COVERAGE=#{want} first)"
       next
     end
 
@@ -114,7 +121,12 @@ task 'coverage:report' do
     result = SimpleCov::ResultMerger.merge_results(*files, ignore_timeout: true)
 
     SimpleCov.coverage_dir(File.join('coverage', label))
-    SimpleCov::Formatter::HTMLFormatter.new.format(result)
+    # silent: true suppresses SimpleCov's own "Coverage report generated for
+    # <command_name> to ..." status line. For the merged system/combined reports
+    # that command_name is every system-<pid>-<timestamp> name joined with ", " --
+    # hundreds of them, burying this task's own one-line summary below. The
+    # concise line this task prints next says everything that noise did.
+    SimpleCov::Formatter::HTMLFormatter.new(silent: true).format(result)
     puts "#{label.capitalize} coverage: #{result.covered_percent.round(2)}% " \
          "(#{result.covered_lines}/#{result.total_lines} lines)"
   end

--- a/lib/ceedling/preprocess/README.md
+++ b/lib/ceedling/preprocess/README.md
@@ -1,188 +1,180 @@
 # Preprocessing
 
-Ceedling runs the real C preprocessor in several different modes to answer different questions about a file. It then reconstructs a usable C file from what it learns.
+Ceedling runs the real C preprocessor to answer questions about a test file or header, then rebuilds a usable C file from what it learns. It never reimplements preprocessing. A real preprocessor already understands every conditional and macro trick a project uses; an approximation would not.
 
-A C preprocessor’s job is to resolve conditionals, expand macros, and pull in the contents of every `#include`d file. Ceedling relies on a real preprocessor to do this rather than reimplementing it. A real preprocessor already understands every conditional and macro trick a project might use. A hand-built approximation would not.
+The subsystem answers two questions and produces one artifact:
 
-Ceedling asks the preprocessor four different kinds of questions, and each one gets its own mode of invocation.
+- **What does this file include?** A reconciled, categorized list of a file's own top-level `#include` directives — each tagged user or system, each rendered as it should appear in generated code.
+- **What does this file contain once resolved?** The file's text with conditionals resolved and includes followed, either preserving macro directives (for later text extraction) or fully expanded (to see through a macro hiding a signature).
+- **A reconstructed C file** built from that resolved text plus the reconciled include list, ready to compile or to feed a mock/Partial generator.
 
-- **Bare-includes mode** finds every header a file depends on, without opening a single one of them. It exists to produce a trustworthy, top-level include list. It is actually two techniques working together: a real preprocessor pass, and a plain text scan that catches what the preprocessor pass alone cannot see.
-- **Directives-only mode** resolves conditionals and follows real includes, but leaves macro directives and comments in the output untouched. It exists to categorize includes as user or system headers, and to produce a version of a file with its macros still intact for later text extraction.
-- **Full-expansion mode** resolves everything a preprocessor can resolve, including every macro use in the body of a file. It exists for the case where a macro is hiding something a later step needs to see plainly, such as a function’s true signature or visibility.
-- **Text-scan fallback** does not invoke a preprocessor at all. It exists for the times a real preprocessor pass is unavailable or fails, scanning the original file’s text directly as a less certain but always-available substitute.
-
-Each of these is explained in its own section below, with an example of the kind of output it produces.
+One class is the entry point: `Preprocessinator` (`preprocessinator.rb`). Every other class in this directory does one piece of the job and is named where that piece is described below. Release builds do not use any of this — a release build only needs true dependencies for staleness tracking, handled by a lighter tool.
 
 ## Where This Fits in a Test Build
 
-Ceedling’s test pipeline reaches this subsystem through one class, `Preprocessinator`. The test pipeline calls in to learn what a test file or header includes. It calls in again to produce a fully resolved version of a file’s content, ready for further text extraction. Both the test-building and mock-generating stages of the pipeline call `Preprocessinator` this way, and this document explains the mechanics behind those calls rather than the pipeline’s own stage order (separately documented alongside the pipeline itself).
+`Preprocessinator`'s public methods are the whole interface. The test pipeline calls them from `test_invoker/` build stages; this document explains their mechanics, not the stage order (documented alongside the pipeline).
 
-`Preprocessinator` does not do this work alone. It hands each piece of the job to one of several smaller classes living alongside it in this directory. Each of those classes is named where its own particular job is explained below.
-
-Release builds do not use this subsystem at all. A release build only needs to know a file’s true dependencies for staleness tracking, a simpler question answered by a lighter tool of its own.
+- `preprocess_bare_includes(filepath:, test:, search_paths:, flags:, defines:)` — the bare `#include` list only, for early stand-in generation. Returns `Array<Include>`.
+- `generate_directives_only_output(filepath:, test:, flags:, include_paths:, vendor_paths:, defines:)` — runs the accurate pass, strips its comments, compacts it. Returns the raw output's path, or `nil` if the preprocessor failed.
+- `preprocess_file_includes_common(test:, filepath:, directives_only_filepath:, fallback:, flags:, include_paths:, vendor_paths:, defines:)` — the full extract-reconcile-cache path for a mockable header or a Partial header/source. Returns the reconciled `Array<Include>`.
+- `preprocess_mockable_header_file(...)`, `preprocess_partial_header_file_preserve_macros(...)`, `preprocess_partial_source_file_preserve_macros(...)`, `preprocess_test_file(...)` — each extracts includes (via the method above, except the test file, which already has its list), then rebuilds the file.
+- `preprocess_partial_header_expand_macros(...)` / `preprocess_partial_source_expand_macros(...)` — the full-expansion pass, for signature extraction.
+- `store_includes_list(...)` / `load_includes_list(...)` — the per-file YAML cache of a reconciled list.
 
 ## Reading a Line Marker
 
-Running a C preprocessor over a file does not produce anything resembling the original file. Every `#include`d file’s contents are pulled in and flattened into the same stream of text, and the whole tree of includes ends up concatenated together as one document.
-
-To keep track of which piece of that flattened stream came from which original file, the preprocessor inserts special lines called line markers as it works. A line marker looks like this:
+A C preprocessor flattens a file and every header it pulls in into one stream. To record which piece came from which file, it inserts *line markers*:
 
 ```
 # 6 "src/module.c" 2
 ```
 
-The number is a line count. The quoted text is a file name. The trailing numbers are flags describing what just happened. A flag of `1` means the preprocessor has just entered a new file, typically because of an `#include`. A flag of `2` means the preprocessor has just returned to the file it was in before. A flag of `3` means the file just entered is a system header, found through a system include path rather than a project path. These three flags are what let Ceedling walk through a flattened stream of preprocessor output and correctly attribute each line back to its real, original file. A class called `PreprocessinatorLineMarkerIncludesExtractor` is the one that actually does this walking.
+The integer is a line number in the named file. The trailing integers are flags: `1` = just entered a new file (an `#include`), `2` = just returned to the previous file, `3` = the entered file is a system header (found on a system path), `4` = implicit `extern "C"`. Walking these flags is how Ceedling attributes flattened output back to real files.
+
+`PreprocessinatorLineMarkerIncludesExtractor` (`preprocessinator_line_marker_includes_extractor.rb`) does that walking. `LINE_MARKER_REGEX` matches a marker; it tolerates leading whitespace (`^\s*`), because `-fdirectives-only` gives an indented `#include` an indented marker (GH #1268). The extractor reads in binary mode — GCC output under a non-C locale carries non-ASCII bytes, and Windows `\r\n` must survive to a per-line `chomp!`.
 
 ## Finding Every Include, Accurately
 
-Knowing exactly which headers a file includes, and whether each one is a user header or a system header, turns out to be harder than it sounds. A header protected by an include guard will not appear a second time if it happens to be reached again through a different path. This means a single pass over line markers cannot be fully trusted to report every include at the top level of a file.
+Knowing a file's includes, and whether each is a user or system header, is harder than it sounds. An include-guarded header reached a second time through another path never reappears in the stream. So a single line-marker pass cannot be trusted as a complete top-level list.
 
-Ceedling solves this with two separate preprocessor passes that are then reconciled together. A class called `PreprocessinatorIncludesHandler` runs both passes and hands each one’s raw output to a small parser built just for it. `PreprocessinatorBareIncludesExtractor` reads the first pass’s output. `PreprocessinatorLineMarkerIncludesExtractor`, already named above, reads the second.
+Ceedling reconciles two things: a **bare list** of what the file depends on (undifferentiated), and an **accurate list** that categorizes each entry user or system but over-reports (it sees deep nesting). `PreprocessinatorIncludesHandler` (`preprocessinator_includes_handler.rb`) runs every pass and hands each pass's raw output to a parser built for it. `Includes.reconcile` (`includes/includes.rb`) then intersects them.
 
-The first pass runs the preprocessor in bare-includes mode, a mode meant only to report dependencies, deliberately pointed at no real project search paths at all. Because no real header can be found this way, none are ever opened, so no include guard can ever suppress anything. This pass is not troubled by nesting or guards. What it cannot do is say whether any one of those includes is a user header or a system header.
+The bare list has **three contributors**, unioned and deduplicated by filename. Each catches what the others structurally cannot.
 
-Restricting search paths is not by itself enough to guarantee that no real header is ever opened. A C preprocessor’s quoted `#include` resolution always additionally checks the directory of the file it is currently processing, independent of whatever search paths were given. A header sitting alongside the file being scanned, a same-directory sibling, gets opened and recursed into anyway, regardless of the restricted search paths above. Left unaddressed, this leaks past the pass’s own guarantee: a header reached only through this directory-relative side channel looks the same as a genuine top-level include, which can lead `Includes.reconcile` to keep a mocked header’s own real source in a test’s build when nothing about the test actually needed it there.
+### Bare contributor 1 — the isolated gcc dependency pass
 
-To close this gap, `PreprocessinatorIncludesHandler#extract_bare_includes` stages an isolated, sibling-free copy of the file being scanned into a fresh temporary directory before invoking the preprocessor, so directory-relative resolution has nothing to find. That temporary directory is minted directly inside the test’s own `preprocess/files/<test>/` build directory, already created by an earlier build stage, rather than in a dedicated subdirectory of its own, and it is not named after the file it holds. Both choices keep the resulting path as short as possibleto help ensure path length does not exceed Windows’ legacy 260-character `MAX_PATH`. Each call gets its own uniquely-named temporary directory, so concurrently preprocessing several different test files never lets one become a sibling of another, and the directory is removed once the preprocessor invocation finishes, whether or not it succeeded.
-
-Bare-includes mode is invoked roughly like this, with only Ceedling’s own vendor path available to search:
+`PreprocessinatorIncludesHandler#extract_bare_includes(test:, filepath:, search_paths:, flags:, defines:)` runs:
 
 ```
-gcc -E -M -MG -MP -I"build/vendor/ceedling" -D"UNIT_TEST" -nostdinc -x c "test_module.c"
+gcc -E -M -MG -MP -I"build/vendor/ceedling" -D"UNIT_TEST" -DGNU_COMPILER -nostdinc -x c "test_module.c"
 ```
 
-Its output is not C code at all. It is a make-style dependency rule, listing the file itself and everything it depends on:
+`-M` (not `-MM`) keeps system headers in the rule, so the later intersection filters them by agreement rather than by the compiler's guess. `-MG` treats a missing header as a to-be-generated file instead of an error. `-MP` emits a phony rule per dependency. `-nostdinc` and the vendor-only `-I` keep real project headers off the search path. Output is a make rule, not C:
 
 ```
 test_module.o: test_module.c unity.h module.h \
   mock_dependency.h
 ```
 
-### The Gap a Real Preprocessor Pass Cannot Close Alone
+`PreprocessinatorBareIncludesExtractor.extract_includes(make_rules)` (`preprocessinator_bare_includes_extractor.rb`) turns each phony `header:` line into a plain `Include`. The handler gates on `MAKE_RULE_MATCHER` first — no rule means the pass produced nothing usable, and it returns `[]`.
 
-Bare-includes mode has one more limitation. It only keeps an `#include` if the preprocessor's own conditional evaluation resolves that way. But bare-includes mode never opens any header, so it cannot see a macro some other header defines. When a conditional depends on a macro like that, the preprocessor treats it as undefined. The conditional resolves the wrong way. A real, always-present `#include` silently disappears from this pass's own output.
+Restricting search paths is not enough on its own. A preprocessor's quoted-`#include` resolution *always* also checks the directory of the file being processed. A same-directory sibling header gets opened and recursed into regardless. So `extract_bare_includes` first stages a sibling-free copy of the file into a fresh temp directory (`@file_wrapper.stage_isolated_copies`), runs gcc against that, and removes the copy in an `ensure`. The temp directory is minted inside the test's own `preprocess/files/<test>/` build directory and is not named after the file — both keep the path short for Windows' legacy `MAX_PATH`. Each call gets its own directory, so concurrent preprocessing of sibling files never cross-contaminates.
 
-Ceedling closes this gap with a second, simpler technique: a plain scan of the file's own text for anything that looks like an `#include` line, no matter what conditional surrounds it. This scan runs no preprocessor and evaluates no conditionals. It only needs to notice that an `#include` line exists in the file's own text. `PreprocessinatorIncludesHandler#extract_bare_includes_from_text` does this scanning. Its result is unioned with the real bare-includes pass's own result before reconciliation runs.
+This pass *can* resolve an `#include` whose target is a macro, because a command-line `-D` is visible even to the isolated copy. It *cannot* see a macro another header defines: a conditional gated on `#if SOMETHING_FROM_ANOTHER_HEADER` evaluates against an undefined macro, resolves the wrong way, and drops a real `#include`.
 
-This union is safe. `Includes.reconcile` still checks every candidate against the accurate, second pass before keeping it. A line the text scan notices but the accurate pass never actually resolved is still discarded, exactly as before. The union only restores an entry both a literal reading of the file and a real preprocessor agree belongs there.
+### Bare contributor 2 — the literal text scan (#1223)
 
-Neither technique replaces the other. The real preprocessor pass can resolve an `#include` whose own target is a macro, something like `#include SOME_HEADER_NAME`, since that requires expanding a macro before any filename exists at all. The text scan has no filename to find in a case like that. The text scan, in turn, sees past a conditional the preprocessor pass cannot evaluate, since it never tries to evaluate conditionals in the first place. Each covers a gap the other cannot.
+`PreprocessinatorIncludesHandler#extract_bare_includes_from_text(filepath:)` scans the file's own text for anything shaped like an `#include "..."` or `#include <...>` line, evaluating no conditionals at all. It closes the gap above: an `#include` behind a guard the isolated pass can't evaluate still has a literal filename in the text.
 
-The second pass runs the preprocessor in directives-only mode, with full search paths, and reads the resulting line markers, exactly as described above, to learn which included files are user headers and which are system headers. This pass sees real nesting and real include guards, so its own list cannot be fully trusted as a top-level list on its own.
+The union is safe. `Includes.reconcile` still keeps an entry only if the accurate pass also reports it. The scan can restore an entry both a literal reading and a real preprocessor agree on; it cannot introduce a spurious one.
 
-Directives-only mode is invoked with full project search paths:
+It has its own blind spot: an `#include` whose target is a macro has no literal filename to find.
+
+### Bare contributor 3 — computed-include correlation (#1267)
+
+`PreprocessinatorIncludesHandler#extract_computed_includes(filepath:, directives_only_filepath:)` covers the case both other contributors miss: a macro-target `#include` *and* a cross-header guard, e.g.
+
+```c
+#include "Types.h"                 // defines SOIL_MOISTURE_MAX
+#if SOIL_MOISTURE_MAX > 0
+#include INCLUDE_DEVICE(types2)    // -> STR(types2.h) -> "types2.h"
+#endif
+```
+
+The isolated pass can't evaluate the guard; the text scan has no filename. But the accurate `-fdirectives-only` pass *does* open the header and emit an ordinary entering marker for it. The method recovers that resolution:
+
+1. `computed_include_source_lines(filepath)` scans the raw source with `ParsingParcels#code_lines_with_num` (comments stripped, backslash continuations folded, first-physical-line number reported). It collects the 1-indexed line of every `#include` directive whose argument matches neither `PATTERNS::USER_INCLUDE_DIRECTIVE_FILENAME` nor `PATTERNS::SYSTEM_INCLUDE_DIRECTIVE_FILENAME` — a bare token, i.e. a macro.
+2. `PreprocessinatorLineMarkerIncludesExtractor#resolve_computed_includes(preprocessed_filepath:, source_basename:, source_lines:)` walks the directives-only output. It tracks `src_line`, the source line the next non-marker physical line maps to: a `# n "<source basename>" …` marker sets `src_line = n`; each body line of that file increments it. The macro-target directive is *replaced* by the entering marker for the header it pulled in, so it never appears as a body line — `src_line` still names that directive's line when its entering marker (`flag 1`, another file) appears. Body lines and markers of any other file are skipped, so a header's own nesting can't drift the count. It returns `{ source_line => resolved_path }` for every wanted line that produced an entering marker.
+3. Each resolved path becomes a base `Include`.
+
+`preprocess_file_includes_common` unions the result into `bare` right after contributor 2, guarded `unless fallback` — fallback has no directives-only stream to read. `Includes.reconcile` is untouched: the computed include is now corroborated in `bare` like a literal one and still gated by the accurate list.
+
+Limitations, both characterized in the integration suite: a computed `#include` split across a backslash continuation is not correlated (the source scan reports its first physical line; the marker is attributed to a line the continuation shifts), and computed-include resolution is unavailable in fallback mode.
+
+### The accurate pass — directives-only
+
+`generate_directives_only_output` runs:
 
 ```
-gcc -E -I"src" -D"UNIT_TEST" -x c -fdirectives-only "test_module.c" -o "out.c"
+gcc -E -I"src" -D"UNIT_TEST" -x c -fdirectives-only "test_module.c" -o "raw.c"
 ```
 
-Its output still looks recognizably like source. Conditionals are already resolved and includes already followed, but macro directives and comments are left exactly as written, and line markers show where each piece of text actually came from:
+No `-dD`. Conditionals are resolved and includes followed, but macro directives and comments stay as written, and line markers show provenance:
 
 ```
 # 1 "test_module.c"
 # 1 "unity.h" 1
 # 1 "module.h" 1
-#define MODULE_LIMIT 10 // upper bound for calculations
+#define MODULE_LIMIT 10 // upper bound
 void module_calculate(int value);
 # 2 "test_module.c" 2
-
-void test_should_calculate_within_limit(void)
-{
-  TEST_ASSERT_EQUAL(20, module_calculate(2));
-}
 ```
 
-Reconciling the two lists together gives the best of both. The first pass supplies the authoritative list `#include` directives in the preprocessed file. The second pass supplies the categorization for each entry, user or system include, that list already contains. Anything only the second pass reports, having been reached solely through some deeper, guarded path, is set aside. The reconciled list is also cleaned of any include referring to the file itself, and any include of a header superseded by a mock of that same header.
+`PreprocessinatorIncludesHandler` reads this twice:
+
+- `extract_user_includes_preprocess(name:, filepath:, preprocessed_filepath:)` → `PreprocessinatorLineMarkerIncludesExtractor#extract_includes_from_file(path, USER, test: name)`. No depth limit — a user header matters however deeply it nests. `test:` lets the extractor strip the test's own mock subdirectory off a resolved mock path.
+- `extract_system_includes_preprocess(...)` → `extract_includes_from_file(path, SYSTEM, SYSTEM_INCLUDE_MAX_DEPTH)`. `SYSTEM_INCLUDE_MAX_DEPTH` is a literal `5` in the handler — a practical ceiling, since system headers nest deeply through their own wrappers and anything past a handful of levels is noise, not a project dependency. There is no config key for it.
+
+`generate_directives_only_output` also strips the raw output's comments in place (`PreprocessinatorCommentStripper`) and writes a second, marker-free compacted file (`PreprocessinatorReconstructor`). Line-to-line correspondence with the source survives comment stripping, which is what the computed-include walk depends on.
+
+### Reconciliation
+
+`Includes.reconcile(bare:, user:, system:, test_filepath:, &on_ambiguous)`:
+
+- `bare` must be plain `Include` objects only. `user` / `system` are `UserInclude` / `SystemInclude` (or `MockInclude`).
+- A **user** entry survives if some bare entry corresponds to it *by path* — segment-wise, honoring whichever side carries less path. Two same-basename project files in different directories stay distinct. A bare entry matching more than one candidate resolves to the first in `user`'s order (real preprocessor-derived priority) and calls `on_ambiguous` with the bare path, the choice, and the also-rans.
+- A **system** entry survives if some bare entry shares its *filename* (system headers legitimately reach one basename through several real files). The kept entry is rebuilt with `include_path:` recovered from `bare` via `best_bare_match`, so `<sys/stat.h>` renders as written, not collapsed to `<stat.h>`.
+- A matched user entry deliberately renders filename-only. Its bare pass already resolved a quoted `#include "Types.h"` inside `src/LightSensor.h` to `src/Types.h` the moment a real `src/Types.h` existed — there is no original spelling left to recover, and `src/Types.h` verbatim would not be found via Ceedling's `-Isrc` convention.
+- `test_filepath` anchors a bare entry's own `..` and names the one file an `on_ambiguous` message should point at.
+
+`Preprocessinator#reconcile_includes(bare:, user:, system:, test_filepath:, drop_mocked: true)` is the shared merge step. It calls `Includes.reconcile`, logs a `NOTICE` on each ambiguity, and — when `drop_mocked` — runs `Includes.sanitize!` to drop a header whose `cmock_mock_prefix`-named mock is also present. Two call sites use it, each owning its own bare source and caching:
+
+- `preprocess_file_includes_common` — mockable headers and Partials. `drop_mocked: true`.
+- `test_invoker/test_build_setup.rb` stage 4, third pass — the test file itself. `drop_mocked: false`, because a test's own `#include` of a mock is deliberate. Its bare source is stage 4's own list (no text or computed supplement).
+
+The reconciled list is also cleaned of any self-reference (`clean_self_reference`, normalized-path comparison).
 
 ## Expanding a File in Full
 
-A separate preprocessor pass, run with every macro fully expanded and every conditional fully resolved, exists for a narrower purpose. Sometimes a function’s true signature is hidden behind a project’s own macro, such as a macro standing in for the word `static`. A pass that merely preserves macro text intact cannot see through a substitution like that. A fully expanded pass can, because by the time it finishes running, the substitution has already happened.
-
-Full-expansion mode is invoked without the directives-only flag:
+A separate pass runs with every macro expanded, for the narrow case where a signature or visibility keyword hides behind a project macro (`#define PRIVATE static`). `Preprocessinator#preprocess_partial_{header,source}_expand_macros` funnel through `_preprocess_partial_expand_macros`, which runs `tools_test_file_full_preprocessor`:
 
 ```
 gcc -E -I"src" -D"UNIT_TEST" -x c "test_module.c" -o "out.c"
 ```
 
-Given a project that defines `#define PRIVATE static` and a function written as `PRIVATE void module_calculate(void)`, directives-only output still shows the macro use exactly as written:
+`command[:options][:boom] = false` — a nonzero exit must fall back to directives-only signatures, not raise. On failure the method returns `nil`. This is the most expensive mode and is used sparingly.
 
-```
-#define PRIVATE static
-PRIVATE void module_calculate(void)
-{
-```
-
-Full-expansion output shows the substitution already carried out, with the `#define` itself gone and `static` sitting plainly in its place:
-
-```
-# 3 "test_module.c"
-static void module_calculate(void)
-{
-```
-
-This mode is used sparingly, specifically where a signature or a visibility keyword needs to be resolved with full confidence, since it is the most expensive of the preprocessor modes Ceedling relies on.
+Directives-only output still shows `PRIVATE void module_calculate(void)`; full-expansion output shows `static void module_calculate(void)` with the `#define` gone.
 
 ## Putting a File Back Together
 
-Raw preprocessor output cannot be handed directly to anything expecting an ordinary, self-contained C file.
-
-A class called `PreprocessinatorFileAssembler` is what actually runs the preprocessor invocations shown above, and what stitches their output back into a real file afterward. For the second half of that job it leans on another class, `PreprocessinatorReconstructor`, which walks the flattened stream watching line markers, keeping only the lines that belong to the file actually being reconstructed and discarding every line that arrived from somewhere else.
-
-Given flattened output like the following:
+Raw preprocessor output is not a self-contained C file. `PreprocessinatorFileAssembler` (`preprocessinator_file_assembler.rb`) runs the invocations above and stitches the output back. For the stitching it uses `PreprocessinatorReconstructor` (`preprocessinator_reconstructor.rb`), which walks the flattened stream by line marker and keeps only lines belonging to the file being reconstructed:
 
 ```
 # 1 "some/file/we/do/not/want.c" 5
 some_text_we_do_not_want();
 # 11 "path/do/want.c" 99999
 some_text_we_do_want();
-
-some_awesome_text_we_want_so_hard();
-holy_crepes_more_awesome_text();
 # 3 "some/other/file/we/ignore.c" 5
 ignored_text();
 ```
 
-only the lines belonging to `path/do/want.c` survive the walk:
-
-```
-some_text_we_do_want();
-
-some_awesome_text_we_want_so_hard();
-holy_crepes_more_awesome_text();
-```
-
-`PreprocessinatorFileAssembler` then places the file’s own, original `#include` directives back at the top, drawn from the reconciled include list described above, ahead of this recovered body text. The result reads as a complete, ordinary C file again, ready for compiling or for further text extraction.
+leaves only `some_text_we_do_want();`. `PreprocessinatorFileAssembler` then places the file's own original `#include` directives — drawn from the reconciled list — back at the top, ahead of the recovered body.
 
 ## Comments and Why They Go First
 
-Several later steps read meaningful text directly out of preprocessor output. A step reading macro definitions, or reading a special marker macro placed by a test author, has to trust that whatever looks like a directive or a macro name really is one. A stray comment containing text that merely resembles a directive could otherwise be mistaken for a real one.
-
-To avoid this, a class called `PreprocessinatorCommentStripper` finds and removes comments from a file’s preprocessed output before any of that later reading happens. It leans on a lower-level class, `CCommentScanner`, to do the actual finding. `CCommentScanner` is built on the same `StringScanner` approach explained in this codebase’s c_extractor documentation, walking the text one position at a time rather than searching it as a whole. This approach is careful to never mistake a `//` or a `/*` sitting inside a quoted string for the start of a real comment.
-
-Directives-only output carrying a comment like this:
-
-```
-# 1 "module.c"
-#define FOO 1 // enable feature
-```
-
-has that comment blanked out, while the line marker and the directive itself are left completely untouched:
-
-```
-# 1 "module.c"
-#define FOO 1
-```
-
-When a multi-line comment is removed, it is replaced with the same number of blank lines it originally spanned, so the file’s total line count stays exactly as it was, keeping every later line-number calculation correct.
+Later steps read macro definitions and marker macros straight out of preprocessor output. A stray comment that resembles a directive would be mistaken for one. `PreprocessinatorCommentStripper` (`preprocessinator_comment_stripper.rb`) removes comments before any such reading, using `CCommentScanner` — a `StringScanner` walk (see the c_extractor docs) that never mistakes a `//` or `/*` inside a string for a comment. A removed multi-line comment is replaced by the same number of blank lines, so every later line-number calculation stays correct.
 
 ## Finding Where a Snippet Came From
 
-A separate, smaller class, `PreprocessinatorCodeFinder`, exists for tracing a piece of already-preprocessed text back to the original line number it came from. Given a snippet of code and a body of preprocessor output containing it, it walks backward through the nearest line markers to work out which original file and line the snippet actually belongs to.
-
-Ceedling’s Partials feature relies on this directly. A function copied out into a generated Partial file still needs to point back at its true, original location, and this is how that original location is found.
+`PreprocessinatorCodeFinder` (`preprocessinator_code_finder.rb`) traces a piece of already-preprocessed text back to its original file and line by walking backward through the nearest line markers. Ceedling's Partials feature uses this to point a copied-out function at its true source location.
 
 ## Caching and the Fallback Path
 
-Running a real preprocessor is genuinely expensive, and a project’s files do not change on every single build. `PreprocessinatorIncludesHandler`, already named above, also owns a small cache of the include lists it works out for a file, and reuses a cached list rather than repeating a preprocessor pass when nothing relevant about that file has changed since the last run.
+Running a real preprocessor is expensive and files rarely change. `PreprocessinatorIncludesHandler` owns a per-file YAML cache of reconciled lists (`write_includes_list` / `load_includes_list`, keyed by test and filepath, guarded by a per-file `Mutex`). A corrupt cache raises a `YamlLoadException` wrapped with a clear message. Callers gate every cache use behind their own `DependencyTracker` staleness check.
 
-Sometimes running a real preprocessor is not possible at all, whether because a project’s toolchain does not support the mode Ceedling needs, or because a particular invocation simply fails for some other reason. When this happens, Ceedling falls back to a plain text scan of the original file instead, guided by a small class called `CPreprocessorConditionals`, which tracks `#ifdef`, `#ifndef`, `#if`, `#elif`, `#else`, and `#endif` state well enough to skip text that real conditional compilation would have excluded. This fallback cannot resolve a conditional with the same certainty a real preprocessor can, so its results are necessarily less certain. It exists to keep a build moving forward far enough for a test author to see what is actually going wrong, rather than leaving a build unable to proceed at all.
+When a real pass is impossible — the toolchain lacks `-fdirectives-only` (Apple Clang ignores it and warns), or a specific invocation fails — Ceedling falls back to a text scan of the original file, guided by `CPreprocessorConditionals` (`c_preprocessor_conditionals.rb`), which tracks `#ifdef` / `#ifndef` / `#if` / `#elif` / `#else` / `#endif` well enough to skip text real conditional compilation would exclude. `PreprocessinatorIncludesHandler#extract_{user,system}_includes_from_text(name:, filepath:, defines:)` are the fallback counterparts of the directives-only extractors. Fallback is per file: `generate_directives_only_output` returning `nil` for one file drops that file alone to the text path (`directives_only_filepath.nil?` → `fallback` true), while others use the accurate path. Fallback results are less certain, and computed-include resolution is unavailable there.
+
+## Executable Specification
+
+`spec/integration/includes_extraction_spec.rb` is the executable specification of everything above. Each example lays a small C tree on disk, runs the real Preprocessinator graph against real GCC (no `ceedling` build), and asserts the reconciled, rendered list — across accurate and fallback modes, every guard shape, the mock filter, same-basename collisions, and the computed-include matrix. The unit specs under `spec/units/preprocess/` cover each parser's branching in isolation.

--- a/lib/ceedling/preprocess/preprocessinator.rb
+++ b/lib/ceedling/preprocess/preprocessinator.rb
@@ -575,6 +575,24 @@ class Preprocessinator
       bare_includes + @includes_handler.extract_bare_includes_from_text( filepath: filepath )
     ).uniq( &:filename )
 
+    # Supplement again with computed #includes -- a directive whose target is a macro
+    # invocation rather than a literal filename. Both bare passes above are blind to
+    # one: the gcc dep pass can't evaluate a sibling-header guard around it in the
+    # isolated copy, and the text scan has no literal filename to find. The accurate
+    # directives-only pass did resolve it, though, so extract_computed_includes reads
+    # that pass's own line markers back and hands us GCC's resolution to fold into
+    # `bare` like any literal. Guarded `unless fallback`: fallback has no
+    # directives-only stream to correlate against (documented limitation). Same
+    # reconcile safety as the text scan above -- an entry only survives if the
+    # accurate user/system list also carries it.
+    unless fallback
+      bare_includes = (
+        bare_includes + @includes_handler.extract_computed_includes(
+          filepath: filepath, directives_only_filepath: directives_only_filepath
+        )
+      ).uniq( &:filename )
+    end
+
     # Extract user includes
     user_includes = preprocess_user_includes(
       name:                     test,

--- a/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
+++ b/lib/ceedling/preprocess/preprocessinator_includes_handler.rb
@@ -43,7 +43,7 @@ class PreprocessinatorIncludesHandler
     @loginator.log( msg, Verbosity::OBNOXIOUS )
 
     # Creation:
-    #  - This output is created with the -MM -MG -MP command line options.
+    #  - This output is created with the -M -MG -MP command line options.
     #  - Limited search paths are used towards shallow extracting of only the user #include statements of the file.
     #    This preprocessor mode assumes any includes discovered outside of a search path will be generated.
     #
@@ -181,6 +181,35 @@ class PreprocessinatorIncludesHandler
     clean_self_reference( filepath, includes )
   end
 
+  # Resolve every `#include` in the original file whose target is a macro invocation
+  # rather than a literal `"..."` / `<...>` filename. Neither bare pass above can see
+  # such a directive: the gcc dep pass runs against an isolated copy and can't evaluate
+  # a sibling-header guard around it, and the text scan has no literal filename to
+  # match. The accurate directives-only pass DID resolve it -- it opened the header and
+  # emitted an ordinary entering line marker. This method finds each non-literal
+  # `#include`'s source line, then asks the line-marker extractor which header GCC
+  # entered at that line, and returns those as base `Include` objects to union into
+  # `bare` (see Preprocessinator#preprocess_file_includes_common). Meaningful only with
+  # a directives-only stream to read; a nil `directives_only_filepath` (fallback, or a
+  # per-file directives-only failure) yields an empty list -- a documented limitation.
+  #
+  # @return [Array<Include>] base Include objects, one per resolved computed #include
+  def extract_computed_includes(filepath:, directives_only_filepath:)
+    return [] if directives_only_filepath.nil?
+
+    computed_lines = computed_include_source_lines( filepath )
+    return [] if computed_lines.empty?
+
+    resolved = @line_marker_includes_extractor.resolve_computed_includes(
+      preprocessed_filepath: directives_only_filepath,
+      source_basename:       File.basename( filepath ),
+      source_lines:          computed_lines
+    )
+
+    includes = resolved.values.map { |path| Include.new( path ) }
+    clean_self_reference( filepath, includes )
+  end
+
   def extract_user_includes_from_text(name:, filepath:, defines: [])
     _extract_includes_from_text( :user_include_from_directive, 'user', name: name, filepath: filepath, defines: defines )
   end
@@ -239,6 +268,33 @@ class PreprocessinatorIncludesHandler
     end
 
     clean_self_reference( filepath, includes )
+  end
+
+  # An `#include` directive with an argument of some kind. `\S` after the whitespace
+  # rejects a malformed `#include` with nothing after it.
+  INCLUDE_DIRECTIVE = /^\s*#\s*include\s+\S/ unless const_defined?(:INCLUDE_DIRECTIVE, false)
+
+  # 1-indexed source line numbers of every `#include` in `filepath` whose argument is
+  # a bare token rather than a literal `"..."` or `<...>` -- i.e. a macro the
+  # preprocessor must expand before any filename exists. `code_lines_with_num` has
+  # already stripped comments and folded backslash continuations, so a commented-out
+  # or string-embedded `#include` never reaches here, and a continued directive
+  # reports the line its first physical line sat on.
+  def computed_include_source_lines(filepath)
+    lines = []
+
+    # Binary read for the same reason the sibling text scans use it: a text-mode read
+    # can raise on an invalid byte sequence before code_lines' encoding cleanup runs.
+    @file_wrapper.open( filepath, 'rb' ) do |input|
+      @parsing_parcels.code_lines_with_num( input ) do |line, line_num|
+        next unless line.match?( INCLUDE_DIRECTIVE )
+        next if line.match?( PATTERNS::USER_INCLUDE_DIRECTIVE_FILENAME )
+        next if line.match?( PATTERNS::SYSTEM_INCLUDE_DIRECTIVE_FILENAME )
+        lines << line_num
+      end
+    end
+
+    lines
   end
 
   # Shared progress line for the four extraction methods above.

--- a/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
+++ b/lib/ceedling/preprocess/preprocessinator_line_marker_includes_extractor.rb
@@ -132,7 +132,92 @@ class PreprocessinatorLineMarkerIncludesExtractor
     return extract_includes(io: io, filepath: filepath, type: type, max_depth: max_depth, test: test)
   end
 
+  # Correlate `-fdirectives-only` entering line markers back to the raw source lines
+  # that produced them, for a set of lines of interest. Used to recover GCC's own
+  # resolution of an `#include` whose target is a macro invocation: the directive
+  # carries no literal filename to scan for, but the accurate directives-only pass
+  # still resolves it and emits an ordinary entering marker for the header.
+  #
+  # @param preprocessed_filepath [String] raw directives-only output (line markers
+  #   intact, comments stripped or not -- physical line count is 1:1 with the source
+  #   either way, which is all this walk needs)
+  # @param source_basename [String] basename of the original source file, used to
+  #   recognize its own line markers in the stream
+  # @param source_lines [Enumerable<Integer>] 1-indexed source line numbers to report
+  #   a resolution for (the lines carrying a non-literal `#include`)
+  # @return [Hash{Integer => String}] source line number => path GCC resolved that
+  #   line's `#include` to; only lines that actually produced an entering marker appear
+  def resolve_computed_includes(preprocessed_filepath:, source_basename:, source_lines:)
+    wanted = source_lines.to_a
+    return {} if wanted.empty?
+
+    begin
+      # Binary mode for the same reason extract_includes_from_file uses it: GCC output
+      # under a non-C locale carries non-ASCII bytes, and \r\n must survive untranslated
+      # for the per-line chomp! below to normalize.
+      @file_wrapper.open( preprocessed_filepath, 'rb' ) do |file|
+        return correlate_computed_includes( io: file, source_basename: source_basename, wanted: Set.new( wanted ) )
+      end
+    rescue StandardError => e
+      raise CeedlingException.new("Failed to correlate computed #includes from preprocessor output file '#{preprocessed_filepath}' ⏩️ #{e.message}")
+    end
+  end
+
   private
+
+  # Walk the directives-only stream tracking which source line of the file of interest
+  # the current physical line maps to, and report the resolved path for every entering
+  # marker attributed to a `wanted` source line.
+  #
+  # `src_line` names the source line the NEXT non-marker physical line will be. A
+  # `# n "<file of interest>"` marker sets it to `n`; each subsequent body line of that
+  # file bumps it by one. The macro-target `#include` directive is REPLACED by the
+  # entering marker for the header it pulled in, so it never shows up as a body line --
+  # `src_line` therefore still reads that directive's own line number when its entering
+  # marker appears. Body lines and markers of any OTHER file are skipped entirely, so
+  # a header's own nesting can't drift the count.
+  def correlate_computed_includes(io:, source_basename:, wanted:)
+    resolved = {}
+    in_file_of_interest = false
+    src_line = 0
+
+    io.each_line do |line|
+      line.chomp!
+
+      match = LINE_MARKER_REGEX.match(line)
+
+      # A non-marker line advances the counter only while inside the file of interest.
+      unless match
+        src_line += 1 if in_file_of_interest
+        next
+      end
+
+      marker_path = match[2]
+      next if marker_path.start_with?('<')  # <built-in>, <command-line>
+
+      marker_path = PathMatcher.resolve_relative(marker_path, anchor: '')
+      flags = match[3] ? match[3].split.map(&:to_i) : []
+
+      if File.basename(marker_path) == source_basename
+        # Entering or resuming the file of interest: its own markers carry the
+        # authoritative line number for whatever comes next.
+        src_line = match[1].to_i
+        in_file_of_interest = true
+      elsif in_file_of_interest && flags.include?(1)
+        # An entering marker for another file, standing in for a directive on the
+        # file-of-interest line the counter currently names.
+        resolved[src_line] = marker_path if wanted.include?(src_line)
+        in_file_of_interest = false
+      else
+        # Any other marker (returning to an intermediate header, a nested entry):
+        # we're no longer tracking file-of-interest body lines until its own marker
+        # brings us back.
+        in_file_of_interest = false
+      end
+    end
+
+    resolved
+  end
 
   def validate_type_argument(type)
     unless [SYSTEM, USER].include?(type)

--- a/spec/integration/includes_extraction_spec.rb
+++ b/spec/integration/includes_extraction_spec.rb
@@ -317,6 +317,156 @@ describe 'Includes extraction (integration)' do
     expect(extracted(tree, 'ff.c', defines: ['ENABLE_X'], fallback: true)).to eq(['#include "x.h"'])
   end
 
+  # --- Computed (macro-target) includes (#1267) ------------------------
+
+  # Every fixture here uses the standard stringize dance to build a header name from a
+  # macro argument: STR2/STR turn `dev_extra` into `"dev_extra.h"`, so
+  # `#include PICK(dev_extra)` is an #include whose target only exists after macro
+  # expansion -- invisible to a literal text scan.
+  COMPUTED = <<~C
+    #define STR2(x) #x
+    #define STR(x) STR2(x)
+    #define PICK(name) STR(name.h)
+  C
+
+  it 'resolves a computed #include guarded by a sibling-header macro (the #1267 shape)' do
+    skip 'accurate (-fdirectives-only) path unavailable on this toolchain' unless @accurate
+    tree = {
+      'widget.c' => <<~C,
+        #include "device_config.h"
+        #{COMPUTED}
+        #if DEVICE_COUNT > 1
+        #include PICK(device_extra)
+        #endif
+        int w(void) { return DEVICE_EXTRA_MACRO; }
+      C
+      'device_config.h' => %(#ifndef DEVICE_CONFIG_H\n#define DEVICE_CONFIG_H\n#define DEVICE_COUNT 2\n#endif\n),
+      'device_extra.h'  => %(#ifndef DEVICE_EXTRA_H\n#define DEVICE_EXTRA_H\n#define DEVICE_EXTRA_MACRO (42)\n#endif\n)
+    }
+    expect(extracted(tree, 'widget.c')).to contain_exactly(
+      '#include "device_config.h"', '#include "device_extra.h"'
+    )
+  end
+
+  it 'does not resolve a computed #include whose guard the accurate pass evaluates false' do
+    skip 'accurate (-fdirectives-only) path unavailable on this toolchain' unless @accurate
+    tree = {
+      'widget.c' => <<~C,
+        #include "device_config.h"
+        #{COMPUTED}
+        #if DEVICE_COUNT > 9
+        #include PICK(device_extra)
+        #endif
+        int w(void) { return 0; }
+      C
+      'device_config.h' => %(#ifndef DEVICE_CONFIG_H\n#define DEVICE_CONFIG_H\n#define DEVICE_COUNT 2\n#endif\n),
+      'device_extra.h'  => %(#ifndef DEVICE_EXTRA_H\n#define DEVICE_EXTRA_H\n#define DEVICE_EXTRA_MACRO (42)\n#endif\n)
+    }
+    expect(extracted(tree, 'widget.c')).to eq(['#include "device_config.h"'])
+  end
+
+  it 'keeps a single entry for an unguarded computed #include the bare pass already resolves' do
+    # No guard: the bare gcc pass sees the same-file STR/PICK macros (a -D define is
+    # visible even in the isolated copy) and -MG makes the missing header phony, so it
+    # already lands in `bare`. The computed-include path adds it too; dedup by filename
+    # keeps exactly one.
+    tree = {
+      'widget.c' => <<~C,
+        #{COMPUTED}
+        #include PICK(solo_device)
+        int w(void) { return 0; }
+      C
+      'solo_device.h' => %(#ifndef SOLO_DEVICE_H\n#define SOLO_DEVICE_H\nint sd(void);\n#endif\n)
+    }
+    expect(extracted(tree, 'widget.c')).to eq(['#include "solo_device.h"'])
+  end
+
+  it 'resolves each of two adjacent computed #includes by its own guard' do
+    skip 'accurate (-fdirectives-only) path unavailable on this toolchain' unless @accurate
+    tree = {
+      'widget.c' => <<~C,
+        #include "device_config.h"
+        #{COMPUTED}
+        #if DEVICE_COUNT > 1
+        #include PICK(dev_on)
+        #endif
+        #if DEVICE_COUNT > 9
+        #include PICK(dev_off)
+        #endif
+        int w(void) { return DEV_ON_MACRO; }
+      C
+      'device_config.h' => %(#ifndef DEVICE_CONFIG_H\n#define DEVICE_CONFIG_H\n#define DEVICE_COUNT 2\n#endif\n),
+      'dev_on.h'  => %(#ifndef DEV_ON_H\n#define DEV_ON_H\n#define DEV_ON_MACRO 1\n#endif\n),
+      'dev_off.h' => %(#ifndef DEV_OFF_H\n#define DEV_OFF_H\n#define DEV_OFF_MACRO 0\n#endif\n)
+    }
+    expect(extracted(tree, 'widget.c')).to contain_exactly(
+      '#include "device_config.h"', '#include "dev_on.h"'
+    )
+  end
+
+  it 'resolves a computed #include that targets a project header with bracket syntax' do
+    skip 'accurate (-fdirectives-only) path unavailable on this toolchain' unless @accurate
+    tree = {
+      'widget.c' => <<~C,
+        #include "device_config.h"
+        #define BR(x) <x.h>
+        #if DEVICE_COUNT > 1
+        #include BR(bracket_device)
+        #endif
+        int w(void) { return BRACKET_DEVICE_MACRO; }
+      C
+      'device_config.h'  => %(#ifndef DEVICE_CONFIG_H\n#define DEVICE_CONFIG_H\n#define DEVICE_COUNT 2\n#endif\n),
+      'bracket_device.h' => %(#ifndef BRACKET_DEVICE_H\n#define BRACKET_DEVICE_H\n#define BRACKET_DEVICE_MACRO 7\n#endif\n)
+    }
+    # Rendered as a user include: reconciliation keys on where GCC found the header
+    # (a project -I path), not on the directive's punctuation -- same as the literal
+    # bracket-vs-quote characterization above.
+    expect(extracted(tree, 'widget.c')).to contain_exactly(
+      '#include "device_config.h"', '#include "bracket_device.h"'
+    )
+  end
+
+  it 'does not correlate a computed #include split across a backslash continuation' do
+    skip 'accurate (-fdirectives-only) path unavailable on this toolchain' unless @accurate
+    # Documented limitation: the raw-source scan reports the directive at its first
+    # physical line, but GCC attributes the entered header to a line shifted by the
+    # continuation, so the two never line up. A single-physical-line computed
+    # #include (every other case here) is unaffected.
+    tree = {
+      'widget.c' => <<~C,
+        #include "device_config.h"
+        #{COMPUTED}
+        #if DEVICE_COUNT > 1
+        #include \\
+          PICK(device_extra)
+        #endif
+        int w(void) { return 0; }
+      C
+      'device_config.h' => %(#ifndef DEVICE_CONFIG_H\n#define DEVICE_CONFIG_H\n#define DEVICE_COUNT 2\n#endif\n),
+      'device_extra.h'  => %(#ifndef DEVICE_EXTRA_H\n#define DEVICE_EXTRA_H\n#define DEVICE_EXTRA_MACRO (42)\n#endif\n)
+    }
+    expect(extracted(tree, 'widget.c')).to eq(['#include "device_config.h"'])
+  end
+
+  it 'does not resolve a sibling-macro-guarded computed #include on the forced text-scan path' do
+    # Documented limitation: fallback has no directives-only stream to correlate
+    # against, so a computed #include behind a guard the text scan can't evaluate is
+    # left out. The literal sibling header is still found.
+    tree = {
+      'widget.c' => <<~C,
+        #include "device_config.h"
+        #{COMPUTED}
+        #if DEVICE_COUNT > 1
+        #include PICK(device_extra)
+        #endif
+        int w(void) { return 0; }
+      C
+      'device_config.h' => %(#ifndef DEVICE_CONFIG_H\n#define DEVICE_CONFIG_H\n#define DEVICE_COUNT 2\n#endif\n),
+      'device_extra.h'  => %(#ifndef DEVICE_EXTRA_H\n#define DEVICE_EXTRA_H\n#define DEVICE_EXTRA_MACRO (42)\n#endif\n)
+    }
+    expect(extracted(tree, 'widget.c', fallback: true)).to eq(['#include "device_config.h"'])
+  end
+
   it 'falls back per file when the directives-only pass cannot resolve an include' do
     # The directives-only tool has no -MG, so an unresolvable #include makes that pass
     # exit non-zero; generate_directives_only_output returns nil and this one file

--- a/spec/support/spec_helper.rb
+++ b/spec/support/spec_helper.rb
@@ -6,25 +6,35 @@
 # =========================================================================
 
 # Coverage instrumentation must start before any Ceedling code below is required, or
-# Ruby's Coverage module never sees those files' lines at all. Only active when
-# CEEDLING_TEST_COVERAGE is exactly 'units' -- this file is also required by the
-# system-test suite's own outer rspec process (spec_system_helper.rb requires it too),
-# which barely touches lib/ceedling directly itself (the real work happens in each
-# system-test child subprocess, instrumented separately by simplecov_boot.rb); a bare
-# truthy check here would make that process ALSO claim SimpleCov's "units" resultset
-# entry and silently overwrite the real unit-test coverage with its own near-empty
-# coverage, since SimpleCov's own multi-process merging replaces rather than
-# accumulates same-named entries. Picks up the shared .simplecov config (repo root)
-# via SimpleCov's own upward-directory-search autoload. The final HTML report is
-# generated once, explicitly, by `rake coverage:report` after both the unit and
-# system suites finish, rather than by this process's own exit.
-if ENV['CEEDLING_TEST_COVERAGE'] == 'units'
+# Ruby's Coverage module never sees those files' lines at all. Active only when
+# CEEDLING_TEST_COVERAGE names this process's own suite exactly -- 'units' or
+# 'integration'. This file is ALSO required by the system-test suite's own outer rspec
+# process (spec_system_helper.rb requires it too), which barely touches lib/ceedling
+# directly itself (the real work happens in each system-test child subprocess,
+# instrumented separately by simplecov_boot.rb); a bare truthy check here would make
+# that process ALSO claim a resultset entry and silently overwrite real coverage with
+# its own near-empty coverage, since SimpleCov's multi-process merging replaces rather
+# than accumulates same-named entries. Picks up the shared .simplecov config (repo
+# root) via SimpleCov's own upward-directory-search autoload. The HTML reports are
+# generated once, explicitly, by `rake coverage:report` after every suite finishes,
+# rather than by this process's own exit.
+coverage_suite = ENV['CEEDLING_TEST_COVERAGE']
+if coverage_suite == 'units' || coverage_suite == 'integration'
   require 'simplecov'
   # .simplecov (already loaded by the require above, via SimpleCov's own
   # autoload) is configuration only -- this explicit call is what actually
   # begins tracking for this process.
   SimpleCov.start
-  SimpleCov.command_name 'units'
+  SimpleCov.command_name coverage_suite
+
+  # Units writes the canonical coverage/.resultset.json. Integration, like the
+  # system suite's per-process boots, writes its own raw resultset instead, so
+  # `rake coverage:report` can format a standalone integration report and still
+  # fold the same data into the combined one -- and so a units run and an
+  # integration run in the same coverage/ never merge into one file that both
+  # the "units" and "integration" reports would then wrongly draw from.
+  SimpleCov.coverage_dir(File.join('coverage', 'raw', 'integration')) if coverage_suite == 'integration'
+
   SimpleCov.at_exit { SimpleCov.result }
 end
 

--- a/spec/units/preprocess/preprocessinator_includes_handler_spec.rb
+++ b/spec/units/preprocess/preprocessinator_includes_handler_spec.rb
@@ -406,6 +406,97 @@ RSpec.describe PreprocessinatorIncludesHandler do
 
 
   # ===========================================================================
+  describe '#extract_computed_includes' do
+  # ===========================================================================
+  # Resolves an #include whose target is a macro invocation, not a literal filename.
+  # Finds each such directive's source line, asks the line-marker extractor which
+  # header GCC entered at that line in the accurate pass, and returns base Includes.
+
+    let(:filepath)  { '/src/module.c' }
+    let(:donly)     { '/build/directives_only/module.c' }
+
+    it 'returns an empty list without touching the line-marker extractor when there is no directives-only output' do
+      expect(@preprocessinator_line_marker_includes_extractor).to_not receive(:resolve_computed_includes)
+      expect(
+        subject.extract_computed_includes( filepath: filepath, directives_only_filepath: nil )
+      ).to eq([])
+    end
+
+    it 'returns an empty list for a file whose every #include is a literal "..." or <...>' do
+      stub_file_open(filepath, %(#include "foo.h"\n#include <stdio.h>\nint m(void){return 0;}\n))
+      expect(@preprocessinator_line_marker_includes_extractor).to_not receive(:resolve_computed_includes)
+
+      expect(
+        subject.extract_computed_includes( filepath: filepath, directives_only_filepath: donly )
+      ).to eq([])
+    end
+
+    it 'does not treat a commented-out or string-embedded #include as a computed directive' do
+      content = <<~C
+        // #include COMMENTED_MACRO
+        /* #include BLOCK_MACRO */
+        const char *s = "#include STRING_MACRO";
+        int m(void) { return 0; }
+      C
+      stub_file_open(filepath, content)
+      expect(@preprocessinator_line_marker_includes_extractor).to_not receive(:resolve_computed_includes)
+
+      expect(
+        subject.extract_computed_includes( filepath: filepath, directives_only_filepath: donly )
+      ).to eq([])
+    end
+
+    it 'asks the line-marker extractor about each non-literal #include line and wraps the resolved paths as bare Includes' do
+      content = <<~C
+        #include "literal.h"
+        #include DEVICE_HEADER(a)
+        int m(void) { return 0; }
+      C
+      stub_file_open(filepath, content)
+
+      expect(@preprocessinator_line_marker_includes_extractor).to receive(:resolve_computed_includes).with(
+        preprocessed_filepath: donly,
+        source_basename:       'module.c',
+        source_lines:          [2]
+      ).and_return( { 2 => 'src/device_a.h' } )
+
+      result = subject.extract_computed_includes( filepath: filepath, directives_only_filepath: donly )
+
+      expect(result.map(&:filepath)).to eq(['src/device_a.h'])
+      expect(result).to all( be_an_instance_of(Include) )
+    end
+
+    it 'passes every computed-include line number through, in source order' do
+      content = <<~C
+        #include FIRST_MACRO
+        int a;
+        #include SECOND_MACRO
+        int b;
+      C
+      stub_file_open(filepath, content)
+
+      expect(@preprocessinator_line_marker_includes_extractor).to receive(:resolve_computed_includes).with(
+        hash_including( source_lines: [1, 3] )
+      ).and_return( {} )
+
+      subject.extract_computed_includes( filepath: filepath, directives_only_filepath: donly )
+    end
+
+    it 'drops a computed-include line the extractor could not correlate to an entered header' do
+      content = %(#include ACTIVE_MACRO\n#include INACTIVE_MACRO\nint m(void){return 0;}\n)
+      stub_file_open(filepath, content)
+
+      allow(@preprocessinator_line_marker_includes_extractor).to receive(:resolve_computed_includes)
+        .and_return( { 1 => 'src/active.h' } )  # line 2 absent -- guard was false
+
+      result = subject.extract_computed_includes( filepath: filepath, directives_only_filepath: donly )
+
+      expect(result.map(&:filepath)).to eq(['src/active.h'])
+    end
+  end
+
+
+  # ===========================================================================
   describe '#extract_system_includes_from_text' do
   # ===========================================================================
 

--- a/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
+++ b/spec/units/preprocess/preprocessinator_line_marker_includes_extractor_spec.rb
@@ -195,6 +195,130 @@ describe PreprocessinatorLineMarkerIncludesExtractor do
     end
   end
 
+  describe '#resolve_computed_includes' do
+    # Correlates `-fdirectives-only` entering markers back to the raw source lines
+    # that produced them. Used to recover GCC's own resolution of a macro-target
+    # `#include` -- the directive has no literal filename to scan for, but the
+    # accurate pass still opens the header and emits an ordinary entering marker.
+
+    def resolve(content, basename, lines)
+      allow(@file_wrapper).to receive(:open).with('donly.c', 'rb').and_yield( StringIO.new(content) )
+      @extractor.resolve_computed_includes(
+        preprocessed_filepath: 'donly.c', source_basename: basename, source_lines: lines
+      )
+    end
+
+    it 'returns an empty hash (and reads nothing) when no source lines are wanted' do
+      expect(@file_wrapper).to_not receive(:open)
+      expect(
+        @extractor.resolve_computed_includes(
+          preprocessed_filepath: 'donly.c', source_basename: 'foo.c', source_lines: []
+        )
+      ).to eq({})
+    end
+
+    it 'maps a wanted source line to the path GCC entered at that line' do
+      # foo.c line 3 carries the computed #include; the marker replaces that line, so
+      # the running source-line counter still reads 3 when the entering marker appears.
+      content = <<~OUTPUT
+        # 1 "foo.c"
+        int a;
+        int b;
+        # 1 "device.h" 1
+
+        typedef int dev_t;
+        # 4 "foo.c" 2
+        int c;
+      OUTPUT
+
+      expect( resolve(content, 'foo.c', [3]) ).to eq( { 3 => 'device.h' } )
+    end
+
+    it 'ignores an entering marker attributed to a line that was not asked about' do
+      content = <<~OUTPUT
+        # 1 "foo.c"
+        int a;
+        # 1 "literal.h" 1
+        # 3 "foo.c" 2
+        int c;
+      OUTPUT
+
+      expect( resolve(content, 'foo.c', [99]) ).to eq( {} )
+    end
+
+    it 'does not let another file\'s own nested markers or body drift the source-line counter' do
+      # Two computed includes, on lines 1 and 3. device_a.h itself includes inner.h;
+      # neither inner.h's marker nor any non-target body line may advance the count,
+      # or the line-3 correlation lands wrong.
+      content = <<~OUTPUT
+        # 1 "foo.c"
+        # 1 "device_a.h" 1
+        # 1 "inner.h" 1
+        deep stuff
+        more deep stuff
+        # 2 "device_a.h" 2
+        shallow stuff
+        # 2 "foo.c" 2
+        int x;
+        # 1 "device_b.h" 1
+        # 3 "foo.c" 2
+        int y;
+      OUTPUT
+
+      expect( resolve(content, 'foo.c', [1, 3]) ).to eq(
+        { 1 => 'device_a.h', 3 => 'device_b.h' }
+      )
+    end
+
+    it 'skips <built-in> / <command-line> markers without disturbing correlation' do
+      content = <<~OUTPUT
+        # 1 "<built-in>"
+        # 1 "<command-line>" 2
+        # 1 "foo.c"
+        int a;
+        int b;
+        # 1 "device.h" 1
+        # 3 "foo.c" 2
+      OUTPUT
+
+      expect( resolve(content, 'foo.c', [3]) ).to eq( { 3 => 'device.h' } )
+    end
+
+    it 'reports nothing for a wanted line whose computed include produced no entering marker' do
+      # e.g. the guard around it evaluated false, or the target was already included.
+      content = <<~OUTPUT
+        # 1 "foo.c"
+        int a;
+        int b;
+
+        int c;
+      OUTPUT
+
+      expect( resolve(content, 'foo.c', [3]) ).to eq( {} )
+    end
+
+    it 'collapses an uncanonicalized .. in the entered path, matching the other marker walk' do
+      content = <<~OUTPUT
+        # 1 "test/unit/foo.c"
+        a;
+        # 1 "test/unit/../common/dev.h" 1
+        # 3 "test/unit/foo.c" 2
+      OUTPUT
+
+      expect( resolve(content, 'foo.c', [2]) ).to eq( { 2 => 'test/common/dev.h' } )
+    end
+
+    it 'wraps an underlying read failure in a CeedlingException naming the file' do
+      allow(@file_wrapper).to receive(:open).and_raise( StandardError.new('gone') )
+
+      expect {
+        @extractor.resolve_computed_includes(
+          preprocessed_filepath: 'donly.c', source_basename: 'foo.c', source_lines: [1]
+        )
+      }.to raise_error( CeedlingException, /donly\.c/ )
+    end
+  end
+
   describe '#extract_includes_from_file' do
     it 'opens the file in binary mode and extracts the same way as from a string' do
       # The initial-marker match is by basename against the filepath argument itself

--- a/spec/units/preprocess/preprocessinator_spec.rb
+++ b/spec/units/preprocess/preprocessinator_spec.rb
@@ -73,6 +73,9 @@ RSpec.describe Preprocessinator do
       allow(@includes_handler).to receive(:write_includes_list)
 
       allow(@includes_handler).to receive(:extract_system_includes_preprocess).and_return([])
+      # Computed-include supplement: off by default here; the dedicated cases below
+      # override this return to exercise the union.
+      allow(@includes_handler).to receive(:extract_computed_includes).and_return([])
     end
 
     # Regression coverage for #1223: the gcc-based bare pass runs against an
@@ -420,6 +423,7 @@ RSpec.describe Preprocessinator do
       allow(@file_path_utils).to receive(:form_preprocessed_includes_list_filepath).and_return('/build/includes/module.h.yml')
       allow(@includes_handler).to receive(:extract_bare_includes).and_return([])
       allow(@includes_handler).to receive(:extract_bare_includes_from_text).and_return([])
+      allow(@includes_handler).to receive(:extract_computed_includes).and_return([])
       allow(@includes_handler).to receive(:extract_user_includes_preprocess).and_return([])
       allow(@includes_handler).to receive(:extract_system_includes_preprocess).and_return([])
       allow(@includes_handler).to receive(:write_includes_list)
@@ -485,6 +489,7 @@ RSpec.describe Preprocessinator do
       allow(@file_path_utils).to receive(:form_preprocessed_includes_list_filepath).and_return('/build/includes/module.h.yml')
       allow(@includes_handler).to receive(:extract_bare_includes).and_return([])
       allow(@includes_handler).to receive(:extract_bare_includes_from_text).and_return([])
+      allow(@includes_handler).to receive(:extract_computed_includes).and_return([])
       allow(@includes_handler).to receive(:extract_user_includes_preprocess).and_return([])
       allow(@includes_handler).to receive(:extract_user_includes_from_text).and_return([])
       allow(@includes_handler).to receive(:extract_system_includes_preprocess).and_return([])


### PR DESCRIPTION
## What

Final PR of the three-part includes-extraction effort. Adds support for a conditional `#include` whose target is a macro invocation and whose guard depends on a macro defined in another header — the #1267 bug — and rewrites `lib/ceedling/preprocess/README.md` against the refactored design.

PR1 (#1277) built the `spec/integration/` tier and unit safety net. PR2 (#1278) DRY'd the extractors and extracted the shared `reconcile_includes` core. This PR is the feature, test-first, on top of both.

## The bug

```c
#include "Types.h"                 // defines SOIL_MOISTURE_MAX
#if SOIL_MOISTURE_MAX > 0
#include INCLUDE_DEVICE(types2)    // -> STR(types2.h) -> "types2.h"
#endif
```

`types2.h` was dropped from Partials/mock generation. Both bare-includes contributors are blind to it: the isolated `gcc -M` pass can't evaluate the sibling-header guard, and the literal text scan has no filename to match a macro target. `Includes.reconcile`'s intersection then discards it even though the accurate `-fdirectives-only` pass resolved it.

## The fix

A third bare-includes contributor, `unless fallback`:

- **`PreprocessinatorLineMarkerIncludesExtractor#resolve_computed_includes(preprocessed_filepath:, source_basename:, source_lines:)`** — walks the directives-only output tracking which source line each physical line maps to (`# n "<basename>"` sets it; body lines increment it; the macro-target directive is replaced by its header's entering marker, so the counter still names that directive's line when the marker appears). Returns `{ source_line => resolved_path }` for every entering marker attributed to a wanted line. Other files' nested markers and body are skipped so they can't drift the count.
- **`PreprocessinatorIncludesHandler#extract_computed_includes(filepath:, directives_only_filepath:)`** — finds each non-literal `#include`'s source line via `code_lines_with_num` (comments/continuations already handled), asks the extractor which header GCC entered there, wraps the results as base `Include` objects.
- **`preprocess_file_includes_common`** unions them into `bare` right after the existing text-scan supplement. `Includes.reconcile` is untouched — a computed include is now corroborated in `bare` like a literal one and still gated by the accurate user/system list.

Two limitations, both characterized in the integration suite: a computed `#include` split across a backslash continuation is not correlated, and computed-include resolution is unavailable in fallback mode.

## Scope note

Wired into `preprocess_file_includes_common` only (mockable headers, Partial headers/sources) — this is the #1267 path and what the spike validated end to end. A computed `#include` written directly in a `test_*.c` file's own text (rare; not the reported bug) still goes through `test_build_setup.rb` stage 4, which keeps its own bare source. Consistent with PR2's "shared reconcile core, not full orchestrator unification" decision.

## Tests (test-first)

- `preprocessinator_line_marker_includes_extractor_spec.rb` — 8 cases for `resolve_computed_includes` against canned directives-only text (line mapping, nested-marker isolation, `<built-in>` skipping, `..` collapse, no-marker, error wrapping).
- `preprocessinator_includes_handler_spec.rb` — 6 cases for `extract_computed_includes` (nil directives-only, all-literal, commented/string, line-number collection, base-`Include` wrapping, uncorrelated drop). 3 written failing first, then implemented.
- `includes_extraction_spec.rb` — 7 new integration cases: #1267 shape, false guard, unguarded (dedup), adjacent pair, bracket target, backslash continuation (documented no-op), fallback (documented no-op).
- README rewrite: names the actual methods/flags/constants, three bare contributors, shared `reconcile_includes`, `SYSTEM_INCLUDE_MAX_DEPTH`, per-file fallback, points at the integration tier.

## Verification

- `rake specs:units` 3239/0, `rake specs:integration` 28/0 (host + `madsciencelab-plugins:1.1.0` container)
- #1267 repro in Docker: `test:AlertManager` 10/10, full `wondrous_forest` suite 65/65; generated `_impl.c` now carries `#include "types2.h"`
- Preprocessing + include-path system specs green in Docker
- CI is the backstop across all platforms / Ruby matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Also in this PR: integration-tier coverage reporting

`ff780be1` — the integration suite exercises real `lib/ceedling` objects but never fed coverage. It now instruments the same Ruby-3.3-only way as units and system (`CEEDLING_TEST_COVERAGE=integration` → its own `coverage/raw/integration/.resultset.json`), `rake coverage:report` formats a fourth *integration* report and folds the data into *combined*, and every report is built with `HTMLFormatter.new(silent: true)` so SimpleCov's `"Coverage report generated for <hundreds of system-<pid> names> to ..."` line stops burying the task's own one-line summaries.
