### PR TITLE
Fix dumpconfig's non-safe YAML and add a --stdout option

### DIFF
--- a/bin/cli.rb
+++ b/bin/cli.rb
@@ -394,11 +394,12 @@ module CeedlingTasks
 
 
     # simplecov:disable line
-    desc "dumpconfig FILEPATH [SECTIONS...]", "Process project configuration and write final config to a YAML file"
+    desc "dumpconfig [FILEPATH] [SECTIONS...]", "Process project configuration and write final config to a YAML file"
     method_option :project, :type => :string, :default => nil, :lazy_default => CLI_MISSING_PARAMETER_DEFAULT, :aliases => ['-p'],
                   :desc => DOC_PROJECT_FLAG
     method_option :mixin, :type => :string, :default => [], :repeatable => true, :aliases => ['-m'], :desc => DOC_MIXIN_FLAG
     method_option :app, :type => :boolean, :default => true, :desc => "Runs Ceedling application and its config manipulations"
+    method_option :stdout, :type => :boolean, :default => false, :desc => "Write YAML to standard output instead of FILEPATH, for consuming tools"
     method_option :ruby_replacement, :type => :boolean, :default => false, :desc => DOC_RUBY_REPLACEMENT_FLAG
     method_option :debug, :type => :boolean, :default => false, :hide => true
     long_desc( CEEDLING_HANDOFF_OBJECTS[:loginator].sanitize(
@@ -406,7 +407,8 @@ module CeedlingTasks
       `ceedling dumpconfig` loads your project configuration, including all manipulations & merges,
       and writes the final config to a YAML file.
 
-      FILEPATH is a required path to a destination YAML file. A nonexistent path will be created.
+      FILEPATH is a required path to a destination YAML file unless `--stdout` is set. A
+      nonexistent path will be created.
 
       SECTIONS is an optional config “path” that extracts a portion of a configuration. The
       top-level YAML container will be the path’s last element.
@@ -421,15 +423,29 @@ module CeedlingTasks
       the configuration. Disabling it dumps project config after any mixins but before any
       application manipulations.
 
+      • `--stdout` writes the YAML directly to standard output instead of FILEPATH -- handy for a
+      consuming tool that wants Ceedling's resolved configuration without a temp file. Omit FILEPATH
+      when using this flag; any positional arguments given are treated as SECTIONS instead.
+      \x5> ceedling dumpconfig --stdout tools test_compiler
+
       • #{LONGDOC_RUBY_REPLACEMENT_FLAG}
       LONGDESC
     ) )
-    def dumpconfig(filepath, *sections)
+    def dumpconfig(filepath = nil, *sections)
       @handler.validate_string_param(
         options[:project],
         CLI_MISSING_PARAMETER_DEFAULT,
         "--project is missing a required filepath parameter"
       )
+
+      if options[:stdout]
+        # No destination-file slot to occupy in stdout mode -- every positional
+        # argument given is a section path element instead.
+        sections = [filepath, *sections].compact
+        filepath = nil
+      elsif filepath.nil?
+        raise Thor::Error.new("FILEPATH is a required parameter unless --stdout is set")
+      end
 
       # Get an unfrozen copy so we can add / modify
       _options = options.dup()

--- a/bin/cli_handler.rb
+++ b/bin/cli_handler.rb
@@ -287,7 +287,12 @@ class CliHandler
 
     _, config = @composinator.loadinate( builtin_load_paths:BUILTIN_MIXIN_LOAD_PATHS, filepath:options[:project], mixins:options[:mixin], env:env )
 
-    @cli_helper.console_project_name( config )
+    # A nil filepath means --stdout was set -- the YAML itself is the only thing
+    # that may reach stdout in that case, for a consuming tool to parse cleanly,
+    # so every banner/notice below is skipped rather than interleaved into it.
+    stdout_mode = filepath.nil?
+
+    @cli_helper.console_project_name( config ) unless stdout_mode
 
     # Exception handling to ensure we dump the configuration regardless of config validation errors
     begin
@@ -301,18 +306,18 @@ class CliHandler
 
         _, path = @helper.which_ceedling?( env:env, config:config, app_cfg:app_cfg )
 
-        config = @helper.load_ceedling( 
+        config = @helper.load_ceedling(
           config: config,
           rakefile_path: path,
           default_tasks: default_tasks
         )
       else
-        @loginator.console( " > Skipped loading Ceedling application" )
+        @loginator.console( " > Skipped loading Ceedling application" ) unless stdout_mode
       end
     ensure
       @helper.dump_yaml( config, filepath, sections )
 
-      @loginator.console( "\nDumped project configuration to #{filepath}\n", LogLabels::TITLE )      
+      @loginator.console( "\nDumped project configuration to #{filepath}\n", LogLabels::TITLE ) unless stdout_mode
     end
   end
 

--- a/bin/cli_helper.rb
+++ b/bin/cli_helper.rb
@@ -450,7 +450,13 @@ class CliHelper
       _config = { _sections.last => value }
     end
 
-    File.open( filepath, 'w' ) {|out| YAML.dump( _config, out )}
+    # A nil filepath is the --stdout signal threaded down from the CLI layer --
+    # write the YAML directly to standard output instead of a file.
+    if filepath.nil?
+      YAML.dump( _config, $stdout )
+    else
+      File.open( filepath, 'w' ) {|out| YAML.dump( _config, out )}
+    end
   end
 
 

--- a/docs/mkdocs/getting-started/command-line.md
+++ b/docs/mkdocs/getting-started/command-line.md
@@ -111,12 +111,12 @@ configuration. If no tasks are provided, built-in default tasks or your
 
 ---
 
-### `ceedling dumpconfig FILEPATH [SECTIONS...]`
+### `ceedling dumpconfig [FILEPATH] [SECTIONS...]`
 
 Process project configuration and write final result to a YAML file.
 
-`FILEPATH` is a required path to a destination YAML file. A nonexistent 
-path will be created.
+`FILEPATH` is a required path to a destination YAML file, unless `--stdout` is 
+set (see below). A nonexistent path will be created.
 
 `SECTIONS` is an optional config “path” that extracts a portion of a 
 configuration. The top-level YAML container will be the path’s last 
@@ -127,7 +127,17 @@ element. Example: `ceedling dumpconfig my/path/config.yml tools test_compiler`.
 | `--project` | `-p` | Loads the filepath as your base project configuration | none |
 | `--mixin` | `-m` | Merges the configuration mixin by name, filepath, or inline YAML (`=` sigil). Repeatable. | `[]` |
 | `--app` | | Runs Ceedling application and its config manipulations | `true` |
+| `--stdout` | | Writes YAML to standard output instead of `FILEPATH`, for consuming tools | `false` (disabled) |
 | `--ruby-replacement` | | Enables inline Ruby string expansion (`#{...}`) in project configuration | `false` (disabled) |
+
+Use `--stdout` when a consuming tool wants Ceedling’s fully resolved 
+configuration piped directly into its own process rather than written to 
+a temp file and read back. Omit `FILEPATH` when using this flag — any 
+positional arguments given are treated as `SECTIONS` instead:
+
+```
+ceedling dumpconfig --stdout tools test_compiler
+```
 
 ---
 

--- a/lib/ceedling/filename_extension.rb
+++ b/lib/ceedling/filename_extension.rb
@@ -80,4 +80,12 @@ class FilenameExtension
     @extensions.join(' or ')
   end
 
+  # Psych's dump hook: rendered as a plain YAML sequence of the configured
+  # extensions, not a `!ruby/object:FilenameExtension` tag -- `dumpconfig`
+  # (and anything else that YAML-dumps project configuration) must produce
+  # clean, safe YAML any tool can read back, not just Ceedling itself.
+  def encode_with(coder)
+    coder.represent_seq(nil, @extensions)
+  end
+
 end

--- a/spec/system/dumpconfig_spec.rb
+++ b/spec/system/dumpconfig_spec.rb
@@ -1,0 +1,106 @@
+# =========================================================================
+#   Ceedling - Test-Centered Build System for C
+#   ThrowTheSwitch.org
+#   Copyright (c) 2010-26 Mike Karlesky, Mark VanderVoord, & Greg Williams
+#   SPDX-License-Identifier: MIT
+# =========================================================================
+
+require 'spec_system_helper'
+require 'yaml'
+
+##
+## `ceedling dumpconfig` coverage
+## ==============================
+##
+## Two concerns, both otherwise untested at this tier (mixin_ordering_spec.rb and
+## ruby_replacement_spec.rb each exercise `dumpconfig` only incidentally, for their
+## own unrelated concerns):
+##
+## 1. A default (--app enabled) dumpconfig run's `:extension` config entries are
+##    FilenameExtension objects (lib/ceedling/filename_extension.rb) -- without a
+##    custom YAML serialization hook, these dump as tagged `!ruby/object:...`
+##    values instead of clean, safe YAML any tool can read back.
+##
+## 2. `--stdout` writes the same YAML directly to standard output instead of a
+##    file, for a consuming tool that wants Ceedling's resolved configuration
+##    without a temp file -- every console banner/notice dumpconfig would
+##    otherwise print must be suppressed so the stream stays pure YAML.
+##
+ceedling_system_tests do
+
+  before :all do
+    @c = SystemContext.new
+    @c.deploy_gem
+  end
+
+  after :all do
+    @c.done!
+  end
+
+  before { @proj_name = unique_proj_name("dumpconfig") }
+
+  describe "Deployed as a gem" do
+    before do
+      @c.with_context do
+        @c.ceedling_appcmd_exec("new #{@proj_name}")
+      end
+    end
+
+    it "dumps clean YAML to a file, with :extension entries as plain arrays, not tagged Ruby objects" do
+      dump_file = nil
+      @c.with_context do
+        Dir.chdir @proj_name do
+          dump_file = File.expand_path('dump_config.yml')
+          @c.ceedling_appcmd_exec("dumpconfig #{dump_file}")
+        end
+      end
+
+      raw = File.read(dump_file)
+      expect(raw).not_to include('!ruby/object')
+
+      config = YAML.safe_load(raw, permitted_classes: [Symbol])
+      expect(config.dig(:extension, :source)).to be_a(Array)
+      expect(config.dig(:extension, :source)).not_to be_empty
+    end
+
+    it "writes the same clean YAML to standard output instead of a file with --stdout" do
+      output = nil
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_appcmd_exec("dumpconfig --stdout")
+        end
+      end
+
+      # A leaked banner/notice would either break the parse outright or show up
+      # as extraneous top-level content -- a clean parse is the direct proof
+      # nothing but YAML reached the stream.
+      config = YAML.safe_load(output.to_s, permitted_classes: [Symbol])
+      expect(config.dig(:extension, :source)).to be_a(Array)
+      expect(output).not_to include('!ruby/object')
+      expect(output).not_to include('Dumped project configuration')
+    end
+
+    it "extracts just the requested section to stdout, positional arguments treated as SECTIONS" do
+      output = nil
+      @c.with_context do
+        Dir.chdir @proj_name do
+          output = @c.ceedling_appcmd_exec("dumpconfig --stdout tools test_compiler")
+        end
+      end
+
+      config = YAML.safe_load(output.to_s, permitted_classes: [Symbol])
+      expect(config.keys).to eq([:test_compiler])
+    end
+
+    it "fails with a clear error and non-zero exit status when FILEPATH is omitted without --stdout" do
+      @c.with_context do
+        Dir.chdir @proj_name do
+          @c.ceedling_appcmd_exec("dumpconfig")
+        end
+      end
+
+      expect(@c.last_exit_status).not_to eq(0)
+      expect(@c.raw_output).to match(/FILEPATH is a required parameter/)
+    end
+  end
+end

--- a/spec/units/filename_extension_spec.rb
+++ b/spec/units/filename_extension_spec.rb
@@ -6,6 +6,7 @@
 # =========================================================================
 
 require 'spec_helper'
+require 'yaml'
 require 'ceedling/filename_extension'
 
 describe FilenameExtension do
@@ -86,6 +87,22 @@ describe FilenameExtension do
 
     it 'is false when configured with at least one extension' do
       expect(FilenameExtension.new('.c').empty?).to be false
+    end
+  end
+
+  # `dumpconfig` (and anything else that YAML-dumps project configuration) must
+  # produce clean, safe YAML any tool can read back -- not a tagged Ruby object
+  # only Ceedling's own unsafe-load path could round-trip. Entirely in-memory:
+  # YAML.dump with no IO argument returns a String directly, never touching disk.
+  describe '#encode_with (YAML serialization)' do
+    it 'dumps as a plain YAML sequence, not a tagged Ruby object' do
+      dumped = YAML.dump(FilenameExtension.new(['.s', '.S']))
+      expect(dumped).not_to include('!ruby/object')
+    end
+
+    it 'round-trips through a safe YAML load back to the plain extensions list' do
+      dumped = YAML.dump(FilenameExtension.new(['.s', '.S']))
+      expect(YAML.safe_load(dumped)).to eq(['.s', '.S'])
     end
   end
 


### PR DESCRIPTION
## Summary

- **Fix: clean, safe YAML from `dumpconfig`.** `FilenameExtension` (`lib/ceedling/filename_extension.rb`) had no custom YAML serialization hook, so a default (`--app` enabled) `dumpconfig` run emitted `!ruby/object:FilenameExtension` tags into `:extension` config entries — unreadable by any safe YAML loader, including Ceedling's own (`permitted_classes: [Symbol]` only). `FilenameExtension#encode_with` now dumps it as a plain YAML sequence of its own extensions, matching its internal data exactly. It's the only custom object type Ceedling puts into the config hash, so this is an isolated fix, not a broader pattern.

- **New: `dumpconfig --stdout`.** Writes the resolved YAML directly to standard output instead of a file, for a consuming tool that wants Ceedling's configuration without a temp file. `FILEPATH` becomes optional; when `--stdout` is set, every positional argument is treated as a `SECTIONS` path element instead, and every console banner/notice `dumpconfig` would otherwise print is suppressed so the stream stays pure YAML.

## Tests

- `spec/units/filename_extension_spec.rb` — new in-memory case proving `YAML.dump` produces no `!ruby/object` tag and round-trips cleanly through `YAML.safe_load`.
- New `spec/system/dumpconfig_spec.rb` — covers a real (`--app` default) file dump's clean `:extension` output, `--stdout` with and without a `SECTIONS` filter, and the `FILEPATH`-required error path when `--stdout` is omitted.

## Docs

Updated `docs/mkdocs/getting-started/command-line.md` (flag table + `FILEPATH`/`SECTIONS` explanation). `docs/mkdocs/reference/command-line.md`'s brief link-back summary for `dumpconfig` already covers this without changes.

## Verification

Full unit + integration suites and the new/adjacent system specs (`dumpconfig_spec.rb`, `mixin_ordering_spec.rb`, `ruby_replacement_spec.rb`) green on host (macOS) and the `madsciencelab-plugins` Docker image (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)